### PR TITLE
fix: use x64 ZWCAD 2022 managed references

### DIFF
--- a/src/Fs.Fox.ZwCad2022/Fs.Fox.ZwCad2022.csproj
+++ b/src/Fs.Fox.ZwCad2022/Fs.Fox.ZwCad2022.csproj
@@ -59,13 +59,33 @@
         </None>
     </ItemGroup>
 
-    <!-- ZWCAD 2022 的 NuGet 包引用 -->
+    <!-- ZWCAD 2022 的 NuGet 包内托管 DLL 是 Win32 PE，x64 构建改用 FsLibs 中的 ZRX2022 x64 托管程序集。 -->
     <ItemGroup>
-        <PackageReference Include="ZWCAD.NetApi" Version="20.22.0" ExcludeAssets="runtime" />
+        <PackageReference Include="ZWCAD.NetApi" Version="20.22.0" ExcludeAssets="compile;runtime" />
         <PackageReference Include="PolySharp" Version="1.16.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <Reference Include="ZwDatabaseMgd">
+            <HintPath>$(FsLibsDir)SDK\ZRX2022\lib-x64\ZwDatabaseMgd.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="ZwDatabaseMgdBrep">
+            <HintPath>$(FsLibsDir)SDK\ZRX2022\lib-x64\ZwDatabaseMgdBrep.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="ZwManaged">
+            <HintPath>$(FsLibsDir)SDK\ZRX2022\lib-x64\ZwManaged.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="ZcWindows">
+            <HintPath>$(FsLibsDir)SDK\ZRX2022\lib-x64\ZcWindows.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
+        <Reference Include="ZdWindows">
+            <HintPath>$(FsLibsDir)SDK\ZRX2022\lib-x64\ZdWindows.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
         <Reference Include="Microsoft.CSharp" />
     </ItemGroup>
     


### PR DESCRIPTION
Summary: exclude ZWCAD.NetApi compile/runtime assets for ZWCAD 2022, resolve the managed assemblies from FsLibs ZRX2022 lib-x64, and document why the NuGet managed DLLs are not used for x64 builds.

Validation: built Fs.Fox.ZwCad2022 Release Any CPU with VS 18 amd64 MSBuild; result was 0 warnings and 0 errors.