### PR TITLE
fix: port low-risk IFoxCAD corrections

### DIFF
--- a/src/CADShared/ExtensionMethod/DBObjectEx.cs
+++ b/src/CADShared/ExtensionMethod/DBObjectEx.cs
@@ -59,7 +59,8 @@ public static class DBObjectEx
     /// <param name="appName">应用程序名称</param>
     public static void RemoveXData(this DBObject obj, string appName)
     {
-        if (obj.XData is null)
+        using var appData = obj.GetXDataForApplication(appName);
+        if (appData is null)
             return;
 
         // 直接赋值进去等于清空名称

--- a/src/CADShared/ExtensionMethod/Entity/BlockReferenceEx.cs
+++ b/src/CADShared/ExtensionMethod/Entity/BlockReferenceEx.cs
@@ -149,13 +149,13 @@ public static class BlockReferenceEx
                 att = (AttributeReference)item;
             }
 
+            if (!propertyNameValues.TryGetValue(att.Tag, out var value))
+                continue;
+
             using (att.ForWrite())
             {
-                if (propertyNameValues.TryGetValue(att.Tag, out var value))
-                {
-                    att.TextString = value;
-                    att.AdjustAlignment(blockReference.Database);
-                }
+                att.TextString = value;
+                att.AdjustAlignment(blockReference.Database);
             }
         }
     }

--- a/src/CADShared/ExtensionMethod/Jig/JigEx.cs
+++ b/src/CADShared/ExtensionMethod/Jig/JigEx.cs
@@ -367,7 +367,7 @@ public class JigEx : DrawJig, IDisposable
             // 最后一次的图元如果没有加入数据库,就在此销毁,所以JigEx调用的时候加using
             _drawEntities.ForEach(ent =>
             {
-                if (ent.Database == null && !ent.IsDisposed)
+                if (!ent.IsDisposed && ent.Database == null)
                     ent.Dispose();
             });
         }


### PR DESCRIPTION
## 变更

- Jig 清理队列时先检查实体是否已释放，再访问 `Database`，避免外部已释放实体触发宿主异常。
- `RemoveXData(obj, appName)` 按目标 RegApp 精确判断；目标不存在时不进入写操作，并释放查询返回的 `ResultBuffer`。
- 块属性先匹配 Tag 再调用 `ForWrite()`，避免无关属性无谓提权；继续遍历全部属性，确保重复 Tag 全部更新。

## 上游依据

- Jig：[`bc7a242`](https://gitee.com/inspirefunction/ifoxcad/commit/bc7a2429c144ab627fcfaddde05f20d2be07589e)，作者 yupeng_dyp。
- XData：[`e13eecd`](https://gitee.com/inspirefunction/ifoxcad/commit/e13eecd58995986775845548f9d46b828eb66724)，作者 DYH。
- 块属性：[`6744217`](https://gitee.com/inspirefunction/ifoxcad/commit/67442178d7b9909ded07536acf0527246ef17dbe) 与撤销提前退出的 [`0d3bf68`](https://gitee.com/inspirefunction/ifoxcad/commit/0d3bf6889574e55c41ce12c9101eb4c1fd26bd8f)，作者 荣Sir；最终合并提交 [`d600dbf`](https://gitee.com/inspirefunction/ifoxcad/commit/d600dbf9377af205d7cfa6c0adf34487541d3e2d)。

本 PR 按 Fs.Fox.CAD 当前命名空间和共享源码结构手工移植，没有 cherry-pick 上游发布或格式化变更。

## 自动验证

- `git diff --check`
- AutoCAD 2019：正式类库及 `TestAcad2019`，Debug/Release 构建通过
- AutoCAD 2025：正式类库及 `TestAcad2025`，Debug/Release 构建通过，0 警告、0 错误
- ZWCAD 2022：正式类库及 `TestZcad2022`，Debug/Release 构建通过
- ZWCAD 2025：正式类库及 `TestZcad2025`，Debug/Release 构建通过

## CAD 宿主验收（待人工执行）

- Jig：队列实体已在外部释放时，`JigEx.Dispose()` 不抛异常；未入库且未释放的实体仍由 Jig 清理。
- XData：对象同时包含两个 RegApp 时，删除不存在的应用不写对象；删除目标应用后另一个应用的数据保持不变。
- 块属性：未命中 Tag 的属性不进入写状态；重复的目标 Tag 均被更新。

构建通过不等同于上述宿主行为已验证。

## 范围

不包含 ZWCAD `GetEnv/SetEnv`、`EntGet/EntMod/EntUpd`、动态块可见性、ZWCAD 进度条或 `DwgFiler`。

Refs #26