### PR TITLE
fix: correct ZWCAD GetEnv/SetEnv interop

### DIFF
--- a/src/CADShared/Runtime/Env.cs
+++ b/src/CADShared/Runtime/Env.cs
@@ -500,17 +500,17 @@ public static class Env
     static extern int AcedSetEnv(string? envName, StringBuilder NewValue);
 #endif
 
-    // TODO: 中望没有测试,此处仅为不报错;本工程所有含有"中望"均存在问题
 #if ZWCAD
-    [System.Security.SuppressUnmanagedCodeSecurity]
-    [DllImport("zced.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint =
- "zcedGetEnv")]
-    static extern int AcedGetEnv(string? envName, StringBuilder ReturnValue);
+    // ZRX2022/2025 export the size_t overload from ZWCAD.exe under the same x64 decorated name.
+    [SuppressUnmanagedCodeSecurity]
+    [DllImport("zwcad.exe", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl,
+        ExactSpelling = true, EntryPoint = "?zcedGetEnv@@YAHPEB_WPEA_W_K@Z")]
+    private static extern int AcedGetEnv(string? envName, StringBuilder returnValue, UIntPtr bufferLength);
 
-    [System.Security.SuppressUnmanagedCodeSecurity]
-    [DllImport("zced.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.Cdecl, EntryPoint =
- "zcedSetEnv")]
-    static extern int AcedSetEnv(string? envName, StringBuilder NewValue);
+    [SuppressUnmanagedCodeSecurity]
+    [DllImport("zwcad.exe", CharSet = CharSet.Unicode, CallingConvention = CallingConvention.Cdecl,
+        ExactSpelling = true, EntryPoint = "zcedSetEnv")]
+    private static extern int AcedSetEnv(string? envName, string newValue);
 #endif
 
     /// <summary>
@@ -531,7 +531,11 @@ public static class Env
         // https://docs.microsoft.com/zh-cn/windows/win32/sysinfo/registry-element-size-limits
 
         var sbRes = new StringBuilder(1 << 23);
+#if ZWCAD
+        _ = AcedGetEnv(name, sbRes, new UIntPtr((uint)sbRes.Capacity));
+#else
         _ = AcedGetEnv(name, sbRes);
+#endif
         return sbRes.ToString();
     }
 
@@ -545,7 +549,11 @@ public static class Env
     /// <returns></returns>
     public static int SetEnv(string name, string var)
     {
+#if ZWCAD
+        return AcedSetEnv(name, var);
+#else
         return AcedSetEnv(name, new StringBuilder(var));
+#endif
     }
 
     #endregion

--- a/tests/TestShared/TestEnv.cs
+++ b/tests/TestShared/TestEnv.cs
@@ -130,6 +130,41 @@ public class Testenv
         Env.Printl($"getenv-osmode: {Env.GetEnv("osmode")}");
         Env.Printl($"getvar-osmode: {Env.GetVar("osmode")}");
     }
+
+#if ZWCAD
+    [CommandMethod(nameof(Test_ZwCadGetSetEnv))]
+    public static void Test_ZwCadGetSetEnv()
+    {
+        const string testName = "FsFoxCadZwcadInteropTest";
+        const string testValue = "Fs.Fox.CAD-ZWCAD-环境变量";
+        var originalValue = Env.GetEnv(testName);
+        var missingName = $"{testName}_{Guid.NewGuid():N}";
+
+        if (!string.IsNullOrEmpty(Env.GetEnv(missingName)))
+            throw new InvalidOperationException("A random environment variable unexpectedly exists.");
+
+        var setResult = 0;
+        var restoreResult = 0;
+        try
+        {
+            setResult = Env.SetEnv(testName, testValue);
+            var actualValue = Env.GetEnv(testName);
+            if (!string.Equals(actualValue, testValue, StringComparison.Ordinal))
+                throw new InvalidOperationException("ZWCAD environment variable read-back failed.");
+        }
+        finally
+        {
+            restoreResult = Env.SetEnv(testName, originalValue);
+        }
+
+        var restoredValue = Env.GetEnv(testName);
+        if (!string.Equals(restoredValue, originalValue, StringComparison.Ordinal))
+            throw new InvalidOperationException("ZWCAD environment variable restore failed.");
+
+        Env.Printl($"ZWCAD GetEnv/SetEnv passed. Set={setResult}, Restore={restoreResult}");
+    }
+#endif
+
     [CommandMethod(nameof(Test_AppendPath))]
     public static void Test_AppendPath()
     {


### PR DESCRIPTION
## 变更

- 将 ZWCAD `GetEnv/SetEnv` 的原生模块从不存在的 `zced.dll` 改为实际导出所在的 `zwcad.exe`。
- `GetEnv` 使用 ZRX2022/ZRX2025 共用的三参数 x64 入口点，并以 `UIntPtr` 映射 `size_t`、传入 `StringBuilder.Capacity`。
- 两个声明均使用 `CharSet.Unicode`、`CallingConvention.Cdecl` 和 `ExactSpelling = true`；`SetEnv` 按原生 `const wchar_t*` 使用托管 `string`。
- 增加仅在 ZWCAD 测试程序集注册的 `Test_ZwCadGetSetEnv` 命令，覆盖随机不存在变量、Unicode 写入/读回和 `finally` 恢复原值。

公共 `Env.GetEnv/SetEnv` API、AutoCAD/GCAD 声明、现有缓冲区策略及支持路径逻辑不变。

## 上游依据与差异

- [`26a0557`](https://gitee.com/inspirefunction/ifoxcad/commit/26a05570b99d7711bc742dc2fbb03de3db3f80c2)，作者 DYH：确认 ZWCAD 入口位于 `zwcad.exe`，但该提交混合了 `EntGet` 等后续能力。
- [`159c076`](https://gitee.com/inspirefunction/ifoxcad/commit/159c0761cf6289c0195e8c5b7fe7ca99210b9fa1)，作者 vicwjb：改用三参数 GetEnv 的修饰名，但 C# 声明仍只有两个参数。

本 PR 未 cherry-pick 上游提交，而是按两代 SDK 头文件和导入库重新声明完整 ABI。

## ABI 证据

ZRX2022 和 ZRX2025 的 `zacedads.h` 均声明：

```cpp
int zcedGetEnv(const ZTCHAR* sym, ZTCHAR* var, size_t nBufLen);
int zcedSetEnv(const ZTCHAR* sym, const ZTCHAR* val);
```

两代 x64 `ZWCAD.lib` 均确认：

- DLL：`ZWCAD.exe`
- GetEnv：`?zcedGetEnv@@YAHPEB_WPEA_W_K@Z`
- SetEnv 导入名：`zcedSetEnv`

本机 ZWCAD 2022 的实际 `ZWCAD.exe` 导出也与上述名称一致。

## 自动验证

- `git diff --check`
- ZRX2022/ZRX2025 头文件和 x64 导入库断言通过
- 本机 ZWCAD 2022 可执行文件导出检查通过
- AutoCAD 2019：正式类库及 `TestAcad2019`，Debug/Release 构建通过
- AutoCAD 2025：正式类库及 `TestAcad2025`，Debug/Release 构建通过，0 警告、0 错误
- ZWCAD 2022：正式类库及 `TestZcad2022`，Debug/Release 构建通过
- ZWCAD 2025：正式类库及 `TestZcad2025`，Debug/Release 构建通过

## CAD 宿主验收（待人工执行）

分别在 ZWCAD 2022 和 ZWCAD 2025 加载对应测试程序集并执行：

```text
Test_ZwCadGetSetEnv
```

命令应完成缺失变量读取、Unicode 写入/读回和原值恢复，并输出通过信息。出现 `DllNotFoundException`、`EntryPointNotFoundException`、访问冲突、值不一致或恢复失败均视为未通过。

当前没有本机 ZWCAD 2025 实际导出或运行结果。静态 ABI 与构建通过不替代两代宿主验收。

## 范围

不包含 `EntGet/EntMod/EntUpd`、动态块可见性、ZWCAD 进度条、缓冲区策略重构或 `DwgFiler`。

Refs #26