### PR TITLE
feat: add safe read-only EntGet interop

### DIFF
--- a/src/CADShared/CADShared.projitems
+++ b/src/CADShared/CADShared.projitems
@@ -96,6 +96,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Runtime\Env.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Runtime\IdleAction.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Runtime\IdleNoCommandAction.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Runtime\PInvokeCad.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Runtime\SymbolTable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Runtime\SystemVariableManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SelectionFilter\OpComp.cs" />

--- a/src/CADShared/Runtime/Env.cs
+++ b/src/CADShared/Runtime/Env.cs
@@ -926,4 +926,36 @@ public static class Env
     }
 
     #endregion
+
+    #region Native entity data
+
+    /// <summary>
+    /// Returns the DXF data for a resident database object.
+    /// </summary>
+    /// <param name="objectId">A valid, resident and non-erased database object identifier.</param>
+    /// <returns>The object's DXF typed values.</returns>
+    public static TypedValue[] EntGet(ObjectId objectId)
+    {
+        if (!objectId.IsOk())
+        {
+            throw new System.ArgumentException(
+                "EntGet requires a valid, resident and non-erased ObjectId.", nameof(objectId));
+        }
+
+        var status = PInvokeCad.GetAdsName(objectId, out var adsName);
+        if (status != (int)CadErrorStatus.OK)
+            throw new CadException((CadErrorStatus)status);
+
+        var nativeBuffer = PInvokeCad.EntGet(ref adsName);
+        if (nativeBuffer == IntPtr.Zero)
+        {
+            throw new CadException(CadErrorStatus.InvalidAdsName,
+                "EntGet returned no entity data.");
+        }
+
+        using var buffer = ResultBuffer.Create(nativeBuffer, true);
+        return buffer.AsArray();
+    }
+
+    #endregion
 }

--- a/src/CADShared/Runtime/PInvokeCad.cs
+++ b/src/CADShared/Runtime/PInvokeCad.cs
@@ -1,0 +1,75 @@
+namespace Fs.Fox.Cad;
+
+/// <summary>
+/// Native CAD entry points shared by the supported x64 hosts.
+/// </summary>
+internal static class PInvokeCad
+{
+    private const string GetAdsNameEntryPoint =
+        "?acdbGetAdsName@@YA?AW4ErrorStatus@Acad@@AEAY01_JVAcDbObjectId@@@Z";
+
+    private const string GetZdsNameEntryPoint =
+        "?zcdbGetZdsName@@YA?AW4ErrorStatus@Zcad@@AEAY01_JVZcDbObjectId@@@Z";
+
+    private const string ZcdbEntGetEntryPoint = "?zcdbEntGet@@YAPEAUresbuf@@QEB_J@Z";
+
+#if ZWCAD
+    [DllImport("ZwDatabase.dll", CallingConvention = CallingConvention.Cdecl,
+        EntryPoint = GetZdsNameEntryPoint, ExactSpelling = true)]
+    private static extern int ZcdbGetZdsName(out CadAdsName adsName, ObjectId objectId);
+
+    [DllImport("zwcad.exe", CallingConvention = CallingConvention.Cdecl,
+        EntryPoint = ZcdbEntGetEntryPoint, ExactSpelling = true)]
+    private static extern IntPtr ZcdbEntGet(ref CadAdsName adsName);
+
+    internal static int GetAdsName(ObjectId objectId, out CadAdsName adsName)
+    {
+        return ZcdbGetZdsName(out adsName, objectId);
+    }
+
+    internal static IntPtr EntGet(ref CadAdsName adsName)
+    {
+        return ZcdbEntGet(ref adsName);
+    }
+#else
+#if AC_2019
+    private const string AcDbModule = "acdb23.dll";
+#elif AC_2021
+    private const string AcDbModule = "acdb24.dll";
+#elif AC_2025
+    private const string AcDbModule = "acdb25.dll";
+#elif AC_2027
+    private const string AcDbModule = "acdb26.dll";
+#else
+#error Unsupported AutoCAD target. Add its acdb module before enabling EntGet.
+#endif
+
+    [DllImport(AcDbModule, CallingConvention = CallingConvention.Cdecl,
+        EntryPoint = GetAdsNameEntryPoint, ExactSpelling = true)]
+    private static extern int AcdbGetAdsName(out CadAdsName adsName, ObjectId objectId);
+
+    [DllImport("accore.dll", CallingConvention = CallingConvention.Cdecl,
+        EntryPoint = "acdbEntGet", ExactSpelling = true)]
+    private static extern IntPtr AcdbEntGet(ref CadAdsName adsName);
+
+    internal static int GetAdsName(ObjectId objectId, out CadAdsName adsName)
+    {
+        return AcdbGetAdsName(out adsName, objectId);
+    }
+
+    internal static IntPtr EntGet(ref CadAdsName adsName)
+    {
+        return AcdbEntGet(ref adsName);
+    }
+#endif
+}
+
+/// <summary>
+/// x64 ads_name/zds_name storage: two contiguous 64-bit values.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+internal struct CadAdsName
+{
+    public long First;
+    public long Second;
+}

--- a/tests/TestShared/TestEntGet.cs
+++ b/tests/TestShared/TestEntGet.cs
@@ -1,0 +1,54 @@
+namespace Test;
+
+public static class TestEntGet
+{
+    [CommandMethod(nameof(Test_EntGet))]
+    public static void Test_EntGet()
+    {
+        var prompt = Env.Editor.GetEntity("\nSelect an entity to test EntGet: ");
+        if (prompt.Status != PromptStatus.OK)
+            return;
+
+        var objectId = prompt.ObjectId;
+        var values = Env.EntGet(objectId);
+
+        for (var i = 1; i < 100; i++)
+        {
+            values = Env.EntGet(objectId);
+            if (values.Length == 0)
+                throw new InvalidOperationException("EntGet returned an empty result.");
+        }
+
+        var dxfName = values.Where(value => value.TypeCode == 0)
+            .Select(value => value.Value?.ToString())
+            .FirstOrDefault();
+        if (!string.Equals(dxfName, objectId.ObjectClass.DxfName,
+                StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Unexpected DXF name. Expected {objectId.ObjectClass.DxfName}, got {dxfName}.");
+        }
+
+        var handle = values.Where(value => value.TypeCode == 5)
+            .Select(value => value.Value?.ToString())
+            .FirstOrDefault();
+        if (!string.Equals(handle, objectId.Handle.ToString(),
+                StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"Unexpected handle. Expected {objectId.Handle}, got {handle}.");
+        }
+
+        try
+        {
+            _ = Env.EntGet(ObjectId.Null);
+            throw new InvalidOperationException("EntGet accepted ObjectId.Null.");
+        }
+        catch (System.ArgumentException)
+        {
+            // Expected: invalid identifiers are rejected before native interop.
+        }
+
+        Env.Printl($"EntGet passed for {dxfName} ({handle}).");
+    }
+}

--- a/tests/TestShared/TestShared.projitems
+++ b/tests/TestShared/TestShared.projitems
@@ -21,6 +21,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)TestDwgFilerEx.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestDwgMark.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestEditor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TestEntGet.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestEntity\TestAddEntity.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestEnv.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestExtents.cs" />


### PR DESCRIPTION
## Summary

- add read-only `Env.EntGet(ObjectId)` for AutoCAD and ZWCAD
- keep `ads_name`/`zds_name` layout and native entry points internal
- reject invalid identifiers and propagate native `GetAdsName/GetZdsName` status codes
- transfer the returned `resbuf*` to `ResultBuffer.Create(ptr, true)` so disposal calls the vendor release routine
- add a shared CAD command that validates DXF type, handle, repeated reads, and invalid-ID rejection

## Upstream attribution

This is a reviewed reimplementation of IFoxCAD changes by DYH:

- [`a6f4ca1`](https://gitee.com/inspirefunction/ifoxcad/commit/a6f4ca1ac382e7d325b0d7e16536e11b60a927b7)
- [`26a0557`](https://gitee.com/inspirefunction/ifoxcad/commit/26a05570b99d7711bc742dc2fbb03de3db3f80c2)

The upstream implementation is not copied directly because it ignores name-conversion status codes, converts the native buffer without releasing it, and uses an unverified ZWCAD signature.

## ABI and ownership decisions

- x64 `ads_name` and `zds_name` are represented as two sequential 64-bit values.
- AutoCAD binds `acdbEntGet` from `accore.dll` and selects the compile-target `acdb23/24/25/26.dll` for `acdbGetAdsName`.
- ZWCAD binds the common ZRX2022/ZRX2025 decorated exports from `zwcad.exe` and `ZwDatabase.dll`.
- `ResultBuffer.Create(nativeBuffer, true)` owns the native result; verified AutoCAD/ZWCAD wrappers release it through `acutRelRb`/`zcutRelRb`.
- this PR does not include `EntMod`, `EntUpd`, or dynamic block visibility.

## Validation

- `git diff --check`
- AutoCAD 2019 test project: Debug and Release build passed
- AutoCAD 2025 test project: Debug and Release build passed, 0 warnings/errors
- ZWCAD 2022 test project: Debug and Release build passed
- ZWCAD 2025 test project: Debug and Release build passed
- AutoCAD 2027 library: Debug and Release build passed, 0 warnings/errors
- AutoCAD 2021 library could not enter compilation because its existing external `D:\MakeX\Holu\AutoCAD.ManagedReferences.props` import is absent; ObjectARX2021 `acdb24.lib` was checked separately for the declared symbol
- ObjectARX2019/2025 and ZRX2022/2025 headers/import libraries checked for module, exact export, parameter width, and return type

## CAD host acceptance still required

Run `Test_EntGet` in:

- [ ] AutoCAD 2019
- [ ] AutoCAD 2025
- [ ] ZWCAD 2022
- [ ] ZWCAD 2025

Build and static ABI evidence do not replace these host checks.

Refs #26