### PR TITLE
feat: add safe EntMod and EntUpd interop

### DIFF
--- a/src/CADShared/Runtime/Env.cs
+++ b/src/CADShared/Runtime/Env.cs
@@ -929,6 +929,8 @@ public static class Env
 
     #region Native entity data
 
+    private const int AdsReturnNormal = 5100;
+
     /// <summary>
     /// Returns the DXF data for a resident database object.
     /// </summary>
@@ -955,6 +957,46 @@ public static class Env
 
         using var buffer = ResultBuffer.Create(nativeBuffer, true);
         return buffer.AsArray();
+    }
+
+    /// <summary>
+    /// Replaces a resident entity's DXF data without forcing a graphics refresh.
+    /// </summary>
+    /// <param name="typedValues">DXF data, normally obtained from <see cref="EntGet"/>.</param>
+    /// <returns><see langword="true"/> when the native operation returns RTNORM.</returns>
+    public static bool EntMod(IEnumerable<TypedValue> typedValues)
+    {
+        ArgumentNullException.ThrowIfNull(typedValues);
+
+        var values = typedValues.ToArray();
+        if (values.Length == 0)
+        {
+            throw new System.ArgumentException(
+                "EntMod requires at least one DXF typed value.", nameof(typedValues));
+        }
+
+        using var buffer = new ResultBuffer(values);
+        return PInvokeCad.EntMod(buffer.UnmanagedObject) == AdsReturnNormal;
+    }
+
+    /// <summary>
+    /// Regenerates the graphics for a resident database object after native DXF modification.
+    /// </summary>
+    /// <param name="objectId">A valid, resident and non-erased database object identifier.</param>
+    /// <returns><see langword="true"/> when the native operation returns RTNORM.</returns>
+    public static bool EntUpd(ObjectId objectId)
+    {
+        if (!objectId.IsOk())
+        {
+            throw new System.ArgumentException(
+                "EntUpd requires a valid, resident and non-erased ObjectId.", nameof(objectId));
+        }
+
+        var status = PInvokeCad.GetAdsName(objectId, out var adsName);
+        if (status != (int)CadErrorStatus.OK)
+            throw new CadException((CadErrorStatus)status);
+
+        return PInvokeCad.EntUpd(ref adsName) == AdsReturnNormal;
     }
 
     #endregion

--- a/src/CADShared/Runtime/PInvokeCad.cs
+++ b/src/CADShared/Runtime/PInvokeCad.cs
@@ -12,6 +12,8 @@ internal static class PInvokeCad
         "?zcdbGetZdsName@@YA?AW4ErrorStatus@Zcad@@AEAY01_JVZcDbObjectId@@@Z";
 
     private const string ZcdbEntGetEntryPoint = "?zcdbEntGet@@YAPEAUresbuf@@QEB_J@Z";
+    private const string ZcdbEntModEntryPoint = "?zcdbEntMod@@YAHPEBUresbuf@@@Z";
+    private const string ZcdbEntUpdEntryPoint = "?zcdbEntUpd@@YAHQEB_J@Z";
 
 #if ZWCAD
     [DllImport("ZwDatabase.dll", CallingConvention = CallingConvention.Cdecl,
@@ -22,6 +24,14 @@ internal static class PInvokeCad
         EntryPoint = ZcdbEntGetEntryPoint, ExactSpelling = true)]
     private static extern IntPtr ZcdbEntGet(ref CadAdsName adsName);
 
+    [DllImport("zwcad.exe", CallingConvention = CallingConvention.Cdecl,
+        EntryPoint = ZcdbEntModEntryPoint, ExactSpelling = true)]
+    private static extern int ZcdbEntMod(IntPtr buffer);
+
+    [DllImport("zwcad.exe", CallingConvention = CallingConvention.Cdecl,
+        EntryPoint = ZcdbEntUpdEntryPoint, ExactSpelling = true)]
+    private static extern int ZcdbEntUpd(ref CadAdsName adsName);
+
     internal static int GetAdsName(ObjectId objectId, out CadAdsName adsName)
     {
         return ZcdbGetZdsName(out adsName, objectId);
@@ -30,6 +40,16 @@ internal static class PInvokeCad
     internal static IntPtr EntGet(ref CadAdsName adsName)
     {
         return ZcdbEntGet(ref adsName);
+    }
+
+    internal static int EntMod(IntPtr buffer)
+    {
+        return ZcdbEntMod(buffer);
+    }
+
+    internal static int EntUpd(ref CadAdsName adsName)
+    {
+        return ZcdbEntUpd(ref adsName);
     }
 #else
 #if AC_2019
@@ -52,6 +72,14 @@ internal static class PInvokeCad
         EntryPoint = "acdbEntGet", ExactSpelling = true)]
     private static extern IntPtr AcdbEntGet(ref CadAdsName adsName);
 
+    [DllImport("accore.dll", CallingConvention = CallingConvention.Cdecl,
+        EntryPoint = "acdbEntMod", ExactSpelling = true)]
+    private static extern int AcdbEntMod(IntPtr buffer);
+
+    [DllImport("accore.dll", CallingConvention = CallingConvention.Cdecl,
+        EntryPoint = "acdbEntUpd", ExactSpelling = true)]
+    private static extern int AcdbEntUpd(ref CadAdsName adsName);
+
     internal static int GetAdsName(ObjectId objectId, out CadAdsName adsName)
     {
         return AcdbGetAdsName(out adsName, objectId);
@@ -60,6 +88,16 @@ internal static class PInvokeCad
     internal static IntPtr EntGet(ref CadAdsName adsName)
     {
         return AcdbEntGet(ref adsName);
+    }
+
+    internal static int EntMod(IntPtr buffer)
+    {
+        return AcdbEntMod(buffer);
+    }
+
+    internal static int EntUpd(ref CadAdsName adsName)
+    {
+        return AcdbEntUpd(ref adsName);
     }
 #endif
 }

--- a/tests/TestShared/TestEntMod.cs
+++ b/tests/TestShared/TestEntMod.cs
@@ -1,0 +1,128 @@
+namespace Test;
+
+public static class TestEntMod
+{
+    private const int EntityNameCode = -1;
+    private const int ColorCode = 62;
+
+    [CommandMethod(nameof(Test_EntMod))]
+    public static void Test_EntMod()
+    {
+        var objectId = ObjectId.Null;
+
+        try
+        {
+            using (var tr = new DBTrans())
+            {
+                var line = new Line(new Point3d(0, 0, 0), new Point3d(10, 0, 0))
+                {
+                    ColorIndex = 1
+                };
+                objectId = tr.CurrentSpace.AddEntity(line);
+            }
+
+            var original = Env.EntGet(objectId);
+            var modified = ReplaceColor(original, 2);
+
+            if (!Env.EntMod(modified))
+                throw new InvalidOperationException("EntMod rejected valid entity data.");
+
+            AssertColor(objectId, 2);
+
+            if (!Env.EntUpd(objectId))
+                throw new InvalidOperationException("EntUpd rejected a valid ObjectId.");
+
+            AssertColor(objectId, 2);
+            AssertManagedArgumentChecks();
+
+            var withoutEntityName = original
+                .Where(value => value.TypeCode != EntityNameCode)
+                .ToArray();
+            if (withoutEntityName.Length == original.Length)
+                throw new InvalidOperationException("EntGet did not return an entity-name value.");
+            if (Env.EntMod(withoutEntityName))
+                throw new InvalidOperationException("EntMod accepted data without an entity name.");
+
+            Env.Printl($"EntMod/EntUpd passed for {objectId.Handle}.");
+        }
+        finally
+        {
+            if (objectId.IsOk())
+            {
+                using var tr = new DBTrans();
+                var entity = tr.GetObject<Entity>(objectId, OpenMode.ForWrite);
+                entity?.Erase();
+            }
+        }
+    }
+
+    private static TypedValue[] ReplaceColor(TypedValue[] values, short colorIndex)
+    {
+        var result = new TypedValue[values.Length];
+        var replaced = false;
+
+        for (var i = 0; i < values.Length; i++)
+        {
+            if (values[i].TypeCode == ColorCode)
+            {
+                result[i] = new TypedValue(ColorCode, colorIndex);
+                replaced = true;
+            }
+            else
+            {
+                result[i] = values[i];
+            }
+        }
+
+        if (!replaced)
+            throw new InvalidOperationException("EntGet did not return the line color.");
+
+        return result;
+    }
+
+    private static void AssertColor(ObjectId objectId, short expected)
+    {
+        var color = Env.EntGet(objectId)
+            .Where(value => value.TypeCode == ColorCode)
+            .Select(value => Convert.ToInt16(value.Value))
+            .FirstOrDefault();
+        if (color != expected)
+        {
+            throw new InvalidOperationException(
+                $"Unexpected color. Expected {expected}, got {color}.");
+        }
+    }
+
+    private static void AssertManagedArgumentChecks()
+    {
+        try
+        {
+            _ = Env.EntMod(null!);
+            throw new InvalidOperationException("EntMod accepted null data.");
+        }
+        catch (System.ArgumentNullException)
+        {
+            // Expected: null data is rejected before native interop.
+        }
+
+        try
+        {
+            _ = Env.EntMod(Array.Empty<TypedValue>());
+            throw new InvalidOperationException("EntMod accepted empty data.");
+        }
+        catch (System.ArgumentException)
+        {
+            // Expected: empty data is rejected before native interop.
+        }
+
+        try
+        {
+            _ = Env.EntUpd(ObjectId.Null);
+            throw new InvalidOperationException("EntUpd accepted ObjectId.Null.");
+        }
+        catch (System.ArgumentException)
+        {
+            // Expected: invalid identifiers are rejected before native interop.
+        }
+    }
+}

--- a/tests/TestShared/TestShared.projitems
+++ b/tests/TestShared/TestShared.projitems
@@ -22,6 +22,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)TestDwgMark.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestEditor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestEntGet.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TestEntMod.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestEntity\TestAddEntity.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestEnv.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestExtents.cs" />


### PR DESCRIPTION
## Summary

- add `Env.EntMod(IEnumerable<TypedValue>)` with null/empty validation and explicit ADS return semantics
- add `Env.EntUpd(ObjectId)` with the same ObjectId and native name-conversion checks as `EntGet`
- keep all native bindings internal and support AutoCAD plus ZWCAD 2022/2025
- own the caller-created `resbuf*` through `ResultBuffer` so every path releases it
- add a shared host command that writes and refreshes a temporary line, verifies failure mapping, and cleans up in `finally`

## Upstream attribution

Reviewed reimplementation of IFoxCAD changes by DYH:

- [`6d612fd`](https://gitee.com/inspirefunction/ifoxcad/commit/6d612fd31116e357a7eecb2ab59b5f6a8fa89f4a)
- [`3040c16`](https://gitee.com/inspirefunction/ifoxcad/commit/3040c16672c54a289502b093e8942bb476e27398)
- [`26a0557`](https://gitee.com/inspirefunction/ifoxcad/commit/26a05570b99d7711bc742dc2fbb03de3db3f80c2)

The upstream implementation is not copied directly because it leaks the buffer allocated by `TypedValuesToResbuf`, uses unverified ZWCAD entry points, and omits ZWCAD `EntUpd`.

## ABI and ownership

- ObjectARX 2019/2025 export `acdbEntMod` and `acdbEntUpd` from `accore.dll`.
- ZRX 2022/2025 import libraries contain the common decorated exports:
  - `?zcdbEntMod@@YAHPEBUresbuf@@@Z`
  - `?zcdbEntUpd@@YAHQEB_J@Z`
- all four SDKs declare an `int` ADS return and `RTNORM = 5100`
- `EntMod` creates an owning `ResultBuffer`; the native function receives a borrowed pointer and does not take ownership
- `EntMod` deliberately does not call `EntUpd` implicitly

## Validation

- `git diff --check`
- AutoCAD 2019 test project: Debug and Release, 0 warnings/errors
- AutoCAD 2025 test project: Debug and Release, 0 warnings/errors
- ZWCAD 2022 test project: Debug and Release, 0 warnings/errors
- ZWCAD 2025 test project: Debug and Release, 0 warnings/errors
- AutoCAD 2027 library: Debug and Release, 0 warnings/errors
- AutoCAD 2021 remains blocked before compilation by the existing missing external `D:\MakeX\Holu\AutoCAD.ManagedReferences.props`
- headers, x64 import libraries, and decompiled target outputs checked for module, exact entry point, parameter shape, return type, and disposal

## CAD host acceptance still required

Run `Test_EntMod` in:

- [ ] AutoCAD 2019
- [ ] AutoCAD 2025
- [ ] ZWCAD 2022
- [ ] ZWCAD 2025

The command creates and removes its own line. Build and static ABI evidence do not replace database-write and graphics-refresh checks in each host.

Refs #26