### PR TITLE
feat: expose dynamic block visibility metadata

### DIFF
--- a/src/CADShared/ExtensionMethod/Entity/BlockReferenceEx.cs
+++ b/src/CADShared/ExtensionMethod/Entity/BlockReferenceEx.cs
@@ -9,6 +9,12 @@ namespace Fs.Fox.Cad;
 /// </summary>
 public static class BlockReferenceEx
 {
+    private const string EnhancedBlockDictionaryKey = "ACAD_ENHANCEDBLOCK";
+    private const string VisibilityParameterDxfName = "BLOCKVISIBILITYPARAMETER";
+    private const int HardOwnerIdCode = 360;
+    private const int VisibilityPropertyNameCode = 301;
+    private const int VisibilityAllowedValueCode = 303;
+
     #region 裁剪块参照
 
     private const string kFilterDictName = "ACAD_FILTER";
@@ -323,4 +329,89 @@ public static class BlockReferenceEx
             }
         }
     }
+
+    /// <summary>
+    /// Gets the visibility parameter metadata for a dynamic block reference.
+    /// </summary>
+    /// <param name="blockReference">Block reference to inspect.</param>
+    /// <returns>Visibility metadata, or an empty result when no visibility parameter exists.</returns>
+    public static BlockVisibilityInfo GetVisibilityInfo(this BlockReference blockReference)
+    {
+        ArgumentNullException.ThrowIfNull(blockReference);
+
+        if (!blockReference.IsDynamicBlock || !blockReference.DynamicBlockTableRecord.IsOk())
+            return new BlockVisibilityInfo();
+
+        var tr = DBTrans.GetTopTransaction(blockReference.Database);
+        return tr.GetObject(blockReference.DynamicBlockTableRecord) is BlockTableRecord blockTableRecord
+            ? blockTableRecord.GetVisibilityInfo()
+            : new BlockVisibilityInfo();
+    }
+
+    /// <summary>
+    /// Gets the visibility parameter metadata stored in a dynamic block definition.
+    /// </summary>
+    /// <param name="blockTableRecord">Dynamic block definition to inspect.</param>
+    /// <returns>Visibility metadata, or an empty result when no visibility parameter exists.</returns>
+    public static BlockVisibilityInfo GetVisibilityInfo(this BlockTableRecord blockTableRecord)
+    {
+        ArgumentNullException.ThrowIfNull(blockTableRecord);
+
+        var info = new BlockVisibilityInfo();
+        if (!blockTableRecord.IsDynamicBlock || !blockTableRecord.ExtensionDictionary.IsOk())
+            return info;
+
+        var tr = DBTrans.GetTopTransaction(blockTableRecord.Database);
+        if (tr.GetObject(blockTableRecord.ExtensionDictionary) is not DBDictionary dictionary ||
+            !dictionary.Contains(EnhancedBlockDictionaryKey))
+        {
+            return info;
+        }
+
+        var enhancedBlockId = dictionary.GetAt(EnhancedBlockDictionaryKey);
+        if (!enhancedBlockId.IsOk())
+            return info;
+
+        var parameterId = Env.EntGet(enhancedBlockId)
+            .Where(value => value.TypeCode == HardOwnerIdCode)
+            .Select(value => value.Value)
+            .OfType<ObjectId>()
+            .FirstOrDefault(id => id.IsOk() && string.Equals(id.ObjectClass.DxfName,
+                VisibilityParameterDxfName, StringComparison.OrdinalIgnoreCase));
+        if (!parameterId.IsOk())
+            return info;
+
+        var parameterValues = Env.EntGet(parameterId);
+        info.Has = true;
+        info.PropertyName = parameterValues
+            .FirstOrDefault(value => value.TypeCode == VisibilityPropertyNameCode)
+            .Value?.ToString() ?? string.Empty;
+        info.AllowedValues = parameterValues
+            .Where(value => value.TypeCode == VisibilityAllowedValueCode)
+            .Select(value => value.Value?.ToString() ?? string.Empty)
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .ToList();
+        return info;
+    }
+}
+
+/// <summary>
+/// Dynamic block visibility parameter metadata.
+/// </summary>
+public class BlockVisibilityInfo
+{
+    /// <summary>
+    /// Gets or sets whether the block definition contains a visibility parameter.
+    /// </summary>
+    public bool Has { get; set; }
+
+    /// <summary>
+    /// Gets or sets the visibility property name.
+    /// </summary>
+    public string PropertyName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the allowed visibility values in definition order.
+    /// </summary>
+    public List<string> AllowedValues { get; set; } = new();
 }

--- a/tests/TestShared/TestBlockVisibility.cs
+++ b/tests/TestShared/TestBlockVisibility.cs
@@ -1,0 +1,39 @@
+namespace Test;
+
+public static class TestBlockVisibility
+{
+    [CommandMethod(nameof(Test_BlockVisibilityInfo))]
+    public static void Test_BlockVisibilityInfo()
+    {
+        var options = new PromptEntityOptions("\nSelect a block reference: ");
+        options.SetRejectMessage("\nThe selected object is not a block reference.");
+        options.AddAllowedClass(typeof(BlockReference), true);
+
+        var prompt = Env.Editor.GetEntity(options);
+        if (prompt.Status != PromptStatus.OK)
+            return;
+
+        using var tr = new DBTrans();
+        var blockReference = tr.GetObject<BlockReference>(prompt.ObjectId)
+                             ?? throw new InvalidOperationException(
+                                 "The selected block reference could not be opened.");
+        var info = blockReference.GetVisibilityInfo();
+
+        if (!blockReference.IsDynamicBlock && info.Has)
+        {
+            throw new InvalidOperationException(
+                "A non-dynamic block reported a visibility parameter.");
+        }
+
+        if (info.Has && (string.IsNullOrWhiteSpace(info.PropertyName) ||
+                         info.AllowedValues.Count == 0))
+        {
+            throw new InvalidOperationException(
+                "The visibility parameter metadata is incomplete.");
+        }
+
+        var allowedValues = info.Has ? string.Join(", ", info.AllowedValues) : "none";
+        Env.Printl(
+            $"Visibility: Has={info.Has}, Property={info.PropertyName}, Values={allowedValues}");
+    }
+}

--- a/tests/TestShared/TestShared.projitems
+++ b/tests/TestShared/TestShared.projitems
@@ -13,6 +13,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Copyclip.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestAddEntity.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestBlock.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TestBlockVisibility.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestCadFilePath.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestConvexHull.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestCurve.cs" />


### PR DESCRIPTION
## Summary

- add `GetVisibilityInfo` for dynamic `BlockReference` and `BlockTableRecord`
- expose `BlockVisibilityInfo` with parameter presence, property name, and allowed values
- parse `ACAD_ENHANCEDBLOCK` through the verified read-only `Env.EntGet` path
- open only an existing extension dictionary, so a read query never creates dictionary data or upgrades the object
- add a shared CAD command that reports and validates visibility metadata without platform-specific UI

## Upstream attribution

Reviewed reimplementation of IFoxCAD [`a6f4ca1`](https://gitee.com/inspirefunction/ifoxcad/commit/a6f4ca1ac382e7d325b0d7e16536e11b60a927b7) by DYH.

The upstream WPF test UI is not included. The shared test uses the CAD editor and compiles for all supported hosts.

## Data contract

- dictionary key: `ACAD_ENHANCEDBLOCK`
- visibility parameter reference: group code `360`, DXF name `BLOCKVISIBILITYPARAMETER`
- property name: group code `301`
- allowed values: group code `303`
- ordinary blocks, dynamic blocks without visibility, and definitions without an existing extension dictionary return an empty result
- the query path does not call `CreateExtensionDictionary` and does not write to the database

## Validation

- `git diff --check`
- AutoCAD 2019 test project: Debug and Release, 0 warnings/errors
- AutoCAD 2025 test project: Debug and Release, 0 warnings/errors
- ZWCAD 2022 test project: Debug and Release, 0 warnings/errors
- ZWCAD 2025 test project: Debug and Release, 0 warnings/errors
- AutoCAD 2027 library: Debug and Release, 0 warnings/errors
- decompiled AutoCAD and ZWCAD outputs inspected for the read-only extension-dictionary path and shared command
- no dynamic-block DWG fixture exists in this repository

## CAD host acceptance still required

Run `Test_BlockVisibilityInfo` in AutoCAD 2019/2025 and ZWCAD 2022/2025 with:

- [ ] a dynamic block containing a visibility parameter
- [ ] a dynamic block without a visibility parameter
- [ ] an ordinary block

Build evidence does not replace parsing real host-owned evaluation graph data.

Refs #26