### PR TITLE
feat: add cross-host status bar progress meter

### DIFF
--- a/src/CADShared/CADShared.projitems
+++ b/src/CADShared/CADShared.projitems
@@ -97,6 +97,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Runtime\IdleAction.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Runtime\IdleNoCommandAction.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Runtime\PInvokeCad.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Runtime\ProgressMeterUtils.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Runtime\SymbolTable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Runtime\SystemVariableManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SelectionFilter\OpComp.cs" />

--- a/src/CADShared/Runtime/ProgressMeterUtils.cs
+++ b/src/CADShared/Runtime/ProgressMeterUtils.cs
@@ -1,0 +1,96 @@
+#if AC_NET48 || ZWCAD
+using ArgumentNullException = Fs.Fox.Basal.ArgumentNullEx;
+#endif
+
+namespace Fs.Fox.Cad;
+
+/// <summary>
+/// Cross-host access to the application status-bar progress meter.
+/// </summary>
+public static class ProgressMeterUtils
+{
+    /// <summary>
+    /// Creates a status-bar progress meter.
+    /// </summary>
+    /// <param name="label">Progress label.</param>
+    /// <param name="minimum">Minimum position.</param>
+    /// <param name="maximum">Maximum position.</param>
+    public static void SetApplicationStatusBarProgressMeter(
+        string label, int minimum, int maximum)
+    {
+        ArgumentNullException.ThrowIfNull(label);
+        if (minimum > maximum)
+        {
+            throw new System.ArgumentOutOfRangeException(nameof(minimum), minimum,
+                "The minimum progress position cannot exceed the maximum position.");
+        }
+
+#if ZWCAD
+        EnsureZwcadSuccess(ZcedSetStatusBarProgressMeter(label, minimum, maximum),
+            "create the status-bar progress meter");
+#else
+        Utils.SetApplicationStatusBarProgressMeter(label, minimum, maximum);
+#endif
+    }
+
+    /// <summary>
+    /// Updates the status-bar progress position.
+    /// </summary>
+    /// <param name="position">Absolute position, or a negative relative increment.</param>
+    public static void SetApplicationStatusBarProgressMeter(int position)
+    {
+#if ZWCAD
+        EnsureZwcadSuccess(ZcedSetStatusBarProgressMeterPos(position),
+            "update the status-bar progress meter");
+#else
+        Utils.SetApplicationStatusBarProgressMeter(position);
+#endif
+    }
+
+    /// <summary>
+    /// Removes the progress meter and restores the application status bar.
+    /// </summary>
+    public static void RestoreApplicationStatusBar()
+    {
+#if ZWCAD
+        ZcedRestoreStatusBar();
+#else
+        Utils.RestoreApplicationStatusBar();
+#endif
+    }
+
+#if ZWCAD
+    private const string ZwCadModule = "zwcad.exe";
+
+    private const string SetProgressMeterEntryPoint =
+        "?zcedSetStatusBarProgressMeter@@YAHPEB_WHH@Z";
+
+    private const string SetProgressMeterPositionEntryPoint =
+        "?zcedSetStatusBarProgressMeterPos@@YAHH@Z";
+
+    private const string RestoreStatusBarEntryPoint = "?zcedRestoreStatusBar@@YAXXZ";
+
+    [DllImport(ZwCadModule, CharSet = CharSet.Unicode,
+        CallingConvention = CallingConvention.Cdecl,
+        EntryPoint = SetProgressMeterEntryPoint, ExactSpelling = true)]
+    private static extern int ZcedSetStatusBarProgressMeter(
+        [MarshalAs(UnmanagedType.LPWStr)] string label, int minimum, int maximum);
+
+    [DllImport(ZwCadModule, CallingConvention = CallingConvention.Cdecl,
+        EntryPoint = SetProgressMeterPositionEntryPoint, ExactSpelling = true)]
+    private static extern int ZcedSetStatusBarProgressMeterPos(int position);
+
+    [DllImport(ZwCadModule, CallingConvention = CallingConvention.Cdecl,
+        EntryPoint = RestoreStatusBarEntryPoint, ExactSpelling = true)]
+    private static extern void ZcedRestoreStatusBar();
+
+    private static void EnsureZwcadSuccess(int result, string operation)
+    {
+        if (result != 0)
+        {
+            throw new InvalidOperationException(
+                $"ZWCAD failed to {operation}; native result: {result}.");
+        }
+    }
+#endif
+}

--- a/tests/TestShared/TestProgressMeter.cs
+++ b/tests/TestShared/TestProgressMeter.cs
@@ -1,0 +1,25 @@
+namespace Test;
+
+public static class TestProgressMeter
+{
+    [CommandMethod(nameof(Test_ProgressMeter))]
+    public static void Test_ProgressMeter()
+    {
+        try
+        {
+            ProgressMeterUtils.SetApplicationStatusBarProgressMeter(
+                "Fs.Fox.CAD 进度测试", 0, 20);
+            for (var position = 0; position <= 20; position++)
+            {
+                ProgressMeterUtils.SetApplicationStatusBarProgressMeter(position);
+                Thread.Sleep(50);
+            }
+        }
+        finally
+        {
+            ProgressMeterUtils.RestoreApplicationStatusBar();
+        }
+
+        Env.Printl("Progress meter completed and the status bar was restored.");
+    }
+}

--- a/tests/TestShared/TestShared.projitems
+++ b/tests/TestShared/TestShared.projitems
@@ -40,6 +40,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)TestMirrorFile.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestPoint.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestPointOnRegion.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TestProgressMeter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestQuadTree.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestSelectfilter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestSingleKeyWordHook.cs" />


### PR DESCRIPTION
## 本阶段目标

移植 IFoxCAD 的状态栏进度条能力，并按 Fs.Fox.CAD 的 AutoCAD/ZWCAD 多宿主结构重新实现原生互操作。

## 实现

- 新增 `ProgressMeterUtils`，保留创建、更新和恢复状态栏三个公共 `void` API。
- AutoCAD 直接委托现有 `Autodesk.AutoCAD.Internal.Utils`。
- ZWCAD 从 `zwcad.exe` 调用两代 ZRX 均存在的精确 C++ 导出。
- 创建与更新按 SDK 的真实 `int` ABI 声明；返回非 0 时抛出 `InvalidOperationException`。
- 恢复使用 SDK 文档化的 `zcedRestoreStatusBar`，没有移植上游未文档化的 Stop 入口。
- 明确 Unicode、Cdecl 与 ExactSpelling，并增加空标签、反向范围校验。
- 增加 `Test_ProgressMeter` 宿主命令，使用中文标签并在 `finally` 中恢复状态栏。

## 上游归属

- [5340b97](https://gitee.com/inspirefunction/ifoxcad/commit/5340b971fd4fe3c298a15a1646382a0a9b47329e) - DYH - 增加进度条工具以适配中望
- [98030b2](https://gitee.com/inspirefunction/ifoxcad/commit/98030b2c17de7238539694d87b392402871eb9f9) - DYH - 添加 DLL 文件名常量并优化 ZWCAD 调用接口

本 PR 没有直接照搬上游 P/Invoke：上游把 `int` 返回值声明成 `void`，并使用未在两代头文件中声明的 Stop API。

## 自动验证

- AutoCAD 2019：测试项目 Debug/Release 构建通过。
- AutoCAD 2025：测试项目 Debug/Release 构建通过，0 警告、0 错误。
- ZWCAD 2022：测试项目 Debug/Release 构建通过。
- ZWCAD 2025：测试项目 Debug/Release 构建通过。
- AutoCAD 2027：类库 Debug/Release 构建通过，0 警告、0 错误。
- ZRX2022/ZRX2025 `zcore_rxmfcapi.h`：确认创建/更新返回 `int`，恢复返回 `void`。
- 两代 `ZWCAD.lib`：确认三个精确修饰名均存在。
- ILSpy：AutoCAD 产物仅调用托管 Utils；两代 ZWCAD 产物包含预期 Unicode/Cdecl P/Invoke 和返回值检查。
- `git diff --check` 与共享项目项 XML 解析通过。

## 尚需 CAD 宿主验收

自动构建不替代宿主行为验证。请分别在 ZWCAD 2022、ZWCAD 2025 中加载对应测试程序集并执行 `Test_ProgressMeter`，确认：

- 中文标签正常显示。
- 0 到 20 的绝对位置更新正常。
- 命令结束或异常时状态栏恢复。
- 重复执行不残留旧进度条。

Refs #26
