### PR TITLE
test: allow progress meter command to repaint

### DIFF
--- a/tests/TestShared/TestProgressMeter.cs
+++ b/tests/TestShared/TestProgressMeter.cs
@@ -12,6 +12,7 @@ public static class TestProgressMeter
             for (var position = 0; position <= 20; position++)
             {
                 ProgressMeterUtils.SetApplicationStatusBarProgressMeter(position);
+                System.Windows.Forms.Application.DoEvents();
                 Thread.Sleep(50);
             }
         }


### PR DESCRIPTION
## 背景

PR #33 合并后，Qodo 的正式 Code Review 才发布，其中指出手工验收命令在循环内仅 `Thread.Sleep`，可能阻塞 CAD UI 消息循环，使状态栏无法逐步重绘。

该建议正确。本 PR 只修复测试命令，不改变 `ProgressMeterUtils` 的公共 API 或 ZWCAD 原生互操作。

## 修改

- 每次更新状态栏位置后调用 `System.Windows.Forms.Application.DoEvents()`。
- 保留 50ms 延迟，方便在宿主中肉眼观察 0 到 20 的变化。
- 沿用仓库 `RedrawEx` 与 Jig 测试已有的消息处理约定。

## 未纳入

同一轮评审建议外部 DiG 仓库改用新包装器。那是下游包升级和多宿主迁移任务，不属于 Fs.Fox.CAD 的测试修复，不能在本 PR 跨仓库修改。

## 验证

- AutoCAD 2019 测试项目 Debug/Release 构建通过。
- AutoCAD 2025 测试项目 Debug/Release 构建通过，0 警告、0 错误。
- ZWCAD 2022 测试项目 Debug/Release 构建通过。
- ZWCAD 2025 测试项目 Debug/Release 构建通过。
- `git diff --check` 通过。

Follow-up to #33.
Refs #26
