### PR TITLE
fix: use actual ZWCAD entity API exports

### DIFF
--- a/src/CADShared/Runtime/PInvokeCad.cs
+++ b/src/CADShared/Runtime/PInvokeCad.cs
@@ -11,9 +11,10 @@ internal static class PInvokeCad
     private const string GetZdsNameEntryPoint =
         "?zcdbGetZdsName@@YA?AW4ErrorStatus@Zcad@@AEAY01_JVZcDbObjectId@@@Z";
 
-    private const string ZcdbEntGetEntryPoint = "?zcdbEntGet@@YAPEAUresbuf@@QEB_J@Z";
-    private const string ZcdbEntModEntryPoint = "?zcdbEntMod@@YAHPEBUresbuf@@@Z";
-    private const string ZcdbEntUpdEntryPoint = "?zcdbEntUpd@@YAHQEB_J@Z";
+    // P/Invoke resolves the PE export names, not the C++ symbols exposed by ZWCAD.lib.
+    private const string ZcdbEntGetEntryPoint = "zcdbEntGet";
+    private const string ZcdbEntModEntryPoint = "zcdbEntMod";
+    private const string ZcdbEntUpdEntryPoint = "zcdbEntUpd";
 
 #if ZWCAD
     [DllImport("ZwDatabase.dll", CallingConvention = CallingConvention.Cdecl,

--- a/tests/TestShared/TestEntGet.cs
+++ b/tests/TestShared/TestEntGet.cs
@@ -5,40 +5,61 @@ public static class TestEntGet
     [CommandMethod(nameof(Test_EntGet))]
     public static void Test_EntGet()
     {
-        var prompt = Env.Editor.GetEntity("\nSelect an entity to test EntGet: ");
-        if (prompt.Status != PromptStatus.OK)
-            return;
+        var objectId = ObjectId.Null;
 
-        var objectId = prompt.ObjectId;
-        var values = Env.EntGet(objectId);
-
-        for (var i = 1; i < 100; i++)
+        try
         {
-            values = Env.EntGet(objectId);
-            if (values.Length == 0)
-                throw new InvalidOperationException("EntGet returned an empty result.");
-        }
+            using (var tr = new DBTrans())
+            {
+                var line = new Line(new Point3d(0, 0, 0), new Point3d(10, 0, 0));
+                objectId = tr.CurrentSpace.AddEntity(line);
+            }
 
-        var dxfName = values.Where(value => value.TypeCode == 0)
-            .Select(value => value.Value?.ToString())
-            .FirstOrDefault();
-        if (!string.Equals(dxfName, objectId.ObjectClass.DxfName,
-                StringComparison.OrdinalIgnoreCase))
+            var values = Env.EntGet(objectId);
+
+            for (var i = 1; i < 100; i++)
+            {
+                values = Env.EntGet(objectId);
+                if (values.Length == 0)
+                    throw new InvalidOperationException("EntGet returned an empty result.");
+            }
+
+            var dxfName = values.Where(value => value.TypeCode == 0)
+                .Select(value => value.Value?.ToString())
+                .FirstOrDefault();
+            if (!string.Equals(dxfName, objectId.ObjectClass.DxfName,
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException(
+                    $"Unexpected DXF name. Expected {objectId.ObjectClass.DxfName}, got {dxfName}.");
+            }
+
+            var handle = values.Where(value => value.TypeCode == 5)
+                .Select(value => value.Value?.ToString())
+                .FirstOrDefault();
+            if (!string.Equals(handle, objectId.Handle.ToString(),
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                throw new InvalidOperationException(
+                    $"Unexpected handle. Expected {objectId.Handle}, got {handle}.");
+            }
+
+            AssertNullObjectIdRejected();
+            Env.Printl($"EntGet passed for {dxfName} ({handle}).");
+        }
+        finally
         {
-            throw new InvalidOperationException(
-                $"Unexpected DXF name. Expected {objectId.ObjectClass.DxfName}, got {dxfName}.");
+            if (objectId.IsOk())
+            {
+                using var tr = new DBTrans();
+                var entity = tr.GetObject<Entity>(objectId, OpenMode.ForWrite);
+                entity?.Erase();
+            }
         }
+    }
 
-        var handle = values.Where(value => value.TypeCode == 5)
-            .Select(value => value.Value?.ToString())
-            .FirstOrDefault();
-        if (!string.Equals(handle, objectId.Handle.ToString(),
-                StringComparison.OrdinalIgnoreCase))
-        {
-            throw new InvalidOperationException(
-                $"Unexpected handle. Expected {objectId.Handle}, got {handle}.");
-        }
-
+    private static void AssertNullObjectIdRejected()
+    {
         try
         {
             _ = Env.EntGet(ObjectId.Null);
@@ -48,7 +69,5 @@ public static class TestEntGet
         {
             // Expected: invalid identifiers are rejected before native interop.
         }
-
-        Env.Printl($"EntGet passed for {dxfName} ({handle}).");
     }
 }

--- a/tests/TestShared/TestEntGet.cs
+++ b/tests/TestShared/TestEntGet.cs
@@ -2,10 +2,14 @@ namespace Test;
 
 public static class TestEntGet
 {
+    private const int ReadCount = 100;
+
     [CommandMethod(nameof(Test_EntGet))]
     public static void Test_EntGet()
     {
         var objectId = ObjectId.Null;
+        Exception? testFailure = null;
+        var successMessage = string.Empty;
 
         try
         {
@@ -15,9 +19,8 @@ public static class TestEntGet
                 objectId = tr.CurrentSpace.AddEntity(line);
             }
 
-            var values = Env.EntGet(objectId);
-
-            for (var i = 1; i < 100; i++)
+            var values = Array.Empty<TypedValue>();
+            for (var i = 0; i < ReadCount; i++)
             {
                 values = Env.EntGet(objectId);
                 if (values.Length == 0)
@@ -45,17 +48,31 @@ public static class TestEntGet
             }
 
             AssertNullObjectIdRejected();
-            Env.Printl($"EntGet passed for {dxfName} ({handle}).");
+            successMessage = $"EntGet passed for {dxfName} ({handle}).";
+        }
+        catch (Exception exception)
+        {
+            testFailure = exception;
+            throw;
         }
         finally
         {
-            if (objectId.IsOk())
+            try
             {
-                using var tr = new DBTrans();
-                var entity = tr.GetObject<Entity>(objectId, OpenMode.ForWrite);
-                entity?.Erase();
+                if (objectId.IsOk())
+                {
+                    using var tr = new DBTrans();
+                    var entity = tr.GetObject<Entity>(objectId, OpenMode.ForWrite);
+                    entity?.Erase();
+                }
+            }
+            catch (Exception cleanupException) when (testFailure is not null)
+            {
+                testFailure.Data["CleanupException"] = cleanupException;
             }
         }
+
+        Env.Printl(successMessage);
     }
 
     private static void AssertNullObjectIdRejected()


### PR DESCRIPTION
## 背景

真实 ZWCAD 2022 Host 验收发现，#30/#31 中的 `EntGet/EntMod/EntUpd` P/Invoke 使用了 `ZWCAD.lib` 向 C++ 链接器暴露的修饰符号，但这些字符串并不是已安装 `ZWCAD.exe` 的实际 PE 导出名。`Test_EntMod` 因此在第一次调用 `Env.EntGet` 时抛出 `EntryPointNotFoundException`。

## 修改

- ZWCAD 分支改为绑定真实导出的 `zcdbEntGet`、`zcdbEntMod`、`zcdbEntUpd`。
- 保持 x64 `zds_name` 布局、参数签名、`resbuf` 所有权和 `RTNORM` 语义不变。
- 将 `Test_EntGet` 改为自包含命令：自动创建临时 Line，重复读取 100 次，验证 DXF 类型、Handle 和空 ObjectId 参数检查，并在 `finally` 中删除临时实体。
- AutoCAD P/Invoke 分支不变。

## 根因证据

ZWCAD 2022 `22.20.301.8730` x64 的实际 `ZWCAD.exe` 导出表包含：

```text
zcdbEntGet
zcdbEntMod
zcdbEntUpd
```

不包含原代码使用的三个修饰名。ZRX2022/ZRX2025 头文件均声明这三个 API；IFoxCAD v0.9 上游实现同样绑定未修饰入口名。

## 验证

- `git diff --check` 通过。
- AutoCAD 2019 测试项目 Debug/Release 构建通过。
- AutoCAD 2025 测试项目 Debug/Release 构建通过，0 警告、0 错误。
- ZWCAD 2022 测试项目 Debug/Release 构建通过。
- ZWCAD 2025 测试项目 Debug/Release 构建通过。
- ZWCAD 2022 专业版 x64 `22.20.301.8730` 真实 Host：

```text
EntGet passed for LINE (231).
EntMod/EntUpd passed for 232.
```

测试使用启动时的新建图，脚本以放弃修改方式退出，没有保存测试图纸。CAD 日志：`Drawing1_ZL28457A6D.log`。

## 验收边界

ZWCAD 2025 未安装，当前只有编译和 SDK 头文件证据，不能视为 ZWCAD 2025 Host 通过；对应门槛继续保留在 #36。

Fixes #37
Refs #36
