### PR TITLE
fix: restore WorkingDatabase after DBTrans task

### DIFF
--- a/src/CADShared/Runtime/DBTrans.cs
+++ b/src/CADShared/Runtime/DBTrans.cs
@@ -534,6 +534,7 @@ public sealed class DBTrans : IDisposable
     ///      在 参照绑定/深度克隆 的底层共用此函数导致<br/>
     /// 0x02 后台是利用前台当前数据库进行处理的<br/>
     /// 0x03 跨进程通讯暂无测试(可能存在bug)<br/>
+    /// 0x04 委托正常返回或抛出异常时都会恢复进入前的 WorkingDatabase<br/>
     /// </remarks>
     /// <param name="action">委托</param>
     /// <param name="handlingDBTextDeviation">开启单行文字偏移处理</param>
@@ -562,10 +563,16 @@ public sealed class DBTrans : IDisposable
         // 处理单行文字偏移
         // 前台绑定参照的时候不能用它,否则抛出异常:eWasErased
         // 所以本函数自动识别前后台做处理
-        var dbBak = doc.Database;
-        HostApplicationServices.WorkingDatabase = Database;
-        action.Invoke();
-        HostApplicationServices.WorkingDatabase = dbBak;
+        var previousWorkingDatabase = HostApplicationServices.WorkingDatabase;
+        try
+        {
+            HostApplicationServices.WorkingDatabase = Database;
+            action.Invoke();
+        }
+        finally
+        {
+            HostApplicationServices.WorkingDatabase = previousWorkingDatabase;
+        }
     }
 
     #endregion

--- a/tests/TestShared/TestDBTransTask.cs
+++ b/tests/TestShared/TestDBTransTask.cs
@@ -1,0 +1,95 @@
+namespace Test;
+
+/// <summary>
+/// CAD-host commands; build coverage does not execute these methods.
+/// </summary>
+public static class TestDBTransTask
+{
+    [CommandMethod(nameof(Test_DBTransTaskRestoresWorkingDatabase))]
+    public static void Test_DBTransTaskRestoresWorkingDatabase()
+    {
+        var originalWorkingDatabase = HostApplicationServices.WorkingDatabase;
+        using var tr = CreateBackgroundTransaction();
+        var actionUsedBackgroundDatabase = false;
+        var restoredOriginalDatabase = false;
+
+        try
+        {
+            tr.Task(() => {
+                actionUsedBackgroundDatabase = IsCurrentWorkingDatabase(tr.Database);
+            });
+            restoredOriginalDatabase = IsCurrentWorkingDatabase(originalWorkingDatabase);
+        }
+        finally
+        {
+            HostApplicationServices.WorkingDatabase = originalWorkingDatabase;
+        }
+
+        if (!actionUsedBackgroundDatabase)
+            throw new InvalidOperationException("DBTrans.Task did not activate the background database.");
+        if (!restoredOriginalDatabase)
+            throw new InvalidOperationException("DBTrans.Task did not restore WorkingDatabase.");
+
+        Env.Printl("DBTrans Task normal path restored WorkingDatabase.");
+    }
+
+    [CommandMethod(nameof(Test_DBTransTaskRestoresWorkingDatabaseAfterException))]
+    public static void Test_DBTransTaskRestoresWorkingDatabaseAfterException()
+    {
+        var originalWorkingDatabase = HostApplicationServices.WorkingDatabase;
+        using var tr = CreateBackgroundTransaction();
+        var expectedException = new ExpectedTaskException();
+        var actionUsedBackgroundDatabase = false;
+        var expectedExceptionPropagated = false;
+        var restoredOriginalDatabase = false;
+
+        try
+        {
+            try
+            {
+                tr.Task(() => {
+                    actionUsedBackgroundDatabase = IsCurrentWorkingDatabase(tr.Database);
+                    throw expectedException;
+                });
+            }
+            catch (ExpectedTaskException exception) when (ReferenceEquals(exception, expectedException))
+            {
+                expectedExceptionPropagated = true;
+            }
+
+            restoredOriginalDatabase = IsCurrentWorkingDatabase(originalWorkingDatabase);
+        }
+        finally
+        {
+            HostApplicationServices.WorkingDatabase = originalWorkingDatabase;
+        }
+
+        if (!actionUsedBackgroundDatabase)
+            throw new InvalidOperationException("DBTrans.Task did not activate the background database.");
+        if (!expectedExceptionPropagated)
+            throw new InvalidOperationException("DBTrans.Task did not propagate the original exception.");
+        if (!restoredOriginalDatabase)
+            throw new InvalidOperationException("DBTrans.Task did not restore WorkingDatabase after an exception.");
+
+        Env.Printl("DBTrans Task exception path restored WorkingDatabase.");
+    }
+
+    private static DBTrans CreateBackgroundTransaction()
+    {
+        var fileName = Path.Combine(
+            Path.GetTempPath(),
+            $"FsFoxCad-DBTransTask-{Guid.NewGuid():N}.dwg");
+        return new DBTrans(fileName, commit: false);
+    }
+
+    private static bool IsCurrentWorkingDatabase(Database expected)
+    {
+        var current = HostApplicationServices.WorkingDatabase;
+        return ReferenceEquals(current, expected) ||
+               current.UnmanagedObject == expected.UnmanagedObject;
+    }
+
+    private sealed class ExpectedTaskException : Exception
+    {
+    }
+}

--- a/tests/TestShared/TestShared.projitems
+++ b/tests/TestShared/TestShared.projitems
@@ -19,6 +19,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)TestCurve.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestDBobject.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestDBTrans.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TestDBTransTask.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestDwgFilerEx.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestDwgMark.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestEditor.cs" />


### PR DESCRIPTION
## 问题

`DBTrans.Task` 为后台 Database 临时切换 `HostApplicationServices.WorkingDatabase`，但原实现只在委托正常返回后恢复。委托抛异常时，进程级 WorkingDatabase 会遗留为后台数据库。

原实现还把恢复目标假定为活动 Document 的 Database；嵌套或调用前已切换数据库时，这不一定是进入 `Task` 前的真实值。

## 修改

- 进入后台处理前保存实际的 `HostApplicationServices.WorkingDatabase`。
- 使用 `try/finally`，在正常和异常路径恢复原值。
- 不捕获或替换委托异常，保留原异常传播。
- 增加两个 TestShared 宿主命令，分别覆盖正常和异常路径。
- 测试命令自身带防御性恢复，即使回归失败也不会故意把 CAD 会话留在临时后台数据库。
- 补充 XML 备注，明确恢复契约。

## 编译验证

以下 Release 测试项目均为 `0 warning / 0 error`：

- `TestAcad2019.csproj`
- `TestAcad2025.csproj`
- `TestZcad2022.csproj`
- `TestZcad2025.csproj`

同时通过 `git diff --check`。

## 宿主验证边界

本次没有启动 AutoCAD 或 ZWCAD，也没有执行新增的 `CommandMethod`。因此仅确认四目标编译兼容和静态异常恢复逻辑，真实 WorkingDatabase/后台 Database 行为仍标记为 `Not run`。

新增命令：

- `Test_DBTransTaskRestoresWorkingDatabase`
- `Test_DBTransTaskRestoresWorkingDatabaseAfterException`

## 不处理

- 不修改 `_dBTrans` 静态事务栈。
- 不修改终结器或 Dispose 清理顺序。
- 不修改非 LIFO Dispose 行为。
- 不改变公共签名及默认 `commit: true` 语义。
- 不依赖或合并 Draft PR #41。

Fixes #44
Refs #43 #40 #25