### PR TITLE
Refactor: split UI and Editor helper types

### DIFF
--- a/Build/CADSharedModuleBaseline.json
+++ b/Build/CADSharedModuleBaseline.json
@@ -1,17 +1,17 @@
 {
   "schemaVersion": 1,
   "normalizedSourceHash": "sha256-utf8-lf",
-  "expectedCompileCount": 119,
+  "expectedCompileCount": 121,
   "moduleCounts": {
     "Foundation": 11,
     "Platform.Windows": 5,
     "Cad.Interop": 3,
     "Cad.Geometry": 16,
     "Cad.Database": 38,
-    "Cad.Editor": 17,
+    "Cad.Editor": 18,
     "Cad.Application": 8,
     "Cad.Runtime": 14,
-    "Cad.UI": 7
+    "Cad.UI": 8
   },
   "items": [
     {
@@ -590,7 +590,15 @@
       "module": "Cad.UI",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "63abbbb854a3e41e9e3153339700834ccd8b7d1b1939b6ec00c4eacd739fd50f"
+      "sourceSha256": "1dc8ba8f68eba3368834c4d4495827f9561d1e85b357edbe105bdea3b30817ee"
+    },
+    {
+      "order": "0521",
+      "fileName": "PaneMarginType.cs",
+      "module": "Cad.UI",
+      "boundaryDebt": [],
+      "boundaryFindings": [],
+      "sourceSha256": "73f324c135dee848c565046161fea331f19d15d6bcd870ee9f0876fab044d2f6"
     },
     {
       "order": "0530",
@@ -598,7 +606,15 @@
       "module": "Cad.Editor",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "e4baaf3530bd764223fee16db96414eee63e89bfec84375a945d6c30977c4419"
+      "sourceSha256": "c21174af6d84db69ccaf5bbe655872f7985b50b98e05472b8f33a6f876d56c06"
+    },
+    {
+      "order": "0531",
+      "fileName": "KeywordException.cs",
+      "module": "Cad.Editor",
+      "boundaryDebt": [],
+      "boundaryFindings": [],
+      "sourceSha256": "4ec1b840941926c4761a24241ff83a21c63ba9e6f442670892424178346689ca"
     },
     {
       "order": "0540",

--- a/Build/Verify-CADSharedModuleMap.ps1
+++ b/Build/Verify-CADSharedModuleMap.ps1
@@ -28,17 +28,17 @@ $BaselinePath = [IO.Path]::GetFullPath($BaselinePath)
 $sourceRoot = [IO.Path]::GetFullPath((Split-Path -Parent $ProjectItemsPath))
 $sourceRootPrefix = $sourceRoot.TrimEnd([IO.Path]::DirectorySeparatorChar) + [IO.Path]::DirectorySeparatorChar
 
-$expectedCompileCount = 119
+$expectedCompileCount = 121
 $expectedModuleCounts = [ordered]@{
     'Foundation'       = 11
     'Platform.Windows' = 5
     'Cad.Interop'      = 3
     'Cad.Geometry'     = 16
     'Cad.Database'     = 38
-    'Cad.Editor'       = 17
+    'Cad.Editor'       = 18
     'Cad.Application'  = 8
     'Cad.Runtime'      = 14
-    'Cad.UI'           = 7
+    'Cad.UI'           = 8
 }
 $allowedModules = @($expectedModuleCounts.Keys)
 $allowedDebtIds = @(1..24 | ForEach-Object { 'BD-{0:D2}' -f $_ })

--- a/docs/关于IFoxCAD的架构说明.md
+++ b/docs/关于IFoxCAD的架构说明.md
@@ -195,7 +195,7 @@ tests/
   TestZcad20xx/              ZWCAD 宿主测试入口
 ```
 
-`CADShared.projitems` 当前显式列出 119 个共享编译项，并通过 `FsFoxModule` 和 `FsFoxOrder` 记录九个逻辑模块及稳定编译顺序。目录只表达源码所有权，不改变公共命名空间，也不意味着九个独立 DLL；完整映射和已知边界债务见[单程序集逻辑模块化执行计划](logical-modularization-plan.md)。
+`CADShared.projitems` 当前显式列出 121 个共享编译项，并通过 `FsFoxModule` 和 `FsFoxOrder` 记录九个逻辑模块及稳定编译顺序。目录只表达源码所有权，不改变公共命名空间，也不意味着九个独立 DLL；完整映射和已知边界债务见[单程序集逻辑模块化执行计划](logical-modularization-plan.md)。
 
 版本项目是 SDK/API 代际边界，不要求每个产品年度都有一个项目。只有厂商 API、目标框架或二进制兼容性发生变化时才应新增项目；可兼容年度优先复用已有产物，并用兼容性文档记录依据和宿主验收状态。
 

--- a/src/CADShared/CADShared.projitems
+++ b/src/CADShared/CADShared.projitems
@@ -279,9 +279,17 @@
       <FsFoxModule>Cad.UI</FsFoxModule>
       <FsFoxOrder>0520</FsFoxOrder>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Cad\UI\StatusBar\PaneMarginType.cs">
+      <FsFoxModule>Cad.UI</FsFoxModule>
+      <FsFoxOrder>0521</FsFoxOrder>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Cad\Editor\PromptOptionsEx.cs">
       <FsFoxModule>Cad.Editor</FsFoxModule>
       <FsFoxOrder>0530</FsFoxOrder>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Cad\Editor\KeywordException.cs">
+      <FsFoxModule>Cad.Editor</FsFoxModule>
+      <FsFoxOrder>0531</FsFoxOrder>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Foundation\RandomEx.cs">
       <FsFoxModule>Foundation</FsFoxModule>

--- a/src/CADShared/Cad/Editor/KeywordException.cs
+++ b/src/CADShared/Cad/Editor/KeywordException.cs
@@ -1,0 +1,22 @@
+// ReSharper disable UnusedAutoPropertyAccessor.Global
+namespace Fs.Fox.Cad;
+
+/// <summary>
+/// 关键字错误
+/// </summary>
+public class KeywordException : Exception
+{
+    /// <summary>
+    /// 关键字错误
+    /// </summary>
+    /// <param name="input">关键字</param>
+    public KeywordException(string input)
+    {
+        Input = input;
+    }
+
+    /// <summary>
+    /// 关键字
+    /// </summary>
+    public string Input { get; }
+}

--- a/src/CADShared/Cad/Editor/PromptOptionsEx.cs
+++ b/src/CADShared/Cad/Editor/PromptOptionsEx.cs
@@ -1,4 +1,3 @@
-// ReSharper disable UnusedAutoPropertyAccessor.Global
 namespace Fs.Fox.Cad;
 
 /// <summary>
@@ -66,24 +65,4 @@ public static class PromptOptionsEx
             return;
         throw new KeywordException(e.Input.ToUpper());
     }
-}
-
-/// <summary>
-/// 关键字错误
-/// </summary>
-public class KeywordException : Exception
-{
-    /// <summary>
-    /// 关键字错误
-    /// </summary>
-    /// <param name="input">关键字</param>
-    public KeywordException(string input)
-    {
-        Input = input;
-    }
-
-    /// <summary>
-    /// 关键字
-    /// </summary>
-    public string Input { get; }
 }

--- a/src/CADShared/Cad/UI/StatusBar/PaneEx.cs
+++ b/src/CADShared/Cad/UI/StatusBar/PaneEx.cs
@@ -154,22 +154,3 @@ public static class PaneEx
         CadApp.StatusBar.Update();
     }
 }
-
-/// <summary>
-/// 托盘边距类型
-/// </summary>
-public enum PaneMarginType : byte
-{
-    /// <summary>
-    /// 无
-    /// </summary>
-    NONE,
-    /// <summary>
-    /// 小边距
-    /// </summary>
-    SMALL,
-    /// <summary>
-    /// 大边距
-    /// </summary>
-    LARGE
-}

--- a/src/CADShared/Cad/UI/StatusBar/PaneMarginType.cs
+++ b/src/CADShared/Cad/UI/StatusBar/PaneMarginType.cs
@@ -1,0 +1,20 @@
+namespace Fs.Fox.Cad;
+
+/// <summary>
+/// 托盘边距类型
+/// </summary>
+public enum PaneMarginType : byte
+{
+    /// <summary>
+    /// 无
+    /// </summary>
+    NONE,
+    /// <summary>
+    /// 小边距
+    /// </summary>
+    SMALL,
+    /// <summary>
+    /// 大边距
+    /// </summary>
+    LARGE
+}


### PR DESCRIPTION
## 变更

- 从 `PaneEx.cs` 抽出 `PaneMarginType.cs`。
- 从 `PromptOptionsEx.cs` 抽出 `KeywordException.cs`，并让相关 ReSharper 文件级抑制随类型移动。
- 按原声明顺序设置 `0520/0521` 与 `0530/0531` 编译节点。
- 模块基线更新为 121 项、`Cad.UI = 8`、`Cad.Editor = 18`；同步维护者架构说明中的当前数量。

四个公开类型的命名空间、类型名、可见性、成员、枚举值、字段初始化、XML 注释和行为均未修改。StatusBar/Pane 操作、Prompt 关键字处理与异常抛出逻辑不在本 PR 的行为变更范围；公共兼容性基线未更新。

## 验证

- `PaneEx`、`PaneMarginType`、`PromptOptionsEx`、`KeywordException` 的声明主体与拆分前逐字一致；ReSharper 抑制已验证随 `KeywordException` 移动。
- 模块基线审计：117 个非拆分节点的路径、模块、顺序、债务、边界发现和源哈希逐项不变。
- `Verify-CADSharedModuleMap.ps1`：121 项、31 个债务文件、16 个边界发现，通过。
- AC_2019、AC_2025、ZW_2022、ZW_2025：Debug/Release 隔离 `Restore;Rebuild` 全部通过。
- schema v3 `Verify-CADSharedCompatibility.ps1`：四目标通过，未更新 `Build/CADSharedCompatibilityBaseline.json`；仅有既有 NU5110/NU5111 打包警告。
- 工具链：MSBuild `18.8.2.30814`、.NET SDK `10.0.302`。
- detached worktree 重建长期分支基线 `a1616fa` 后，四目标完整 TypeDef 名称序列逐项一致：

| 目标 | 数量 | 基线/候选 SHA-256 |
| --- | ---: | --- |
| AC_2019 | 401 | `4439e1c3e1f402627ab965efd861f0b00937dcb635301d23b951a0e32bfb94ce` |
| AC_2025 | 360 | `b36f37d14881529b28c7dff2e2f0036d7ef728310cb5797f100d015e075ac9ff` |
| ZW_2022 | 398 | `2801c87e86c826e4f71dd777f020b51087e61d3c79382019114ef767f9934a5a` |
| ZW_2025 | 396 | `b3334f3c8ae0dabacf3a1c5b05c6a7db14075c03104b6ac3d246cc3e194045f8` |

CAD 宿主：`Not run`。

Refs #25
Refs #64
Refs #74