### PR TITLE
Refactor: split Jig draw delegate

### DIFF
--- a/Build/CADSharedModuleBaseline.json
+++ b/Build/CADSharedModuleBaseline.json
@@ -1,14 +1,14 @@
 {
   "schemaVersion": 1,
   "normalizedSourceHash": "sha256-utf8-lf",
-  "expectedCompileCount": 121,
+  "expectedCompileCount": 122,
   "moduleCounts": {
     "Foundation": 11,
     "Platform.Windows": 5,
     "Cad.Interop": 3,
     "Cad.Geometry": 16,
     "Cad.Database": 38,
-    "Cad.Editor": 18,
+    "Cad.Editor": 19,
     "Cad.Application": 8,
     "Cad.Runtime": 14,
     "Cad.UI": 8
@@ -562,11 +562,19 @@
     },
     {
       "order": "0490",
+      "fileName": "WorldDrawEvent.cs",
+      "module": "Cad.Editor",
+      "boundaryDebt": [],
+      "boundaryFindings": [],
+      "sourceSha256": "1cf78148ef0d76154ad6b43a144f134e0443a122845b1ca20e220c808bbf9ec5"
+    },
+    {
+      "order": "0491",
       "fileName": "JigEx.cs",
       "module": "Cad.Editor",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "a13d5ab38ec215cc6dace235103fb8b1bb66e18655886ea60153de269fa689af"
+      "sourceSha256": "2e0cf112fc2c65d163e59627adb06885813558922571bf9542473ed3982aaabd"
     },
     {
       "order": "0500",

--- a/Build/Verify-CADSharedModuleMap.ps1
+++ b/Build/Verify-CADSharedModuleMap.ps1
@@ -28,14 +28,14 @@ $BaselinePath = [IO.Path]::GetFullPath($BaselinePath)
 $sourceRoot = [IO.Path]::GetFullPath((Split-Path -Parent $ProjectItemsPath))
 $sourceRootPrefix = $sourceRoot.TrimEnd([IO.Path]::DirectorySeparatorChar) + [IO.Path]::DirectorySeparatorChar
 
-$expectedCompileCount = 121
+$expectedCompileCount = 122
 $expectedModuleCounts = [ordered]@{
     'Foundation'       = 11
     'Platform.Windows' = 5
     'Cad.Interop'      = 3
     'Cad.Geometry'     = 16
     'Cad.Database'     = 38
-    'Cad.Editor'       = 18
+    'Cad.Editor'       = 19
     'Cad.Application'  = 8
     'Cad.Runtime'      = 14
     'Cad.UI'           = 8

--- a/docs/关于IFoxCAD的架构说明.md
+++ b/docs/关于IFoxCAD的架构说明.md
@@ -195,7 +195,7 @@ tests/
   TestZcad20xx/              ZWCAD 宿主测试入口
 ```
 
-`CADShared.projitems` 当前显式列出 121 个共享编译项，并通过 `FsFoxModule` 和 `FsFoxOrder` 记录九个逻辑模块及稳定编译顺序。目录只表达源码所有权，不改变公共命名空间，也不意味着九个独立 DLL；完整映射和已知边界债务见[单程序集逻辑模块化执行计划](logical-modularization-plan.md)。
+`CADShared.projitems` 当前显式列出 122 个共享编译项，并通过 `FsFoxModule` 和 `FsFoxOrder` 记录九个逻辑模块及稳定编译顺序。目录只表达源码所有权，不改变公共命名空间，也不意味着九个独立 DLL；完整映射和已知边界债务见[单程序集逻辑模块化执行计划](logical-modularization-plan.md)。
 
 版本项目是 SDK/API 代际边界，不要求每个产品年度都有一个项目。只有厂商 API、目标框架或二进制兼容性发生变化时才应新增项目；可兼容年度优先复用已有产物，并用兼容性文档记录依据和宿主验收状态。
 

--- a/src/CADShared/CADShared.projitems
+++ b/src/CADShared/CADShared.projitems
@@ -263,9 +263,13 @@
       <FsFoxModule>Cad.UI</FsFoxModule>
       <FsFoxOrder>0480</FsFoxOrder>
     </Compile>
-    <Compile Include="$(MSBuildThisFileDirectory)Cad\Editor\Jig\JigEx.cs">
+    <Compile Include="$(MSBuildThisFileDirectory)Cad\Editor\Jig\WorldDrawEvent.cs">
       <FsFoxModule>Cad.Editor</FsFoxModule>
       <FsFoxOrder>0490</FsFoxOrder>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Cad\Editor\Jig\JigEx.cs">
+      <FsFoxModule>Cad.Editor</FsFoxModule>
+      <FsFoxOrder>0491</FsFoxOrder>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Cad\Editor\Jig\JigExTransient.cs">
       <FsFoxModule>Cad.Editor</FsFoxModule>

--- a/src/CADShared/Cad/Editor/Jig/JigEx.cs
+++ b/src/CADShared/Cad/Editor/Jig/JigEx.cs
@@ -15,12 +15,6 @@ namespace Fs.Fox.Cad;
  *  博客: https://www.cnblogs.com/JJBox/p/15650770.html
  */
 /// <summary>
-/// 重绘事件
-/// </summary>
-/// <param name="draw"></param>
-public delegate void WorldDrawEvent(WorldDraw draw);
-
-/// <summary>
 /// jig扩展类
 /// </summary>
 // ReSharper disable once ClassWithVirtualMembersNeverInherited.Global

--- a/src/CADShared/Cad/Editor/Jig/WorldDrawEvent.cs
+++ b/src/CADShared/Cad/Editor/Jig/WorldDrawEvent.cs
@@ -1,0 +1,7 @@
+namespace Fs.Fox.Cad;
+
+/// <summary>
+/// 重绘事件
+/// </summary>
+/// <param name="draw"></param>
+public delegate void WorldDrawEvent(WorldDraw draw);


### PR DESCRIPTION
## 变更

- 从 `JigEx.cs` 抽出 `WorldDrawEvent.cs`。
- 按原声明顺序设置 `WorldDrawEvent 0490`、`JigEx 0491` 编译节点。
- Jig 历史说明、net48/ZWCAD alias、`#if ZWCAD` 与 `#if false` 均保留在 `JigEx.cs`。
- 模块基线更新为 122 项、`Cad.Editor = 19`；同步维护者架构说明中的当前数量。

`WorldDrawEvent` 与 `JigEx` 的命名空间、类型名、可见性、签名、成员、XML 注释和行为均未修改。Jig 采样、绘制、条件编译、图元生命周期与 Dispose/终结器逻辑不在本 PR 的行为变更范围；公共兼容性基线未更新。

## 验证

- `WorldDrawEvent` 声明主体逐字一致；`JigEx` 文件头、历史说明、class 主体和条件编译逐字一致。
- 模块基线审计：120 个非拆分节点的路径、模块、顺序、债务、边界发现和源哈希逐项不变。
- `Verify-CADSharedModuleMap.ps1`：122 项、31 个债务文件、16 个边界发现，通过。
- AC_2019、AC_2025、ZW_2022、ZW_2025：Debug/Release 隔离 `Restore;Rebuild` 全部通过。
- schema v3 `Verify-CADSharedCompatibility.ps1`：四目标通过，未更新 `Build/CADSharedCompatibilityBaseline.json`；仅有既有 NU5110/NU5111 打包警告。
- 工具链：MSBuild `18.8.2.30814`、.NET SDK `10.0.302`。
- detached worktree 重建长期分支基线 `666ef5c` 后，四目标完整 TypeDef 名称序列逐项一致：

| 目标 | 数量 | 基线/候选 SHA-256 |
| --- | ---: | --- |
| AC_2019 | 401 | `4439e1c3e1f402627ab965efd861f0b00937dcb635301d23b951a0e32bfb94ce` |
| AC_2025 | 360 | `b36f37d14881529b28c7dff2e2f0036d7ef728310cb5797f100d015e075ac9ff` |
| ZW_2022 | 398 | `2801c87e86c826e4f71dd777f020b51087e61d3c79382019114ef767f9934a5a` |
| ZW_2025 | 396 | `b3334f3c8ae0dabacf3a1c5b05c6a7db14075c03104b6ac3d246cc3e194045f8` |

CAD 宿主：`Not run`。

Refs #25
Refs #64
Refs #76