### PR TITLE
Refactor: split SwitchDatabase type

### DIFF
--- a/Build/CADSharedModuleBaseline.json
+++ b/Build/CADSharedModuleBaseline.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 1,
   "normalizedSourceHash": "sha256-utf8-lf",
-  "expectedCompileCount": 125,
+  "expectedCompileCount": 126,
   "moduleCounts": {
     "Foundation": 11,
     "Platform.Windows": 5,
     "Cad.Interop": 3,
     "Cad.Geometry": 16,
-    "Cad.Database": 41,
+    "Cad.Database": 42,
     "Cad.Editor": 19,
     "Cad.Application": 8,
     "Cad.Runtime": 14,
@@ -257,10 +257,25 @@
         },
         {
           "rule": "ApplicationServices",
-          "count": 5
+          "count": 2
         }
       ],
-      "sourceSha256": "8615c232ab929ec2172035c82af01241c41c0d4da77cf1ea182cbece21231e3e"
+      "sourceSha256": "6cbed08713176af5259e5cda20719d1b8b9793b392771c0d85f147695ab2f6d2"
+    },
+    {
+      "order": "0241",
+      "fileName": "SwitchDatabase.cs",
+      "module": "Cad.Database",
+      "boundaryDebt": [
+        "BD-02"
+      ],
+      "boundaryFindings": [
+        {
+          "rule": "ApplicationServices",
+          "count": 3
+        }
+      ],
+      "sourceSha256": "49770ba4e8769aa8b38232c2750b4ec3d5e9bd6465261a65d5e8971e18900720"
     },
     {
       "order": "0250",

--- a/Build/Verify-CADSharedModuleMap.ps1
+++ b/Build/Verify-CADSharedModuleMap.ps1
@@ -28,13 +28,13 @@ $BaselinePath = [IO.Path]::GetFullPath($BaselinePath)
 $sourceRoot = [IO.Path]::GetFullPath((Split-Path -Parent $ProjectItemsPath))
 $sourceRootPrefix = $sourceRoot.TrimEnd([IO.Path]::DirectorySeparatorChar) + [IO.Path]::DirectorySeparatorChar
 
-$expectedCompileCount = 125
+$expectedCompileCount = 126
 $expectedModuleCounts = [ordered]@{
     'Foundation'       = 11
     'Platform.Windows' = 5
     'Cad.Interop'      = 3
     'Cad.Geometry'     = 16
-    'Cad.Database'     = 41
+    'Cad.Database'     = 42
     'Cad.Editor'       = 19
     'Cad.Application'  = 8
     'Cad.Runtime'      = 14

--- a/docs/关于IFoxCAD的架构说明.md
+++ b/docs/关于IFoxCAD的架构说明.md
@@ -195,7 +195,7 @@ tests/
   TestZcad20xx/              ZWCAD 宿主测试入口
 ```
 
-`CADShared.projitems` 当前显式列出 125 个共享编译项，并通过 `FsFoxModule` 和 `FsFoxOrder` 记录九个逻辑模块及稳定编译顺序。目录只表达源码所有权，不改变公共命名空间，也不意味着九个独立 DLL；完整映射和已知边界债务见[单程序集逻辑模块化执行计划](logical-modularization-plan.md)。
+`CADShared.projitems` 当前显式列出 126 个共享编译项，并通过 `FsFoxModule` 和 `FsFoxOrder` 记录九个逻辑模块及稳定编译顺序。目录只表达源码所有权，不改变公共命名空间，也不意味着九个独立 DLL；完整映射和已知边界债务见[单程序集逻辑模块化执行计划](logical-modularization-plan.md)。
 
 版本项目是 SDK/API 代际边界，不要求每个产品年度都有一个项目。只有厂商 API、目标框架或二进制兼容性发生变化时才应新增项目；可兼容年度优先复用已有产物，并用兼容性文档记录依据和宿主验收状态。
 

--- a/src/CADShared/CADShared.projitems
+++ b/src/CADShared/CADShared.projitems
@@ -126,6 +126,11 @@
       <FsFoxOrder>0240</FsFoxOrder>
       <FsFoxBoundaryDebt>BD-02</FsFoxBoundaryDebt>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Cad\Database\SwitchDatabase.cs">
+      <FsFoxModule>Cad.Database</FsFoxModule>
+      <FsFoxOrder>0241</FsFoxOrder>
+      <FsFoxBoundaryDebt>BD-02</FsFoxBoundaryDebt>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Cad\Database\Dictionaries\DBDictionaryEx.cs">
       <FsFoxModule>Cad.Database</FsFoxModule>
       <FsFoxOrder>0250</FsFoxOrder>

--- a/src/CADShared/Cad/Database/DatabaseEx.cs
+++ b/src/CADShared/Cad/Database/DatabaseEx.cs
@@ -183,30 +183,3 @@ public static class DatabaseEx
         return (true, file);
     }
 }
-
-/// <summary>
-/// 自动切换活动数据库
-/// </summary>
-public class SwitchDatabase : IDisposable
-{
-    private readonly Database _db;
-
-    /// <summary>
-    /// 切换活动数据库
-    /// </summary>
-    /// <param name="database">当前数据库</param>
-    public SwitchDatabase(Database database)
-    {
-        _db = HostApplicationServices.WorkingDatabase;
-        HostApplicationServices.WorkingDatabase = database;
-    }
-
-    /// <summary>
-    /// 恢复活动数据库为默认
-    /// </summary>
-    public void Dispose()
-    {
-        HostApplicationServices.WorkingDatabase = _db;
-        GC.SuppressFinalize(this);
-    }
-}

--- a/src/CADShared/Cad/Database/SwitchDatabase.cs
+++ b/src/CADShared/Cad/Database/SwitchDatabase.cs
@@ -1,0 +1,28 @@
+namespace Fs.Fox.Cad;
+
+/// <summary>
+/// 自动切换活动数据库
+/// </summary>
+public class SwitchDatabase : IDisposable
+{
+    private readonly Database _db;
+
+    /// <summary>
+    /// 切换活动数据库
+    /// </summary>
+    /// <param name="database">当前数据库</param>
+    public SwitchDatabase(Database database)
+    {
+        _db = HostApplicationServices.WorkingDatabase;
+        HostApplicationServices.WorkingDatabase = database;
+    }
+
+    /// <summary>
+    /// 恢复活动数据库为默认
+    /// </summary>
+    public void Dispose()
+    {
+        HostApplicationServices.WorkingDatabase = _db;
+        GC.SuppressFinalize(this);
+    }
+}


### PR DESCRIPTION
## 变更

- 从 `DatabaseEx.cs` 抽出 `SwitchDatabase.cs`，原文件只保留同名扩展类。
- 按原声明顺序设置 `DatabaseEx 0240`、`SwitchDatabase 0241` 编译节点。
- 模块基线更新为 126 项、`Cad.Database = 42`；同步维护者架构说明中的当前数量。
- 两个编译项暂时共同保留原有 `BD-02`：`DatabaseEx` 持有 2 次 `DesktopUi` 和 2 次 `ApplicationServices` 命中，`SwitchDatabase` 持有 3 次 `ApplicationServices` 命中。

两个类型的命名空间、类型名、可见性、成员、XML 注释和行为均未修改。保存/提示逻辑与 `WorkingDatabase` 的切换、嵌套、Dispose、异常语义不在本 PR 的行为变更范围；公共兼容性基线未更新。

## 验证

- `DatabaseEx` 与 `SwitchDatabase` 声明正文逐字一致；124 个非拆分编译节点逐项不变。
- 边界命中总量保持 `DesktopUi = 2`、`ApplicationServices = 5`；债务文件/发现条目因一个编译项拆为两个而变为 32/17，没有新增依赖命中。
- `Verify-CADSharedModuleMap.ps1`：126 项、32 个债务文件、17 个边界发现，通过。
- AC_2019、AC_2025、ZW_2022、ZW_2025：Debug/Release `Restore;Rebuild` 全部通过。
- schema v3 `Verify-CADSharedCompatibility.ps1`：四目标通过，未更新 `Build/CADSharedCompatibilityBaseline.json`；仅有既有 NU5110/NU5111 打包警告。
- 工具链：MSBuild `18.6.11.33009`、.NET SDK `10.0.302`。
- detached worktree 重建长期分支基线 `9fe8ec7` 后，四目标完整 TypeDef 名称序列逐项一致：

| 目标 | 数量 | 同轮基线/候选 SHA-256 |
| --- | ---: | --- |
| AC_2019 | 401 | `561302bffdb58baa792963a5c3e5b6fad59d3fe94bd310a45792b2b1e21b8b4c` |
| AC_2025 | 360 | `b36f37d14881529b28c7dff2e2f0036d7ef728310cb5797f100d015e075ac9ff` |
| ZW_2022 | 398 | `06538863b1e635f05fe714a479bbe67fccfa02002cafca78eae30d5d7d39a0cc` |
| ZW_2025 | 396 | `b3334f3c8ae0dabacf3a1c5b05c6a7db14075c03104b6ac3d246cc3e194045f8` |

这些哈希仅作为 #64 定义的同工具链、同轮次变更证据，不作为跨构建长期基线。

CAD 宿主：`Not run`。

Refs #25
Refs #46
Refs #64
Refs #80