### PR TITLE
build: automate TypeDef sequence comparison

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v3
 
+      - name: Test TypeDef sequence comparer
+        run: pwsh -NoProfile -File tools/verification/Test-CADSharedTypeDefSequence.ps1
+
       - name: Verify CADShared module map
         run: pwsh -NoProfile -File Build/Verify-CADSharedModuleMap.ps1
 

--- a/tools/verification/Compare-CADSharedTypeDefSequence.ps1
+++ b/tools/verification/Compare-CADSharedTypeDefSequence.ps1
@@ -1,0 +1,254 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$BaselineRoot,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$CandidateRoot
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if ($null -eq ('System.Reflection.Metadata.MetadataReader' -as [type])) {
+    Add-Type -AssemblyName System.Reflection.Metadata
+}
+
+$targets = @(
+    [pscustomobject]@{
+        Name = 'AC_2019'
+        RelativeAssembly = 'Build\AC_2019_Release\Fs.Fox.AutoCad.dll'
+        ExpectedAssemblyName = 'Fs.Fox.AutoCad'
+    },
+    [pscustomobject]@{
+        Name = 'AC_2025'
+        RelativeAssembly = 'Build\AC_2025_Release\Fs.Fox.AutoCad.dll'
+        ExpectedAssemblyName = 'Fs.Fox.AutoCad'
+    },
+    [pscustomobject]@{
+        Name = 'ZW_2022'
+        RelativeAssembly = 'Build\ZW_2022_Release\Fs.Fox.ZwCad.dll'
+        ExpectedAssemblyName = 'Fs.Fox.ZwCad'
+    },
+    [pscustomobject]@{
+        Name = 'ZW_2025'
+        RelativeAssembly = 'Build\ZW_2025_Release\Fs.Fox.ZwCad.dll'
+        ExpectedAssemblyName = 'Fs.Fox.ZwCad'
+    }
+)
+
+function Resolve-ArtifactRoot {
+    param(
+        [string]$Path,
+        [string]$ParameterName
+    )
+
+    if ([IO.Path]::IsPathRooted($Path)) {
+        $fullPath = [IO.Path]::GetFullPath($Path)
+    }
+    else {
+        $fullPath = [IO.Path]::GetFullPath((Join-Path (Get-Location).Path $Path))
+    }
+
+    if (-not [IO.Directory]::Exists($fullPath)) {
+        throw "$ParameterName directory not found: $fullPath"
+    }
+    return $fullPath
+}
+
+function Convert-BytesToHex {
+    param([byte[]]$Bytes)
+
+    if ($null -eq $Bytes -or $Bytes.Length -eq 0) {
+        return ''
+    }
+    return ([Convert]::ToHexString($Bytes)).ToLowerInvariant()
+}
+
+function Get-TextHash {
+    param([string]$Text)
+
+    $bytes = [Text.UTF8Encoding]::new($false).GetBytes($Text)
+    $sha256 = [Security.Cryptography.SHA256]::Create()
+    try {
+        $hashBytes = $sha256.ComputeHash($bytes)
+        return Convert-BytesToHex $hashBytes
+    }
+    finally {
+        $sha256.Dispose()
+    }
+}
+
+function Get-MetadataToken {
+    param([Reflection.Metadata.Handle]$Handle)
+
+    return [Reflection.Metadata.Ecma335.MetadataTokens]::GetToken($Handle)
+}
+
+function Get-TypeDefinitionName {
+    param(
+        [Reflection.Metadata.MetadataReader]$Reader,
+        [Reflection.Metadata.TypeDefinitionHandle]$Handle,
+        [hashtable]$Cache
+    )
+
+    $token = Get-MetadataToken $Handle
+    $cacheKey = '{0:x8}' -f $token
+    if ($Cache.ContainsKey($cacheKey)) {
+        return $Cache[$cacheKey]
+    }
+
+    $definition = $Reader.GetTypeDefinition($Handle)
+    $name = $Reader.GetString($definition.Name)
+    $declaringType = $definition.GetDeclaringType()
+    if (-not $declaringType.IsNil) {
+        $fullName = (Get-TypeDefinitionName $Reader $declaringType $Cache) + '+' + $name
+    }
+    else {
+        $namespace = $Reader.GetString($definition.Namespace)
+        $fullName = if ([string]::IsNullOrEmpty($namespace)) { $name } else { "$namespace.$name" }
+    }
+
+    $Cache[$cacheKey] = $fullName
+    return $fullName
+}
+
+function Get-TypeDefinitionSnapshot {
+    param([string]$AssemblyPath)
+
+    if (-not [IO.File]::Exists($AssemblyPath)) {
+        throw "Assembly not found: $AssemblyPath"
+    }
+
+    $stream = [IO.File]::Open(
+        $AssemblyPath,
+        [IO.FileMode]::Open,
+        [IO.FileAccess]::Read,
+        [IO.FileShare]::Read
+    )
+    try {
+        $peReader = [Reflection.PortableExecutable.PEReader]::new($stream)
+        try {
+            if (-not $peReader.HasMetadata) {
+                throw "Assembly has no managed metadata: $AssemblyPath"
+            }
+
+            $reader = [Reflection.Metadata.PEReaderExtensions]::GetMetadataReader($peReader)
+            if (-not $reader.IsAssembly) {
+                throw "Managed PE does not contain an assembly definition: $AssemblyPath"
+            }
+
+            $assemblyDefinition = $reader.GetAssemblyDefinition()
+            $assemblyName = $reader.GetString($assemblyDefinition.Name)
+            $typeNameCache = @{}
+            $typeNames = [Collections.Generic.List[string]]::new()
+            foreach ($typeHandle in $reader.TypeDefinitions) {
+                $typeNames.Add((Get-TypeDefinitionName $reader $typeHandle $typeNameCache))
+            }
+
+            $sequence = [string]::Join("`n", $typeNames)
+            return [pscustomobject]@{
+                AssemblyName = $assemblyName
+                TypeNames = $typeNames.ToArray()
+                Hash = (Get-TextHash $sequence)
+            }
+        }
+        finally {
+            $peReader.Dispose()
+        }
+    }
+    finally {
+        $stream.Dispose()
+    }
+}
+
+function Get-FirstSequenceDifference {
+    param(
+        [string[]]$BaselineNames,
+        [string[]]$CandidateNames
+    )
+
+    $commonCount = [Math]::Min($BaselineNames.Length, $CandidateNames.Length)
+    for ($index = 0; $index -lt $commonCount; $index++) {
+        if ($BaselineNames[$index] -cne $CandidateNames[$index]) {
+            $row = $index + 1
+            return [pscustomobject]@{
+                Row = $row
+                Token = ('0x{0:x8}' -f (0x02000000 + $row))
+                Baseline = $BaselineNames[$index]
+                Candidate = $CandidateNames[$index]
+            }
+        }
+    }
+
+    if ($BaselineNames.Length -ne $CandidateNames.Length) {
+        $row = $commonCount + 1
+        return [pscustomobject]@{
+            Row = $row
+            Token = ('0x{0:x8}' -f (0x02000000 + $row))
+            Baseline = if ($row -le $BaselineNames.Length) { $BaselineNames[$row - 1] } else { '<end>' }
+            Candidate = if ($row -le $CandidateNames.Length) { $CandidateNames[$row - 1] } else { '<end>' }
+        }
+    }
+
+    return $null
+}
+
+$resolvedBaselineRoot = Resolve-ArtifactRoot $BaselineRoot 'BaselineRoot'
+$resolvedCandidateRoot = Resolve-ArtifactRoot $CandidateRoot 'CandidateRoot'
+$failures = [Collections.Generic.List[string]]::new()
+
+foreach ($target in $targets) {
+    $baselineAssembly = Join-Path $resolvedBaselineRoot $target.RelativeAssembly
+    $candidateAssembly = Join-Path $resolvedCandidateRoot $target.RelativeAssembly
+
+    try {
+        $baseline = Get-TypeDefinitionSnapshot $baselineAssembly
+        $candidate = Get-TypeDefinitionSnapshot $candidateAssembly
+        $targetFailures = [Collections.Generic.List[string]]::new()
+
+        if ($baseline.AssemblyName -cne $target.ExpectedAssemblyName) {
+            $targetFailures.Add(
+                "baseline assembly name '$($baseline.AssemblyName)' does not match '$($target.ExpectedAssemblyName)'"
+            )
+        }
+        if ($candidate.AssemblyName -cne $target.ExpectedAssemblyName) {
+            $targetFailures.Add(
+                "candidate assembly name '$($candidate.AssemblyName)' does not match '$($target.ExpectedAssemblyName)'"
+            )
+        }
+
+        $difference = Get-FirstSequenceDifference $baseline.TypeNames $candidate.TypeNames
+        if ($null -ne $difference) {
+            $targetFailures.Add(
+                "first difference row=$($difference.Row) token=$($difference.Token) " +
+                "baseline='$($difference.Baseline)' candidate='$($difference.Candidate)'"
+            )
+        }
+
+        $status = if ($targetFailures.Count -eq 0) { 'MATCH' } else { 'MISMATCH' }
+        Write-Host (
+            "$($target.Name) $status " +
+            "baselineCount=$($baseline.TypeNames.Length) candidateCount=$($candidate.TypeNames.Length) " +
+            "baselineHash=$($baseline.Hash) candidateHash=$($candidate.Hash)"
+        )
+
+        foreach ($targetFailure in $targetFailures) {
+            Write-Host "  $targetFailure"
+            $failures.Add("$($target.Name): $targetFailure")
+        }
+    }
+    catch {
+        $message = $_.Exception.Message
+        Write-Host "$($target.Name) ERROR $message"
+        $failures.Add("$($target.Name): $message")
+    }
+}
+
+if ($failures.Count -gt 0) {
+    throw "CADShared TypeDef sequence comparison failed:`n - $($failures -join "`n - ")"
+}
+
+Write-Host "CADShared TypeDef sequence comparison passed for $($targets.Count) targets."

--- a/tools/verification/Test-CADSharedTypeDefSequence.ps1
+++ b/tools/verification/Test-CADSharedTypeDefSequence.ps1
@@ -1,0 +1,232 @@
+[CmdletBinding()]
+param(
+    [string]$ComparatorPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ([string]::IsNullOrWhiteSpace($ComparatorPath)) {
+    $ComparatorPath = Join-Path $PSScriptRoot 'Compare-CADSharedTypeDefSequence.ps1'
+}
+elseif (-not [IO.Path]::IsPathRooted($ComparatorPath)) {
+    $ComparatorPath = Join-Path $repoRoot $ComparatorPath
+}
+$ComparatorPath = [IO.Path]::GetFullPath($ComparatorPath)
+if (-not [IO.File]::Exists($ComparatorPath)) {
+    throw "Comparator script not found: $ComparatorPath"
+}
+
+$targetAssemblies = @(
+    'Build\AC_2019_Release\Fs.Fox.AutoCad.dll',
+    'Build\AC_2025_Release\Fs.Fox.AutoCad.dll',
+    'Build\ZW_2022_Release\Fs.Fox.ZwCad.dll',
+    'Build\ZW_2025_Release\Fs.Fox.ZwCad.dll'
+)
+
+$orderedSource = @'
+namespace FsFoxCad.TypeDefFixture
+{
+    public class First
+    {
+    }
+
+    internal class Second
+    {
+        private sealed class Nested
+        {
+        }
+    }
+}
+'@
+
+$reorderedSource = @'
+namespace FsFoxCad.TypeDefFixture
+{
+    internal class Second
+    {
+        private sealed class Nested
+        {
+        }
+    }
+
+    public class First
+    {
+    }
+}
+'@
+
+function New-FixtureAssembly {
+    param(
+        [string]$Path,
+        [string]$Source,
+        [string]$AssemblyName
+    )
+
+    $projectRoot = Join-Path $tempRoot ('project-' + [Guid]::NewGuid().ToString('N'))
+    $outputRoot = Join-Path $projectRoot 'output'
+    [IO.Directory]::CreateDirectory($projectRoot) | Out-Null
+    $projectPath = Join-Path $projectRoot 'Fixture.csproj'
+    $sourcePath = Join-Path $projectRoot 'Fixture.cs'
+    $projectText = @"
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <AssemblyName>$AssemblyName</AssemblyName>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+</Project>
+"@
+    $utf8 = [Text.UTF8Encoding]::new($false)
+    [IO.File]::WriteAllText($projectPath, $projectText, $utf8)
+    [IO.File]::WriteAllText($sourcePath, $Source, $utf8)
+
+    $buildOutput = @(dotnet build $projectPath --configuration Release --output $outputRoot --nologo --verbosity quiet 2>&1)
+    $buildExitCode = $LASTEXITCODE
+    if ($buildExitCode -ne 0) {
+        $buildOutput | ForEach-Object { Write-Host $_ }
+        throw "Fixture build failed for $AssemblyName with exit code $buildExitCode."
+    }
+
+    $builtAssembly = Join-Path $outputRoot "$AssemblyName.dll"
+    if (-not [IO.File]::Exists($builtAssembly)) {
+        throw "Fixture assembly was not produced: $builtAssembly"
+    }
+    Copy-FixtureAssembly $builtAssembly $Path
+}
+
+function Copy-FixtureAssembly {
+    param(
+        [string]$Source,
+        [string]$Destination
+    )
+
+    [IO.Directory]::CreateDirectory((Split-Path -Parent $Destination)) | Out-Null
+    [IO.File]::Copy($Source, $Destination, $true)
+}
+
+function Get-ExpectedFailure {
+    param([scriptblock]$Action)
+
+    $previousInformationPreference = $InformationPreference
+    try {
+        $InformationPreference = 'SilentlyContinue'
+        try {
+            & $Action
+        }
+        catch {
+            return $_.Exception.Message
+        }
+    }
+    finally {
+        $InformationPreference = $previousInformationPreference
+    }
+    return $null
+}
+
+$tempRoot = Join-Path ([IO.Path]::GetTempPath()) ('FsFoxCadTypeDefTest-' + [Guid]::NewGuid().ToString('N'))
+$baselineRoot = Join-Path $tempRoot 'baseline'
+$candidateRoot = Join-Path $tempRoot 'candidate'
+[IO.Directory]::CreateDirectory($baselineRoot) | Out-Null
+[IO.Directory]::CreateDirectory($candidateRoot) | Out-Null
+
+try {
+    $baselineAcad2019 = Join-Path $baselineRoot $targetAssemblies[0]
+    $baselineAcad2025 = Join-Path $baselineRoot $targetAssemblies[1]
+    $baselineZw2022 = Join-Path $baselineRoot $targetAssemblies[2]
+    $baselineZw2025 = Join-Path $baselineRoot $targetAssemblies[3]
+
+    New-FixtureAssembly $baselineAcad2019 $orderedSource 'Fs.Fox.AutoCad'
+    Copy-FixtureAssembly $baselineAcad2019 $baselineAcad2025
+    New-FixtureAssembly $baselineZw2022 $orderedSource 'Fs.Fox.ZwCad'
+    Copy-FixtureAssembly $baselineZw2022 $baselineZw2025
+
+    foreach ($relativeAssembly in $targetAssemblies) {
+        $sourcePath = Join-Path $baselineRoot $relativeAssembly
+        $destinationPath = Join-Path $candidateRoot $relativeAssembly
+        Copy-FixtureAssembly $sourcePath $destinationPath
+    }
+
+    $hashesBefore = @{}
+    foreach ($root in @($baselineRoot, $candidateRoot)) {
+        foreach ($relativeAssembly in $targetAssemblies) {
+            $path = Join-Path $root $relativeAssembly
+            $hashesBefore[$path] = (Get-FileHash -LiteralPath $path -Algorithm SHA256).Hash
+        }
+    }
+
+    & $ComparatorPath -BaselineRoot $baselineRoot -CandidateRoot $candidateRoot
+
+    foreach ($entry in $hashesBefore.GetEnumerator()) {
+        $hashAfter = (Get-FileHash -LiteralPath $entry.Key -Algorithm SHA256).Hash
+        if ($hashAfter -cne $entry.Value) {
+            throw "Comparator modified input assembly: $($entry.Key)"
+        }
+    }
+    Write-Host 'PASS matching fixtures and read-only inputs'
+
+    $candidateAcad2019 = Join-Path $candidateRoot $targetAssemblies[0]
+    [IO.File]::Delete($candidateAcad2019)
+    New-FixtureAssembly $candidateAcad2019 $reorderedSource 'Fs.Fox.AutoCad'
+    $mismatchMessage = Get-ExpectedFailure {
+        & $ComparatorPath -BaselineRoot $baselineRoot -CandidateRoot $candidateRoot 6>$null
+    }
+    if ([string]::IsNullOrWhiteSpace($mismatchMessage)) {
+        throw 'Comparator accepted a reordered TypeDef sequence.'
+    }
+    foreach ($expectedText in @(
+            'AC_2019',
+            'row=2',
+            'token=0x02000002',
+            "baseline='FsFoxCad.TypeDefFixture.First'",
+            "candidate='FsFoxCad.TypeDefFixture.Second'"
+        )) {
+        if (-not $mismatchMessage.Contains($expectedText, [StringComparison]::Ordinal)) {
+            throw "Reordered sequence failure did not contain '$expectedText': $mismatchMessage"
+        }
+    }
+    Write-Host 'PASS reordered sequence reports the first TypeDef row and token'
+
+    Copy-FixtureAssembly $baselineAcad2019 $candidateAcad2019
+    $candidateZw2025 = Join-Path $candidateRoot $targetAssemblies[3]
+    [IO.File]::Delete($candidateZw2025)
+    $missingMessage = Get-ExpectedFailure {
+        & $ComparatorPath -BaselineRoot $baselineRoot -CandidateRoot $candidateRoot 6>$null
+    }
+    if ([string]::IsNullOrWhiteSpace($missingMessage) -or
+        -not $missingMessage.Contains('ZW_2025', [StringComparison]::Ordinal) -or
+        -not $missingMessage.Contains('Assembly not found', [StringComparison]::Ordinal)) {
+        throw "Missing assembly failure was not target-specific: $missingMessage"
+    }
+    Write-Host 'PASS missing target assembly fails with its target name'
+
+    Copy-FixtureAssembly $baselineZw2025 $candidateZw2025
+    $candidateZw2022 = Join-Path $candidateRoot $targetAssemblies[2]
+    Copy-FixtureAssembly $baselineAcad2019 $candidateZw2022
+    $identityMessage = Get-ExpectedFailure {
+        & $ComparatorPath -BaselineRoot $baselineRoot -CandidateRoot $candidateRoot 6>$null
+    }
+    if ([string]::IsNullOrWhiteSpace($identityMessage) -or
+        -not $identityMessage.Contains('ZW_2022', [StringComparison]::Ordinal) -or
+        -not $identityMessage.Contains(
+            "candidate assembly name 'Fs.Fox.AutoCad' does not match 'Fs.Fox.ZwCad'",
+            [StringComparison]::Ordinal
+        )) {
+        throw "Assembly identity failure was not target-specific: $identityMessage"
+    }
+    Write-Host 'PASS wrong target assembly identity is rejected'
+
+    Write-Host 'CADShared TypeDef sequence comparator tests passed.'
+}
+finally {
+    $resolvedTempRoot = [IO.Path]::GetFullPath($tempRoot)
+    $tempPrefix = [IO.Path]::GetFullPath([IO.Path]::GetTempPath())
+    if (-not $resolvedTempRoot.StartsWith($tempPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "Refusing to remove test directory outside the system temp root: $resolvedTempRoot"
+    }
+    if ([IO.Directory]::Exists($resolvedTempRoot)) {
+        [IO.Directory]::Delete($resolvedTempRoot, $true)
+    }
+}


### PR DESCRIPTION
## Summary

- add a read-only comparator for the complete TypeDef sequence of all four Release targets
- report counts, both hashes, and the first differing row, token, and type
- reject missing targets and incorrect AutoCAD/ZWCAD assembly identities
- add synthetic regression coverage to the existing build workflow

## Decision

TypeDef order is treated as change-local evidence for mechanical refactors, not as a repository-wide long-term compatibility baseline. The comparator accepts explicit baseline and candidate artifact roots and never updates `Build/CADSharedCompatibilityBaseline.json`.

## Validation

- `Test-CADSharedTypeDefSequence.ps1`: passed matching, reordered, missing-target, wrong-identity, and read-only cases
- real `OpAnd` / `OpOr` compile-order swap: rejected for AC_2019, AC_2025, ZW_2022, and ZW_2025; restored order matched exactly
- four Release `Restore;Rebuild` targets: 0 warnings, 0 errors
- module guard: 128 items, 32 debt files, 17 findings
- schema v3 compatibility: all four targets passed
- compatibility and module baseline files: unchanged
- PowerShell parser: passed
- CAD host acceptance: Not run

Refs #25
Implements #64