### PR TITLE
Refactor: 拆分 BlockVisibilityInfo 类型

### DIFF
--- a/Build/CADSharedModuleBaseline.json
+++ b/Build/CADSharedModuleBaseline.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": 1,
   "normalizedSourceHash": "sha256-utf8-lf",
-  "expectedCompileCount": 130,
+  "expectedCompileCount": 131,
   "moduleCounts": {
     "Foundation": 11,
     "Platform.Windows": 5,
     "Cad.Interop": 3,
     "Cad.Geometry": 16,
-    "Cad.Database": 42,
+    "Cad.Database": 43,
     "Cad.Editor": 23,
     "Cad.Application": 8,
     "Cad.Runtime": 14,
@@ -361,7 +361,15 @@
           "count": 1
         }
       ],
-      "sourceSha256": "4f60fe77eb1f97b8f79cd4800711f0692d57ed2a998231a0ff94d54f97201c38"
+      "sourceSha256": "16f05f2ef92fd84c20fe6cb0a65c5fcaadb9e0a166207f5f2255d17f23982339"
+    },
+    {
+      "order": "0321",
+      "fileName": "BlockVisibilityInfo.cs",
+      "module": "Cad.Database",
+      "boundaryDebt": [],
+      "boundaryFindings": [],
+      "sourceSha256": "86ba33bdf31169dee5aa9c12748f11cce20bfef7a455de6eb780384fb6051684"
     },
     {
       "order": "0330",

--- a/Build/Verify-CADSharedModuleMap.ps1
+++ b/Build/Verify-CADSharedModuleMap.ps1
@@ -28,13 +28,13 @@ $BaselinePath = [IO.Path]::GetFullPath($BaselinePath)
 $sourceRoot = [IO.Path]::GetFullPath((Split-Path -Parent $ProjectItemsPath))
 $sourceRootPrefix = $sourceRoot.TrimEnd([IO.Path]::DirectorySeparatorChar) + [IO.Path]::DirectorySeparatorChar
 
-$expectedCompileCount = 130
+$expectedCompileCount = 131
 $expectedModuleCounts = [ordered]@{
     'Foundation'       = 11
     'Platform.Windows' = 5
     'Cad.Interop'      = 3
     'Cad.Geometry'     = 16
-    'Cad.Database'     = 42
+    'Cad.Database'     = 43
     'Cad.Editor'       = 23
     'Cad.Application'  = 8
     'Cad.Runtime'      = 14

--- a/src/CADShared/CADShared.projitems
+++ b/src/CADShared/CADShared.projitems
@@ -169,6 +169,10 @@
       <FsFoxOrder>0320</FsFoxOrder>
       <FsFoxBoundaryDebt>BD-17</FsFoxBoundaryDebt>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Cad\Database\Entities\Blocks\BlockVisibilityInfo.cs">
+      <FsFoxModule>Cad.Database</FsFoxModule>
+      <FsFoxOrder>0321</FsFoxOrder>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Cad\Database\Entities\Bounds\BoundingBox9.cs">
       <FsFoxModule>Cad.Database</FsFoxModule>
       <FsFoxOrder>0330</FsFoxOrder>

--- a/src/CADShared/Cad/Database/Entities/Blocks/BlockReferenceEx.cs
+++ b/src/CADShared/Cad/Database/Entities/Blocks/BlockReferenceEx.cs
@@ -394,24 +394,3 @@ public static class BlockReferenceEx
         return info;
     }
 }
-
-/// <summary>
-/// Dynamic block visibility parameter metadata.
-/// </summary>
-public class BlockVisibilityInfo
-{
-    /// <summary>
-    /// Gets or sets whether the block definition contains a visibility parameter.
-    /// </summary>
-    public bool Has { get; set; }
-
-    /// <summary>
-    /// Gets or sets the visibility property name.
-    /// </summary>
-    public string PropertyName { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Gets or sets the allowed visibility values in definition order.
-    /// </summary>
-    public List<string> AllowedValues { get; set; } = new();
-}

--- a/src/CADShared/Cad/Database/Entities/Blocks/BlockVisibilityInfo.cs
+++ b/src/CADShared/Cad/Database/Entities/Blocks/BlockVisibilityInfo.cs
@@ -1,0 +1,22 @@
+namespace Fs.Fox.Cad;
+
+/// <summary>
+/// Dynamic block visibility parameter metadata.
+/// </summary>
+public class BlockVisibilityInfo
+{
+    /// <summary>
+    /// Gets or sets whether the block definition contains a visibility parameter.
+    /// </summary>
+    public bool Has { get; set; }
+
+    /// <summary>
+    /// Gets or sets the visibility property name.
+    /// </summary>
+    public string PropertyName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the allowed visibility values in definition order.
+    /// </summary>
+    public List<string> AllowedValues { get; set; } = new();
+}


### PR DESCRIPTION
## 变更

- 保留 `BlockReferenceEx` 在原文件，将公开 DTO `BlockVisibilityInfo` 拆到同目录同名文件。
- 保持原类型顺序为 `0320 / 0321`。
- 更新模块基线：编译项 `130 -> 131`，`Cad.Database` `42 -> 43`；其他模块计数不变。
- `BD-17` 与现有边界命中继续只归 `BlockReferenceEx.cs`。
- 不修改扩展方法、事务/native 查询、公共 API、测试、SDK 文档或使用说明文档。

## 本地验证

- AC_2019、AC_2025、ZW_2022、ZW_2025 的 Debug/Release 均完成 Restore + Rebuild。
- 模块守卫：131 items、32 debt-tagged files、17 boundary findings。
- 129 个非拆分 Compile 节点逐项、逐序一致。
- 两个类型的有效文本与 XML 注释和拆分前一致。
- schema v3 兼容守卫对四目标通过，兼容基线文件 SHA-256 未改变。
- 四目标完整 TypeDef 有序序列一致：401 / 360 / 398 / 396。
- TypeDef 比较器自测及最终 staged `git diff --check` 通过。

兼容性打包仍报告仓库既有的 NU5110/NU5111 警告，本次未修改包脚本布局。

## 宿主验收

CAD host: `Not run`。现有 `TestBlockVisibility` 命令未执行，本次不表述为 AutoCAD/ZWCAD 宿主已验证。

Refs #25 #42 #64 #84 #89
