### PR TITLE
Refactor: 拆分 WmMessage 内部辅助类型

### DIFF
--- a/Build/CADSharedModuleBaseline.json
+++ b/Build/CADSharedModuleBaseline.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 1,
   "normalizedSourceHash": "sha256-utf8-lf",
-  "expectedCompileCount": 140,
+  "expectedCompileCount": 141,
   "moduleCounts": {
     "Foundation": 11,
-    "Platform.Windows": 14,
+    "Platform.Windows": 15,
     "Cad.Interop": 3,
     "Cad.Geometry": 16,
     "Cad.Database": 43,
@@ -295,7 +295,17 @@
         "BD-15"
       ],
       "boundaryFindings": [],
-      "sourceSha256": "b2cfc5672802248c4460edb9551d2c157088a224c52dee5514002c3144417cf1"
+      "sourceSha256": "97b1b38576c091ab28337124894bcb40ece0a73eb03f9edb111ee803e997f3d3"
+    },
+    {
+      "order": "0191",
+      "fileName": "WmMessage.cs",
+      "module": "Platform.Windows",
+      "boundaryDebt": [
+        "BD-15"
+      ],
+      "boundaryFindings": [],
+      "sourceSha256": "4656233a56f2aa6e4e7f7b1d5206d3b1672fc7579a0dbfe2bf45ac767d178fee"
     },
     {
       "order": "0200",

--- a/Build/Verify-CADSharedModuleMap.ps1
+++ b/Build/Verify-CADSharedModuleMap.ps1
@@ -28,10 +28,10 @@ $BaselinePath = [IO.Path]::GetFullPath($BaselinePath)
 $sourceRoot = [IO.Path]::GetFullPath((Split-Path -Parent $ProjectItemsPath))
 $sourceRootPrefix = $sourceRoot.TrimEnd([IO.Path]::DirectorySeparatorChar) + [IO.Path]::DirectorySeparatorChar
 
-$expectedCompileCount = 140
+$expectedCompileCount = 141
 $expectedModuleCounts = [ordered]@{
     'Foundation'       = 11
-    'Platform.Windows' = 14
+    'Platform.Windows' = 15
     'Cad.Interop'      = 3
     'Cad.Geometry'     = 16
     'Cad.Database'     = 43

--- a/src/CADShared/CADShared.projitems
+++ b/src/CADShared/CADShared.projitems
@@ -148,6 +148,11 @@
       <FsFoxOrder>0190</FsFoxOrder>
       <FsFoxBoundaryDebt>BD-15</FsFoxBoundaryDebt>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Platform\Windows\Interop\WmMessage.cs">
+      <FsFoxModule>Platform.Windows</FsFoxModule>
+      <FsFoxOrder>0191</FsFoxOrder>
+      <FsFoxBoundaryDebt>BD-15</FsFoxBoundaryDebt>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Platform\Windows\Interop\WindowsAPI.cs">
       <FsFoxModule>Platform.Windows</FsFoxModule>
       <FsFoxOrder>0200</FsFoxOrder>

--- a/src/CADShared/Platform/Windows/Interop/PInvokeUser32.cs
+++ b/src/CADShared/Platform/Windows/Interop/PInvokeUser32.cs
@@ -305,12 +305,3 @@ public static class PInvokeUser32
 
     #endregion
 }
-
-internal class WmMessage
-{
-    #region Message
-
-    public const uint Close = 0x0010;
-
-    #endregion
-}

--- a/src/CADShared/Platform/Windows/Interop/WmMessage.cs
+++ b/src/CADShared/Platform/Windows/Interop/WmMessage.cs
@@ -1,0 +1,10 @@
+namespace Fs.Fox.Basal;
+
+internal class WmMessage
+{
+    #region Message
+
+    public const uint Close = 0x0010;
+
+    #endregion
+}


### PR DESCRIPTION
## 变更

- 保留公开静态类 `PInvokeUser32` 及其嵌套 `GuiThreadInfo` 在原文件，将内部顶层辅助类 `WmMessage` 原文拆到同目录同名文件。
- 保持 `Fs.Fox.Basal.WmMessage` 的内部类型身份、非 static 类语义、`Close` 常量和值不变；`WindowsAPI.CloseWindow` 调用文本不变。
- 在原编译位置使用 `0190 / 0191`，后续 `WindowsAPI.cs = 0200` 不变。
- 模块基线从 140 项更新为 141 项，`Platform.Windows` 从 14 项更新为 15 项。
- `PInvokeUser32.cs` 与 `WmMessage.cs` 均保留 `BD-15`；债务文件从 41 变为 42，仅反映文件粒度展开，边界发现仍为 17。
- 不修改 P/Invoke、公共 API、包身份、兼容基线、SDK 文档或使用说明文档。

## 本地验证

- AC_2019、AC_2025、ZW_2022、ZW_2025 的 Debug/Release 均完成 Restore + Rebuild。
- 源码规范化比对通过：`PInvokeUser32` 剩余正文与 `WmMessage` 完整声明均与拆分前一致。
- 139 个非拆分 Compile 节点逐项、逐序一致。
- 模块守卫：141 items、42 debt-tagged files、17 boundary findings。
- schema v3 兼容守卫对四目标通过，兼容基线 SHA-256 保持 `1A7139BE711A0B26451544291B1FB613BFEBF1BCA908B105F5DB2988B6916378`。
- 四目标完整 TypeDef 有序序列一致：401 / 360 / 398 / 396；对应哈希逐目标不变。
- TypeDef 比较器自测、`git diff --check` 和 staged `git diff --check` 通过。

兼容性打包仍报告仓库既有的 NU5110/NU5111 警告，本次未修改包脚本布局。

## 宿主验收

CAD host: `Not run`。本次未执行 Win32/CAD 宿主行为测试，不表述为 AutoCAD/ZWCAD 宿主已验证。

Refs #25 #42 #64 #84 #94