### PR TITLE
docs: 更新站点仓库地址

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@
 - Issue #25 的 `CADShared` 单程序集逻辑模块化在长期分支 `refactor/cad-modules` 上实施，相关 PR 以该分支为 base。
 - `refactor/cad-modules` 只合并最新 `main`，不 rebase、不强推；主线修复和文档变更进入 `main` 后再同步过去。
 - 不在逻辑模块化的机械移动中夹带行为修改、公共 API 修改、全文件格式化或无关文档重写。
-- 文档治理与发布能力由 Issue #48 跟踪；`Fs.Fox.CAD` 保持唯一产品内容源，已创建的展示/部署仓库及其边界见 [EdgeOne 站点仓库评估](docs/edgeone-site-repository-evaluation.md)和 [Fs.Fox.CAD.Site](https://github.com/FsDiG/Fs.Fox.CAD.Site)。站点框架尚未确定，不要在本仓库提前引入框架专用目录或生成产物。
+- 文档治理与发布能力由 Issue #48 跟踪；`Fs.Fox.CAD` 保持唯一产品内容源，已创建的展示/部署仓库及其边界见 [EdgeOne 站点仓库评估](docs/edgeone-site-repository-evaluation.md)和 [Fs.Fox.CAD.Site](https://github.com/FeiSiPub/Fs.Fox.CAD.Site)。站点框架尚未确定，不要在本仓库提前引入框架专用目录或生成产物。
 
 ## 代码与文档责任
 

--- a/docs/documentation-architecture.md
+++ b/docs/documentation-architecture.md
@@ -26,7 +26,7 @@ Fs.Fox.CAD 是一个面向多种 CAD 宿主的单产品通用基础类库。文�
 4. 文档站点框架暂不确定。目录、元数据、关联和发布契约不得依赖 DocFX、VitePress、Docusaurus、MkDocs 或其他具体实现。
 5. 可编辑的站点实现与可编辑的产品内容是两个边界。主题、组件和部署配置可以独立演进，但页面正文、API 语义、示例和内容级导航只能从 `Fs.Fox.CAD` 的确定提交取得。
 
-独立展示/部署仓库 [FsDiG/Fs.Fox.CAD.Site](https://github.com/FsDiG/Fs.Fox.CAD.Site) 已创建，当前提供框架无关的精确来源锁、GitHub 同步和 Bootstrap 构建；EdgeOne 尚未连接，最终框架尚未选择。详细能力、权限、API 数据包和 POC 门槛见 [EdgeOne Makers 站点仓库架构评估](edgeone-site-repository-evaluation.md)。当前仍不创建 `Fs.Fox.CAD.Docs` 等生成产物仓库；即使未来创建，它也只能接收自动生成内容，不能成为第二个文档源。
+独立展示/部署仓库 [FeiSiPub/Fs.Fox.CAD.Site](https://github.com/FeiSiPub/Fs.Fox.CAD.Site) 已创建，当前提供框架无关的精确来源锁、GitHub 同步和 Bootstrap 构建；EdgeOne 尚未连接，最终框架尚未选择。详细能力、权限、API 数据包和 POC 门槛见 [EdgeOne Makers 站点仓库架构评估](edgeone-site-repository-evaluation.md)。当前仍不创建 `Fs.Fox.CAD.Docs` 等生成产物仓库；即使未来创建，它也只能接收自动生成内容，不能成为第二个文档源。
 
 ## 2. 为什么采用同仓事实源
 
@@ -355,7 +355,7 @@ Release tag 完成正式构建、包检查和发布后，源码仓库才发送 s
 
 ### 12.1 展示/部署仓库
 
-已创建的 [Fs.Fox.CAD.Site](https://github.com/FsDiG/Fs.Fox.CAD.Site) 落实了展示/部署仓库边界：它隔离 Node/前端依赖、主题代码和后续 EdgeOne 权限，同时允许站点展示独立迭代。它必须通过精确来源锁读取 `Fs.Fox.CAD`，不得人工维护产品内容或提交生成页面。最终框架、EdgeOne 和产品内容 POC 仍按 [专项评估](edgeone-site-repository-evaluation.md) 分阶段执行。
+已创建的 [Fs.Fox.CAD.Site](https://github.com/FeiSiPub/Fs.Fox.CAD.Site) 落实了展示/部署仓库边界：它隔离 Node/前端依赖、主题代码和后续 EdgeOne 权限，同时允许站点展示独立迭代。它必须通过精确来源锁读取 `Fs.Fox.CAD`，不得人工维护产品内容或提交生成页面。最终框架、EdgeOne 和产品内容 POC 仍按 [专项评估](edgeone-site-repository-evaluation.md) 分阶段执行。
 
 ### 12.2 生成产物仓库
 

--- a/docs/edgeone-site-repository-evaluation.md
+++ b/docs/edgeone-site-repository-evaluation.md
@@ -5,13 +5,13 @@
 > 源码基线：`FsDiG/Fs.Fox.CAD` `main` @ `416c65f`<br>
 > 跟踪：[Issue #48](https://github.com/FsDiG/Fs.Fox.CAD/issues/48)<br>
 > 现行约定：[文档与代码协同治理方案](documentation-architecture.md)<br>
-> 站点仓库：[FsDiG/Fs.Fox.CAD.Site](https://github.com/FsDiG/Fs.Fox.CAD.Site)（Bootstrap 已创建，EdgeOne 尚未连接）<br>
-> 站点实施：[事件同步 Issue #1](https://github.com/FsDiG/Fs.Fox.CAD.Site/issues/1)；[EdgeOne 交接 Issue #2](https://github.com/FsDiG/Fs.Fox.CAD.Site/issues/2)<br>
+> 站点仓库：[FeiSiPub/Fs.Fox.CAD.Site](https://github.com/FeiSiPub/Fs.Fox.CAD.Site)（Bootstrap 已创建，EdgeOne 尚未连接）<br>
+> 站点实施：[事件同步 Issue #1](https://github.com/FeiSiPub/Fs.Fox.CAD.Site/issues/1)；[EdgeOne 交接 Issue #2](https://github.com/FeiSiPub/Fs.Fox.CAD.Site/issues/2)<br>
 > 本轮范围：评估并建立仓库边界、精确来源获取和 GitHub 同步；不选择最终前端框架，不代替仓库所有者配置 EdgeOne
 
 ## 1. 结论
 
-`FsDiG/Fs.Fox.CAD.Site` 已创建，并由其自身 Actions 验证精确 source commit 获取、Git tree 校验和 Bootstrap 静态构建；后续由 EdgeOne Makers 直接连接该仓库完成云端构建和部署。这个仓库不是第二个帮助文档仓库，也不是生成 HTML 的镜像仓库；它是**可编辑的展示与部署实现仓库**。
+`FeiSiPub/Fs.Fox.CAD.Site` 已创建，并由其自身 Actions 验证精确 source commit 获取、Git tree 校验和 Bootstrap 静态构建；后续由 EdgeOne Makers 直接连接该仓库完成云端构建和部署。这个仓库不是第二个帮助文档仓库，也不是生成 HTML 的镜像仓库；它是**可编辑的展示与部署实现仓库**。
 
 三个边界已经明确：
 
@@ -67,7 +67,7 @@ EdgeOne Makers
 | 类型 | 是否需要 | 是否可人工编辑 | 典型内容 |
 | --- | --- | --- | --- |
 | 产品内容源仓库 | 已有：`Fs.Fox.CAD` | 是 | 代码、XML 注释、Markdown、samples、内容状态和代码关联。 |
-| 展示/部署仓库 | 已创建：[Fs.Fox.CAD.Site](https://github.com/FsDiG/Fs.Fox.CAD.Site) | 是，但仅限站点实现 | 框架依赖、主题、布局、组件、搜索适配、来源锁、EdgeOne 配置。 |
+| 展示/部署仓库 | 已创建：[Fs.Fox.CAD.Site](https://github.com/FeiSiPub/Fs.Fox.CAD.Site) | 是，但仅限站点实现 | 框架依赖、主题、布局、组件、搜索适配、来源锁、EdgeOne 配置。 |
 | 生成产物仓库 | 当前不需要 | 否 | HTML、搜索索引、生成 API 页面、压缩包等可重建输出。 |
 
 原治理方案排除的是“第二个可人工编辑的产品内容仓库”和“只提交生成结果的仓库”。现在提出的 `Fs.Fox.CAD.Site` 不属于这两类：它拥有可维护的前端实现，但不能拥有产品帮助内容。
@@ -347,7 +347,7 @@ Fs.Fox.CAD.Site/
 
 ### Phase 1：最小站点 POC
 
-- [x] 创建 `FsDiG/Fs.Fox.CAD.Site`，加入零依赖 Node Bootstrap、维护规则和来源集成契约；
+- [x] 创建并迁移至 `FeiSiPub/Fs.Fox.CAD.Site`，加入零依赖 Node Bootstrap、维护规则和来源集成契约；
 - [x] 锁定 latest/stable 的完整 source commit 和 Git tree；
 - [x] 验证精确 SHA 获取、远端一致性、构建清单和生成目录排除；
 - [ ] 比较最小站点框架候选，并选择 3 至 5 篇公开 Markdown 验证产品内容渲染；
@@ -411,7 +411,7 @@ Fs.Fox.CAD.Site/
 
 ### 本提案建议
 
-- 已按建议创建 `FsDiG/Fs.Fox.CAD.Site`；
+- 已按建议创建并迁移至 `FeiSiPub/Fs.Fox.CAD.Site`；
 - 用 `content-source.json` 锁定 latest/stable 的完整 source commit；
 - 使用 GitHub App + repository dispatch 更新锁；
 - EdgeOne 原生 Git 集成负责生产构建；


### PR DESCRIPTION
## 摘要

- 将文档中的站点仓库地址从 `FsDiG/Fs.Fox.CAD.Site` 更新为 `FeiSiPub/Fs.Fox.CAD.Site`。
- 保持产品内容源 `FsDiG/Fs.Fox.CAD`、来源锁语义、EdgeOne 边界和框架决策不变。
- 记录站点仓库已经迁移，不引入站点依赖、生成产物或生产代码修改。

## 验证

- `git diff --check`
- 搜索确认源仓库现行文档不再引用旧站点仓库地址
- 新仓库、Issues 与 commit 地址通过 GitHub API 验证

关联 #48