### PR TITLE
fix: 保留并显式禁用 RegionEx.ToCurves 历史实现

### DIFF
--- a/Build/CADSharedCompatibilityBaseline.json
+++ b/Build/CADSharedCompatibilityBaseline.json
@@ -1004,9 +1004,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.AutoCad.xml",
-            "length": 490259,
+            "length": 489799,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "36e5b2e9e09b7e16204a1f14bcfe49d90702e427e16cd6302d6418e86531c518",
+            "contentSha256": "a63e59db6c022f3a34329b7436b95a942a00452222175eeeb64cbb58972804b0",
             "binarySource": null
           },
           {
@@ -2122,9 +2122,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.AutoCad.xml",
-            "length": 452141,
+            "length": 451681,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "efc874e3dd8f43f14dfaecebcef6e7751f2c60b23e36f008135830d6ce318967",
+            "contentSha256": "ad8310802cbd764e28fed8370f9cb5ad410c358281607a8af636778706da3be4",
             "binarySource": null
           },
           {
@@ -3123,9 +3123,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 481181,
+            "length": 480725,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "227da6292324b41e087ff2ecba86c571afe92480aa755994322874a9c675cfc4",
+            "contentSha256": "786be870d5aedbfccefe5f201f5d583ac77069b2e98c2ad40f5f72cca5fc3ffa",
             "binarySource": null
           },
           {
@@ -4124,9 +4124,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 480179,
+            "length": 479723,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "1de7487ff1c00b65379339c6dcce7146eb2f74944835e4d338327c6f6450af7a",
+            "contentSha256": "a83946aff0497fe8c120ee51fcb1c86ae4c9ab04e918e2073f54161a2c0a53e7",
             "binarySource": null
           },
           {

--- a/Build/CADSharedCompatibilityBaseline.json
+++ b/Build/CADSharedCompatibilityBaseline.json
@@ -1004,9 +1004,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.AutoCad.xml",
-            "length": 489799,
+            "length": 490259,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "a63e59db6c022f3a34329b7436b95a942a00452222175eeeb64cbb58972804b0",
+            "contentSha256": "36e5b2e9e09b7e16204a1f14bcfe49d90702e427e16cd6302d6418e86531c518",
             "binarySource": null
           },
           {
@@ -2122,9 +2122,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.AutoCad.xml",
-            "length": 451681,
+            "length": 452141,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "ad8310802cbd764e28fed8370f9cb5ad410c358281607a8af636778706da3be4",
+            "contentSha256": "efc874e3dd8f43f14dfaecebcef6e7751f2c60b23e36f008135830d6ce318967",
             "binarySource": null
           },
           {
@@ -3123,9 +3123,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 480725,
+            "length": 481181,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "786be870d5aedbfccefe5f201f5d583ac77069b2e98c2ad40f5f72cca5fc3ffa",
+            "contentSha256": "227da6292324b41e087ff2ecba86c571afe92480aa755994322874a9c675cfc4",
             "binarySource": null
           },
           {
@@ -4124,9 +4124,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 479723,
+            "length": 480179,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "a83946aff0497fe8c120ee51fcb1c86ae4c9ab04e918e2073f54161a2c0a53e7",
+            "contentSha256": "1de7487ff1c00b65379339c6dcce7146eb2f74944835e4d338327c6f6450af7a",
             "binarySource": null
           },
           {

--- a/Build/CADSharedModuleBaseline.json
+++ b/Build/CADSharedModuleBaseline.json
@@ -548,7 +548,7 @@
       "module": "Cad.Database",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "15888af18e2af736b2924e36cc7b2a989dc2b7cde25260186571a68bcb4d0ded"
+      "sourceSha256": "e50369a685b02025b64b8ecf7a2e9d8cf422a5afc0d33f9b826f5a84d5b34e59"
     },
     {
       "order": "0420",

--- a/Build/CADSharedModuleBaseline.json
+++ b/Build/CADSharedModuleBaseline.json
@@ -548,7 +548,7 @@
       "module": "Cad.Database",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "15aa08f907490bd4079e0c37b25786e4064785910e626059b4d335b40a41aa1e"
+      "sourceSha256": "15888af18e2af736b2924e36cc7b2a989dc2b7cde25260186571a68bcb4d0ded"
     },
     {
       "order": "0420",

--- a/src/CADShared/Cad/Database/Entities/RegionEx.cs
+++ b/src/CADShared/Cad/Database/Entities/RegionEx.cs
@@ -1,81 +1,13 @@
-#if ACAD
-using Autodesk.AutoCAD.BoundaryRepresentation;
-
-#elif ZWCAD
-using ZwSoft.ZwCAD.BoundaryRepresentation;
-#endif
 namespace Fs.Fox.Cad;
 
+// 保留空类型以维持已发布程序集的公共 API 兼容性。
 /// <summary>
 /// 面域扩展
 /// </summary>
 public static class RegionEx
 {
-    
-
-#if AutoCAD
- 
-    /// <summary>
-    /// 面域转曲线
-    /// </summary>
-    /// <param name="region">面域</param>
-    /// <returns>曲线集合</returns>
-    public static IEnumerable<Curve> ToCurves(this Region region)
+    // 保留已发布 RegionEx 类型上的 ExtensionAttribute 元数据。
+    private static void PreserveExtensionMetadata(this object _)
     {
-        if (region.IsNull)
-            yield break;
-        using var brep = new Brep(region);
-        var loops = brep.Complexes.SelectMany(complex => complex.Shells)
-            .SelectMany(shell => shell.Faces)
-            .SelectMany(face => face.Loops);
-        foreach (var loop in loops)
-        {
-            var curves3d = loop.Edges.Select(edge => ((ExternalCurve3d)edge.Curve).NativeCurve)
-                .ToList();
-            var cur = Curve.CreateFromGeCurve(1 < curves3d.Count
-                ? new CompositeCurve3d(curves3d.ToOrderedArray())
-                : curves3d.First());
-
-            foreach (var curve3d in curves3d)
-            {
-                curve3d.Dispose();
-            }
-
-            cur.SetPropertiesFrom(region);
-            yield return cur;
-        }
-    }
-
-#endif
-    
-    /// <summary>
-    /// 按首尾相连对曲线集合进行排序
-    /// </summary>
-    /// <param name="source"></param>
-    /// <returns>曲线列表</returns>
-    /// <exception cref="ArgumentException">当不能首尾相连时会抛出此异常</exception>
-    private static Curve3d[] ToOrderedArray(this IEnumerable<Curve3d> source)
-    {
-        var tol = new Tolerance(0.001, 0.001);
-        var list = source.ToList();
-        var count = list.Count;
-        var array = new Curve3d[count];
-        var i = 0;
-        array[0] = list[0];
-        list.RemoveAt(0);
-        while (i < count - 1)
-        {
-            var pt = array[i++].EndPoint;
-            int index;
-            if ((index = list.FindIndex(c => c.StartPoint.IsEqualTo(pt, tol))) != -1)
-                array[i] = list[index];
-            else if ((index = list.FindIndex(c => c.EndPoint.IsEqualTo(pt, tol))) != -1)
-                array[i] = list[index].GetReverseParameterCurve();
-            else
-                throw new ArgumentException("非连续曲线.");
-            list.RemoveAt(index);
-        }
-
-        return array;
     }
 }

--- a/src/CADShared/Cad/Database/Entities/RegionEx.cs
+++ b/src/CADShared/Cad/Database/Entities/RegionEx.cs
@@ -1,13 +1,81 @@
+#if FSFOX_ENABLE_REGION_TO_CURVES && ACAD
+using Autodesk.AutoCAD.BoundaryRepresentation;
+#elif FSFOX_ENABLE_REGION_TO_CURVES && ZWCAD
+using ZwSoft.ZwCAD.BoundaryRepresentation;
+#endif
+
 namespace Fs.Fox.Cad;
 
-// 保留空类型以维持已发布程序集的公共 API 兼容性。
 /// <summary>
 /// 面域扩展
 /// </summary>
 public static class RegionEx
 {
-    // 保留已发布 RegionEx 类型上的 ExtensionAttribute 元数据。
-    private static void PreserveExtensionMetadata(this object _)
+    // 面域边界提取具有通用类库价值，历史实现暂予保留。
+    // 当前尚未验证临时几何对象的所有权与异常清理，也未完成 ZWCAD 2022 的 API 适配和真实宿主验收，
+    // 因此正式项目均不定义 FSFOX_ENABLE_REGION_TO_CURVES。重新启用前须补齐跨宿主实现、资源清理及真实宿主用例。
+#if FSFOX_ENABLE_REGION_TO_CURVES
+    /// <summary>
+    /// 面域转曲线
+    /// </summary>
+    /// <param name="region">面域</param>
+    /// <returns>曲线集合</returns>
+    public static IEnumerable<Curve> ToCurves(this Region region)
     {
+        if (region.IsNull)
+            yield break;
+
+        using var brep = new Brep(region);
+        var loops = brep.Complexes.SelectMany(complex => complex.Shells)
+            .SelectMany(shell => shell.Faces)
+            .SelectMany(face => face.Loops);
+        foreach (var loop in loops)
+        {
+            var curves3d = loop.Edges.Select(edge => ((ExternalCurve3d)edge.Curve).NativeCurve)
+                .ToList();
+            var cur = Curve.CreateFromGeCurve(1 < curves3d.Count
+                ? new CompositeCurve3d(curves3d.ToOrderedArray())
+                : curves3d.First());
+
+            foreach (var curve3d in curves3d)
+            {
+                curve3d.Dispose();
+            }
+
+            cur.SetPropertiesFrom(region);
+            yield return cur;
+        }
+    }
+#endif
+
+    /// <summary>
+    /// 按首尾相连对曲线集合进行排序
+    /// </summary>
+    /// <param name="source"></param>
+    /// <returns>曲线列表</returns>
+    /// <exception cref="ArgumentException">当不能首尾相连时会抛出此异常</exception>
+    private static Curve3d[] ToOrderedArray(this IEnumerable<Curve3d> source)
+    {
+        var tol = new Tolerance(0.001, 0.001);
+        var list = source.ToList();
+        var count = list.Count;
+        var array = new Curve3d[count];
+        var i = 0;
+        array[0] = list[0];
+        list.RemoveAt(0);
+        while (i < count - 1)
+        {
+            var pt = array[i++].EndPoint;
+            int index;
+            if ((index = list.FindIndex(c => c.StartPoint.IsEqualTo(pt, tol))) != -1)
+                array[i] = list[index];
+            else if ((index = list.FindIndex(c => c.EndPoint.IsEqualTo(pt, tol))) != -1)
+                array[i] = list[index].GetReverseParameterCurve();
+            else
+                throw new ArgumentException("非连续曲线.");
+            list.RemoveAt(index);
+        }
+
+        return array;
     }
 }


### PR DESCRIPTION
## Summary

- 撤销本分支最初对 `RegionEx.ToCurves()` 的删除结论，恢复完整历史实现。
- 将错误且永远为假的 `#if AutoCAD` 改为显式能力开关 `FSFOX_ENABLE_REGION_TO_CURVES`。
- 四个正式项目均不定义该开关；在跨宿主实现、资源所有权和真实宿主验证完成前，`ToCurves()` 继续不进入产物。
- 保留私有曲线排序逻辑、`RegionEx` 的既有 `ExtensionAttribute` 元数据和 XML 文档资产。
- 仅更新 `RegionEx.cs` 的模块源码哈希。

## Why

`ToCurves()` 用于将 Region 的每个边界环转换为数据库曲线，包含内环，具有通用 CAD 基础类库价值。它曾经过环闭合和空 Region 等多次修正，后来因条件编译符号误写而被意外排除。

仓库内是否存在调用点、当前 NuGet 是否包含该方法，都不能用于判断通用工具能力是否值得保留。由于历史实现仍有临时几何对象所有权、异常清理和 ZWCAD 2022 API 差异等未验证问题，本 PR 选择“保留源码、默认禁用”，不仓促恢复为正式 API。

详细的修复与宿主验收边界继续由 #103 跟踪。

## Final Diff Against Main

- `src/CADShared/Cad/Database/Entities/RegionEx.cs`
  - 保留完整算法。
  - 使用有意设计、语义明确的禁用开关。
  - 记录禁用原因和重新启用门槛。
- `Build/CADSharedModuleBaseline.json`
  - 只同步上述源码哈希。
- 公共兼容性基线相对 `main` 无变化。

## Compatibility

- `FSFOX_ENABLE_REGION_TO_CURVES` 未在任何正式项目、props、targets 或 shared project 中定义。
- 四个正式产物仍不包含公开 `ToCurves()`，运行时行为不变。
- `RegionEx` TypeDef、类型元数据和 XML 文档资产与 `main` 一致。
- 本 PR 不发布 NuGet。

## Validation

- [x] `git diff --check`
- [x] `Build/Verify-CADSharedModuleMap.ps1`：`141 / 42 / 17`
- [x] `tools/verification/Test-CADSharedTypeDefSequence.ps1`
- [x] AC_2019 Release build
- [x] AC_2025 Release build
- [x] ZW_2022 Release build
- [x] ZW_2025 Release build
- [x] `Build/Verify-CADSharedCompatibility.ps1`
- [ ] CAD Host：Not run（能力默认禁用，本 PR 不证明转换逻辑已通过宿主验收）

兼容性打包仍报告现有 `NU5110` / `NU5111`，本 PR 不修改 NuGet 脚本，且近期不发布新版 NuGet。

Refs #103