### PR TITLE
支持浩辰CAD 2022 2023 2026

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -98,5 +98,14 @@ jobs:
           # ZWCAD2025 - MSBuild (.NET Framework)
           Build-MSBuild "tests/TestZcad2025/TestZcad2025.csproj" "ZW_2025"
 
+          # GStarCAD 2022 - MSBuild (.NET Framework 4.8)
+          Build-MSBuild "tests/TestGcad2022/TestGcad2022.csproj" "GC_2022"
+
+          # GStarCAD 2023 - MSBuild (.NET Framework 4.8)
+          Build-MSBuild "tests/TestGcad2023/TestGcad2023.csproj" "GC_2023"
+
+          # GStarCAD 2026 - dotnet CLI (.NET 8)
+          Build-DotNet "tests/TestGcad2026/TestGcad2026.csproj" "GC_2026"
+
       - name: Verify CADShared compatibility baseline
         run: pwsh -NoProfile -File Build/Verify-CADSharedCompatibility.ps1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,15 @@ jobs:
             "Build\ZW_2025_Release" `
             "ZWCAD 2025"
 
+          # GStarCAD 2022 - Build + Pack (MSBuild, .NET Framework 4.8)
+          BuildPack-MSBuild "src/Fs.Fox.Gcad2022/Fs.Fox.Gcad2022.csproj" "GC_2022"
+
+          # GStarCAD 2023 - Build + Pack (MSBuild, .NET Framework 4.8)
+          BuildPack-MSBuild "src/Fs.Fox.Gcad2023/Fs.Fox.Gcad2023.csproj" "GC_2023"
+
+          # GStarCAD 2026 - Build + Pack (dotnet CLI, .NET 8)
+          BuildPack-DotNet "src/Fs.Fox.Gcad2026/Fs.Fox.Gcad2026.csproj" "GC_2026"
+
       - name: Publish to NuGet
         run: |
           $packages = Get-ChildItem ./artifacts/*.nupkg
@@ -139,6 +148,9 @@ jobs:
             - IFox.CAD.ACAD2025 (AutoCAD 2025, .NET 8.0)
             - IFox.CAD.ZCAD2022 (ZWCAD 2021-2024, .NET Framework 4.8)
             - IFox.CAD.ZCAD2025 (ZWCAD 2025-2026, .NET Framework 4.8)
+            - IFox.CAD.GCAD2022 (GStarCAD 2022, .NET Framework 4.8)
+            - IFox.CAD.GCAD2023 (GStarCAD 2023, .NET Framework 4.8)
+            - IFox.CAD.GCAD2026 (GStarCAD 2026, .NET 8)
           files: ./artifacts/*.nupkg
           draft: false
           prerelease: false

--- a/Build/CADSharedCompatibilityBaseline.json
+++ b/Build/CADSharedCompatibilityBaseline.json
@@ -2122,9 +2122,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.AutoCad.xml",
-            "length": 452141,
+            "length": 454532,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "efc874e3dd8f43f14dfaecebcef6e7751f2c60b23e36f008135830d6ce318967",
+            "contentSha256": "aa68fd8bb0daf214b90c22a556f2a13cbd863f15975938ae9f7005e1c605520c",
             "binarySource": null
           },
           {
@@ -4124,9 +4124,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 480179,
+            "length": 482570,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "1de7487ff1c00b65379339c6dcce7146eb2f74944835e4d338327c6f6450af7a",
+            "contentSha256": "526f11c0944505de2c5b5380e27ba7c2b9334303d04cc990d78c86ec60da54f0",
             "binarySource": null
           },
           {
@@ -4135,6 +4135,3082 @@
             "hashKind": "matches-build-output-sha256",
             "contentSha256": null,
             "binarySource": "Build/ZW_2025_Release/TestZcad2025.dll"
+          },
+          {
+            "path": "LICENSE",
+            "length": 1091,
+            "hashKind": "raw-sha256",
+            "contentSha256": "a2943fc061379a06f57c4a7ea027980ffd3b1f29488cb00519402fd27113d3fd",
+            "binarySource": null
+          },
+          {
+            "path": "readme.md",
+            "length": 7873,
+            "hashKind": "raw-sha256",
+            "contentSha256": "00ccca236e22a69663270c28e1fd111575561d3708e5ff863b469273cbdc9b9a",
+            "binarySource": null
+          }
+        ]
+      }
+    },
+    {
+      "name": "GC_2022",
+      "assembly": {
+        "identity": {
+          "name": "Fs.Fox.Gcad",
+          "version": "0.9.2.0",
+          "culture": "",
+          "publicKeyToken": ""
+        },
+        "references": [
+          {
+            "name": "gmap",
+            "version": "1.0.8020.18545",
+            "culture": "",
+            "publicKeyOrToken": "",
+            "flags": 0
+          },
+          {
+            "name": "gmdb",
+            "version": "3.5.0.18526",
+            "culture": "",
+            "publicKeyOrToken": "",
+            "flags": 0
+          },
+          {
+            "name": "Microsoft.CSharp",
+            "version": "4.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b03f5f7f11d50a3a",
+            "flags": 0
+          },
+          {
+            "name": "mscorlib",
+            "version": "4.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b77a5c561934e089",
+            "flags": 0
+          },
+          {
+            "name": "PresentationCore",
+            "version": "4.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "31bf3856ad364e35",
+            "flags": 0
+          },
+          {
+            "name": "PresentationFramework",
+            "version": "4.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "31bf3856ad364e35",
+            "flags": 0
+          },
+          {
+            "name": "System",
+            "version": "4.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b77a5c561934e089",
+            "flags": 0
+          },
+          {
+            "name": "System.Core",
+            "version": "4.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b77a5c561934e089",
+            "flags": 0
+          },
+          {
+            "name": "System.Data",
+            "version": "4.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b77a5c561934e089",
+            "flags": 0
+          },
+          {
+            "name": "System.Drawing",
+            "version": "4.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b03f5f7f11d50a3a",
+            "flags": 0
+          },
+          {
+            "name": "System.Windows.Forms",
+            "version": "4.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b77a5c561934e089",
+            "flags": 0
+          },
+          {
+            "name": "WindowsBase",
+            "version": "4.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "31bf3856ad364e35",
+            "flags": 0
+          }
+        ],
+        "publicApiRecordCount": 2262,
+        "publicApi": [
+          {
+            "type": "Fs.Fox.Basal.ArgumentNullEx",
+            "recordCount": 2,
+            "contractSha256": "37ab9b08d69718b4850a40cf43c82340d6baf09836b548bd2b8f6745b127b2d9"
+          },
+          {
+            "type": "Fs.Fox.Basal.ArrayEx",
+            "recordCount": 3,
+            "contractSha256": "a7d7c30392cefc860eb668371ee65f531b692b01dc043cd691e9662a4f8cb1fc"
+          },
+          {
+            "type": "Fs.Fox.Basal.DebugEx",
+            "recordCount": 2,
+            "contractSha256": "e6e81cdbb92cacd0da7f4e8135c5bbbbe336a69164df4acf78320642f911c849"
+          },
+          {
+            "type": "Fs.Fox.Basal.EnumEx",
+            "recordCount": 6,
+            "contractSha256": "8f67523a6f5389fbd9d8aa065c8dc598037ae480ea1841cb992c2516aeec6815"
+          },
+          {
+            "type": "Fs.Fox.Basal.GetWindowCmd",
+            "recordCount": 9,
+            "contractSha256": "7f72f56c0d744ea607d715ae4dd5a68a74421bb414a27bca9f574943a7f1f607"
+          },
+          {
+            "type": "Fs.Fox.Basal.GWL",
+            "recordCount": 9,
+            "contractSha256": "96a77b6035380bca43533199e18d6841d36bf118d73f8c5edb0231748411e8a8"
+          },
+          {
+            "type": "Fs.Fox.Basal.HookType",
+            "recordCount": 18,
+            "contractSha256": "32f677ba3290ad90a17ec392e659ffa3b35bac63000ead25915bac3c85f677ff"
+          },
+          {
+            "type": "Fs.Fox.Basal.LinqEx",
+            "recordCount": 12,
+            "contractSha256": "fa41fee63890ca237f6ef3678480635849824b8e397f854d64f5e5d797f0cd7b"
+          },
+          {
+            "type": "Fs.Fox.Basal.LoopList`1",
+            "recordCount": 37,
+            "contractSha256": "7aab7667dbae54bfd47b4eda8d14d11b0cd1f79e3525ee5003c6d9e2c16f7e9a"
+          },
+          {
+            "type": "Fs.Fox.Basal.LoopListNode`1",
+            "recordCount": 10,
+            "contractSha256": "3914f5f56c2655f0d12445e25f8d585aaf3738f0789530cd912561fec0e8e1dd"
+          },
+          {
+            "type": "Fs.Fox.Basal.LoopState",
+            "recordCount": 17,
+            "contractSha256": "36f37eabec6a916404ddedec4817f221c39dc5a6f7b60c95c7e8459dbb02a506"
+          },
+          {
+            "type": "Fs.Fox.Basal.MOUSEEVENTF",
+            "recordCount": 11,
+            "contractSha256": "3a7d09836e1a3306ba58275281877537fa71113a79c30aae65acd2d2953ae53b"
+          },
+          {
+            "type": "Fs.Fox.Basal.NCmdShow",
+            "recordCount": 15,
+            "contractSha256": "62036a3e7697d2e0c22615b89b1daac246e9bcd77b7e399ffcd6d7cbb33e2fbe"
+          },
+          {
+            "type": "Fs.Fox.Basal.PInvokeUser32",
+            "recordCount": 24,
+            "contractSha256": "b92bde454918268e67be7cb66e7a65293152817ac038f4f6af3f6d720f8139dd"
+          },
+          {
+            "type": "Fs.Fox.Basal.PInvokeUser32+GuiThreadInfo",
+            "recordCount": 11,
+            "contractSha256": "4d0f4a1cc09dad6e83377bd7ae52224a729df768d0f7b44cc00f82dfcc49924f"
+          },
+          {
+            "type": "Fs.Fox.Basal.ProState",
+            "recordCount": 20,
+            "contractSha256": "f87608e21811e725f000fec4a608c6bcfe2f6013761565fb1a20691f13a24134"
+          },
+          {
+            "type": "Fs.Fox.Basal.RandomEx",
+            "recordCount": 16,
+            "contractSha256": "a54558ec16d423cbc9fd3ae53f4099d648cea39d1cfc63109f9b3a0f095d630d"
+          },
+          {
+            "type": "Fs.Fox.Basal.SC",
+            "recordCount": 6,
+            "contractSha256": "c093f92356be05017ebb765b18ebae11c97fb74ceb13c80214a5c7fefb1cc5fb"
+          },
+          {
+            "type": "Fs.Fox.Basal.SystemEx",
+            "recordCount": 3,
+            "contractSha256": "8f8d5b54f31c8a84e244984e8dabcfbd932db93d19bc2bbaafc1469d098b9e4b"
+          },
+          {
+            "type": "Fs.Fox.Basal.TH32CS",
+            "recordCount": 9,
+            "contractSha256": "f6851b16b314b43b3fa1cad9c8fec62d8f9231ab1722b21f874187b58b8f6361"
+          },
+          {
+            "type": "Fs.Fox.Basal.VK",
+            "recordCount": 153,
+            "contractSha256": "fc31ec9b483754682740786322d9c48239e31d0818d170683aa51b109a105624"
+          },
+          {
+            "type": "Fs.Fox.Basal.WindowsAPI",
+            "recordCount": 22,
+            "contractSha256": "a60d29b218040084cc7aa2138fc945bd2a3a213cdf858b44291487d0d6790282"
+          },
+          {
+            "type": "Fs.Fox.Basal.WindowsAPI+CallBack",
+            "recordCount": 5,
+            "contractSha256": "4c9148381c3b42b00153346d5ebf888834d21d021b82394e4514ee285666d082"
+          },
+          {
+            "type": "Fs.Fox.Basal.WindowsAPI+IntRect",
+            "recordCount": 23,
+            "contractSha256": "15cd54b1efab39cfbde8d7043400386fdf9082ea799563a6c1c62d9d16890565"
+          },
+          {
+            "type": "Fs.Fox.Basal.WindowsAPI+IntSize",
+            "recordCount": 5,
+            "contractSha256": "ef7f61c641181ab6eea9ec19152c95fec6cac28feb793daa2fdf32dde5ae3309"
+          },
+          {
+            "type": "Fs.Fox.Basal.WindowsAPI+KeyboardHookStruct",
+            "recordCount": 8,
+            "contractSha256": "c175f9e10d5d541cc065ce4295cca4261f2d13c3dd5f4a4c3dbf065a8777aee3"
+          },
+          {
+            "type": "Fs.Fox.Basal.WindowsAPI+Point3D",
+            "recordCount": 13,
+            "contractSha256": "72e089d8029a6d813f1216d93326cb5ad27c3c0edfb1a67b6a4f544becb8c4fd"
+          },
+          {
+            "type": "Fs.Fox.Basal.WM",
+            "recordCount": 122,
+            "contractSha256": "c9dbcc9dcab7efccdeb3afc398098b55b35205f0c72eac6826e2334e067b2cbe"
+          },
+          {
+            "type": "Fs.Fox.Basal.WS",
+            "recordCount": 51,
+            "contractSha256": "b85848b39ac568b83b526b53cf61cc15419190ccb6af7bd0fb4e5420eed7ae45"
+          },
+          {
+            "type": "Fs.Fox.Cad.AcadPeEnum",
+            "recordCount": 6,
+            "contractSha256": "ee9c1f62ddc81aa4a657d85dd420adf7a23d381cc13027b83b35cae41db2699a"
+          },
+          {
+            "type": "Fs.Fox.Cad.AcadPeInfo",
+            "recordCount": 12,
+            "contractSha256": "7c787cda61cb60177d5cfc0010e7d6944820179f9eddf8215fba97ebcb431097"
+          },
+          {
+            "type": "Fs.Fox.Cad.AcPreferences",
+            "recordCount": 1,
+            "contractSha256": "08f7e98479c23f3056f9a6b681109a64f5d2dfe754c13a7879ca648bd477e5e2"
+          },
+          {
+            "type": "Fs.Fox.Cad.AcPreferences+Display",
+            "recordCount": 76,
+            "contractSha256": "77790ad25685bc31b2f41b5cc8171bdea3a555ae780630fbe223a700a088bbec"
+          },
+          {
+            "type": "Fs.Fox.Cad.ArcEx",
+            "recordCount": 5,
+            "contractSha256": "cb9ef4924f797b264dcf08b04d9f83e078de4c6ff92680d320fcd92866618079"
+          },
+          {
+            "type": "Fs.Fox.Cad.AssemInfo",
+            "recordCount": 7,
+            "contractSha256": "490d411d643f699a40aa104dc41327e4ce881fac717e7118d9f1bab71995e568"
+          },
+          {
+            "type": "Fs.Fox.Cad.AssemLoadType",
+            "recordCount": 5,
+            "contractSha256": "6207205f86dc5a3f75eca9afc3c37baa874bde1437cb116fbc9c0334c2820126"
+          },
+          {
+            "type": "Fs.Fox.Cad.AutoReflection",
+            "recordCount": 5,
+            "contractSha256": "e3ea17af04dbe78fc1fffb28810f6bafd9b439e864fb038453a060e0214a19c1"
+          },
+          {
+            "type": "Fs.Fox.Cad.AutoReg",
+            "recordCount": 7,
+            "contractSha256": "342c917b1a1f879e090c1ca59fa322c37b3e6fed91aa56eea40ff77456bca1c5"
+          },
+          {
+            "type": "Fs.Fox.Cad.AutoRegAssem",
+            "recordCount": 10,
+            "contractSha256": "9c9cbb36689b540b0805a2acbd27b8f64e6db3e1f65472e2595180ef4a7a70ef"
+          },
+          {
+            "type": "Fs.Fox.Cad.AutoRegConfig",
+            "recordCount": 8,
+            "contractSha256": "c9982c1e28610fab72752096cf0b926134a54ef71809dd286c06b961c5be35df"
+          },
+          {
+            "type": "Fs.Fox.Cad.BaseEx",
+            "recordCount": 2,
+            "contractSha256": "5835442b10982b6f5ded05775fabdbafe45896b72c9e4924b86dda14089ad1bb"
+          },
+          {
+            "type": "Fs.Fox.Cad.BlockReferenceEx",
+            "recordCount": 16,
+            "contractSha256": "0acd6af9177a891abe23f8acf0d80412edc5514c8875b7c5e9a0022b0e75ba30"
+          },
+          {
+            "type": "Fs.Fox.Cad.BlockVisibilityInfo",
+            "recordCount": 11,
+            "contractSha256": "1617abe3cfefe47e81fea5cfd552d335e7ac78b7c06cf54547081b796ac66bf7"
+          },
+          {
+            "type": "Fs.Fox.Cad.BoundingBox9",
+            "recordCount": 45,
+            "contractSha256": "7124a745d1f7b8ee3e71a363b8903e4eb8e6e4c11e24db8bf1198179d5dc839e"
+          },
+          {
+            "type": "Fs.Fox.Cad.BrightEditor",
+            "recordCount": 7,
+            "contractSha256": "17cb91e16a8a422fb9cef1e9d733f3bf413e074ebea48a1407b295da40417d66"
+          },
+          {
+            "type": "Fs.Fox.Cad.BrightEntity",
+            "recordCount": 10,
+            "contractSha256": "b5adc602bcb8a226aa351d5bbd8a0e7430be283896316b84146d79a83aec4d74"
+          },
+          {
+            "type": "Fs.Fox.Cad.BulgeVertexWidth",
+            "recordCount": 14,
+            "contractSha256": "d754323c16bc6039e1cf2301f2b0cfa038a2235f1d6b445a376f42cba4adb6b1"
+          },
+          {
+            "type": "Fs.Fox.Cad.CircleEx",
+            "recordCount": 4,
+            "contractSha256": "3ff949587dc1787e1f2cb60a24931f083b45d861c83a3f22d6e0e04c9b1fe93b"
+          },
+          {
+            "type": "Fs.Fox.Cad.CollectionEx",
+            "recordCount": 17,
+            "contractSha256": "25748b9fcba1d1652111d4aeb72fe7b488ca885db865738a11fbb1f0943ca9aa"
+          },
+          {
+            "type": "Fs.Fox.Cad.CollectionEx+KeywordName",
+            "recordCount": 5,
+            "contractSha256": "0e476eb404cae5ec16980c3a70f32e124deb91fc4049e9b798a214aa5c2491ef"
+          },
+          {
+            "type": "Fs.Fox.Cad.CoordinateSystemCode",
+            "recordCount": 6,
+            "contractSha256": "21d78d42bd0ba2b7bddd7f3cb9f5b2d63ae52cf0af4bab5dea19242b929b8006"
+          },
+          {
+            "type": "Fs.Fox.Cad.Curve2dEx",
+            "recordCount": 16,
+            "contractSha256": "fec5ad670f3c087ff4c78c9d125f5a4e32ce5ea25d528acab40cf0c30d9b7c77"
+          },
+          {
+            "type": "Fs.Fox.Cad.Curve3dEx",
+            "recordCount": 21,
+            "contractSha256": "b07fa7207265d6635211d57b7acf526972320460712e1cb3e8ae502ad9c2095e"
+          },
+          {
+            "type": "Fs.Fox.Cad.CurveEx",
+            "recordCount": 30,
+            "contractSha256": "6d5c160bf0bfcd354bb13e5e5383a20d0f1b4fb96cff140009762fc0ded14777"
+          },
+          {
+            "type": "Fs.Fox.Cad.DatabaseEx",
+            "recordCount": 4,
+            "contractSha256": "e14770c7f545e70ffe5021954ddf7c13416aea3c6b5797b4551b8b08f66e7fde"
+          },
+          {
+            "type": "Fs.Fox.Cad.DBDictionaryEx",
+            "recordCount": 17,
+            "contractSha256": "71f038f076172af9935c9dd819af9a8dd8e3c0c6b4fafc3a619a163d59931e72"
+          },
+          {
+            "type": "Fs.Fox.Cad.DBmod",
+            "recordCount": 8,
+            "contractSha256": "41fd10e14be804efcaaf2ba78dc834b1b42d3edf052f7193f62609c7c0cb803e"
+          },
+          {
+            "type": "Fs.Fox.Cad.DBmodEx",
+            "recordCount": 7,
+            "contractSha256": "34c9958880c752cecb15a83d0e5342a01ded0fbcc333f67fc18dd05d79890e53"
+          },
+          {
+            "type": "Fs.Fox.Cad.DBObjectEx",
+            "recordCount": 8,
+            "contractSha256": "cda6bae18b8511d86b77a50ae12996c22ada1aaa67122fbf0c902f4d9b75e34f"
+          },
+          {
+            "type": "Fs.Fox.Cad.DBObjectEx+UpgradeOpenManager",
+            "recordCount": 2,
+            "contractSha256": "eb5b41894fa7dae9db8a95405bd7db6d8ae5e6fdc96c84cf02c0d2fc81a8521a"
+          },
+          {
+            "type": "Fs.Fox.Cad.DBTextEx",
+            "recordCount": 3,
+            "contractSha256": "031a0bc06f0fad4224b8f73962a44ffeba6f757aaf5704569277fcef6f912878"
+          },
+          {
+            "type": "Fs.Fox.Cad.DBTrans",
+            "recordCount": 77,
+            "contractSha256": "9c8c1994bf2c34539366d2de0148f5ab06673f7eb60025117e588a845c0d4b87"
+          },
+          {
+            "type": "Fs.Fox.Cad.DBTransEx",
+            "recordCount": 2,
+            "contractSha256": "e902b23084197a04ee9df3d889a667ada7b40505e10eb372a1d7356d42fe910d"
+          },
+          {
+            "type": "Fs.Fox.Cad.DocumentLockManager",
+            "recordCount": 4,
+            "contractSha256": "040a34bf9cdd72c76711e4074b8b38c160753e675b476370b2fb2a55dcc37e0f"
+          },
+          {
+            "type": "Fs.Fox.Cad.DocumentLockManagerExtension",
+            "recordCount": 2,
+            "contractSha256": "4abe7522989adbe80a2ec05632c9cca0cd1b116df0544de9c903e80372653aff"
+          },
+          {
+            "type": "Fs.Fox.Cad.DosHeader",
+            "recordCount": 23,
+            "contractSha256": "44ba4b052a82acd688c36308f576f4f66580a041f9054738b4f32583a285dd38"
+          },
+          {
+            "type": "Fs.Fox.Cad.DosStub",
+            "recordCount": 5,
+            "contractSha256": "ac8c134727febdc5e14f51c14eb0e1d8ac8f20160e2cc6e9cfde106ac4dfcddc"
+          },
+          {
+            "type": "Fs.Fox.Cad.DwgMark",
+            "recordCount": 4,
+            "contractSha256": "d7e4e904d44eac02f2f5366b901761d87dce1d8f86ad97957d6b738450971034"
+          },
+          {
+            "type": "Fs.Fox.Cad.EditorEx",
+            "recordCount": 45,
+            "contractSha256": "b5b656a4ce5c7ff0cd3784942feb6eadf0d6044c662575ca5006ae677a83224d"
+          },
+          {
+            "type": "Fs.Fox.Cad.EditorEx+RunLispFlag",
+            "recordCount": 5,
+            "contractSha256": "74be99d96511b543df75ff5f8c51dd4df9215c19b3f623ef1ab9907c7e58de58"
+          },
+          {
+            "type": "Fs.Fox.Cad.EntityEx",
+            "recordCount": 12,
+            "contractSha256": "32b1b9fd37e4f98f159d01265b40bb6fc412e9fc0380974ae7d0d44619840bc4"
+          },
+          {
+            "type": "Fs.Fox.Cad.Env",
+            "recordCount": 53,
+            "contractSha256": "1ea02969ebf03fac2b580bbe5a992fdfb74654022d932602a46841e98091bdde"
+          },
+          {
+            "type": "Fs.Fox.Cad.Env+DimblkType",
+            "recordCount": 22,
+            "contractSha256": "cb48f90659b636bc212a50288746a474e9d8bf538e98370218dcc74cf358c533"
+          },
+          {
+            "type": "Fs.Fox.Cad.Env+OSModeType",
+            "recordCount": 17,
+            "contractSha256": "a57d84d6128fa4d0aebf46c15b8cddace4586c279e9c2db58664ded73ff53de9"
+          },
+          {
+            "type": "Fs.Fox.Cad.ErrorInfoEx",
+            "recordCount": 1,
+            "contractSha256": "97e4447eff291fab9e90167c13dc90eac8f76788e2bee5e38862964d9e7094d8"
+          },
+          {
+            "type": "Fs.Fox.Cad.ExportDirectory",
+            "recordCount": 20,
+            "contractSha256": "f4b2f0c1fca5d1da34d1d6ffa738dd512ef7d5a7c2b3a05ff9a7d395186e43f9"
+          },
+          {
+            "type": "Fs.Fox.Cad.FontTTF",
+            "recordCount": 7,
+            "contractSha256": "fe7bdc88937dec1d667324c4ee0a7f1b142407eadae4543f6f4d0ccc56e64294"
+          },
+          {
+            "type": "Fs.Fox.Cad.GeometryEx",
+            "recordCount": 26,
+            "contractSha256": "e4cf1a9e9e5066061ed4565b427c6294a9eaa9d507c9c6d0102b9d96d3ba2a0a"
+          },
+          {
+            "type": "Fs.Fox.Cad.GetMethodErrorNum",
+            "recordCount": 5,
+            "contractSha256": "ba67e854a6ae17a7a473473e7cfc3f9125d8bc8f9af0f748cba016331f4d8a3c"
+          },
+          {
+            "type": "Fs.Fox.Cad.GetPeMethodException",
+            "recordCount": 7,
+            "contractSha256": "bcb21ec8b39f2534aac2826faae1f39fb15392c6b26c99f26c609cc4791da539"
+          },
+          {
+            "type": "Fs.Fox.Cad.HatchConverter",
+            "recordCount": 9,
+            "contractSha256": "c87b91d8972ab4bdeb72f7d395bf470c118ebdb488d778d56046328de0868460"
+          },
+          {
+            "type": "Fs.Fox.Cad.HatchEx",
+            "recordCount": 5,
+            "contractSha256": "4d17e1142e9e818e0127a139f95ba4b11fc1387547d0d409005388e87d62b8ff"
+          },
+          {
+            "type": "Fs.Fox.Cad.HatchInfo",
+            "recordCount": 12,
+            "contractSha256": "e9e5b85123013ae21b7388d6e4ddd75e2de40a466ce162d01ac1d839e3d8e895"
+          },
+          {
+            "type": "Fs.Fox.Cad.HatchInfo+GradientName",
+            "recordCount": 11,
+            "contractSha256": "7c6ae7c0a32a06c7a856c2119e91afaf7805f34f6fe430ad39113b0a7488899e"
+          },
+          {
+            "type": "Fs.Fox.Cad.IdleAction",
+            "recordCount": 4,
+            "contractSha256": "0929683bd6f4b38ade8f79e3a2398cc497be30d4b5d1272c5a720a50dc9442ab"
+          },
+          {
+            "type": "Fs.Fox.Cad.IdleNoCmdAction",
+            "recordCount": 4,
+            "contractSha256": "310a3f61097f8dbfec1148c9f2918c88cb8518acc246a4b01dd5caacd84eab6a"
+          },
+          {
+            "type": "Fs.Fox.Cad.IFoxAutoGo",
+            "recordCount": 4,
+            "contractSha256": "1b8dbb4c3ef3da9f8cdb4213157e1733460257d32140ff7114b9f091b15055c8"
+          },
+          {
+            "type": "Fs.Fox.Cad.IFoxInitializeAttribute",
+            "recordCount": 2,
+            "contractSha256": "054ed97e0f085f66e0c92fe5ab96f5977fa2a668cb77b9ca42d09c1ff723b442"
+          },
+          {
+            "type": "Fs.Fox.Cad.IFoxUtils",
+            "recordCount": 6,
+            "contractSha256": "839482ba7efed99e8ea490f03a001b0958cd8e9c732a7b3d865e3d402b76553b"
+          },
+          {
+            "type": "Fs.Fox.Cad.ImportDirectory",
+            "recordCount": 5,
+            "contractSha256": "6d4e5a55e97439ea86f6957a78bb7a9604ec597569276baf6599018b9cf61413"
+          },
+          {
+            "type": "Fs.Fox.Cad.ImportDirectory+ImportDate",
+            "recordCount": 9,
+            "contractSha256": "f30ae2a6abbb81fcb19882b9da3677735eda4b9406bdbef84a3ff14084452d79"
+          },
+          {
+            "type": "Fs.Fox.Cad.ImportDirectory+ImportDate+FunctionList",
+            "recordCount": 5,
+            "contractSha256": "88d28bc2401b5c285439d221f2569b75da85fb4f79e4e69321bbac72680e26cd"
+          },
+          {
+            "type": "Fs.Fox.Cad.IXrefBindModes",
+            "recordCount": 5,
+            "contractSha256": "69cde853405c248356844326fdcb11242b383438fa4164066a8716c7e975ced6"
+          },
+          {
+            "type": "Fs.Fox.Cad.JigEx",
+            "recordCount": 22,
+            "contractSha256": "97eca7efc5f9aefe7722c1a2b9083159e6cfae1c1d03da657e2f7239276654ce"
+          },
+          {
+            "type": "Fs.Fox.Cad.KeywordException",
+            "recordCount": 4,
+            "contractSha256": "437cec6478060a228d3581fd9d650d191b39f4b6f8503ff0165cc937b7d78cde"
+          },
+          {
+            "type": "Fs.Fox.Cad.LispList",
+            "recordCount": 23,
+            "contractSha256": "046042e196ff1ad9ba62bb04020d09ca724a05d2f5b42e6cd500b11605ca743b"
+          },
+          {
+            "type": "Fs.Fox.Cad.MTextEx",
+            "recordCount": 4,
+            "contractSha256": "33c7d00c0a6931a1758bd10f8193730b8ba9a24bcc9339ffe225e0ba44368140"
+          },
+          {
+            "type": "Fs.Fox.Cad.ObjectIdEx",
+            "recordCount": 11,
+            "contractSha256": "7df3061c49edaa22846f161ba4212419b57c7655e5572d91bcc3e7497726f735"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpAnd",
+            "recordCount": 5,
+            "contractSha256": "647a2ddfec1dfdd9114a0272b28c7b85a997c5a581fcec760df281c115551a16"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpComp",
+            "recordCount": 10,
+            "contractSha256": "441483ecac5751ff5b8bca84dd9a1ff5200d841f6a41441da7bcaf58f61cdd6c"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpEqual",
+            "recordCount": 11,
+            "contractSha256": "ea8f1a76cbb3f49120a4b592e371dbb6955f00d6cce3e1f164d99efa7ca90aa9"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpFilter",
+            "recordCount": 12,
+            "contractSha256": "2a2f0454f836ecb1476438d533abea9027b35b63595adb03a5d4206df197e6be"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpFilter+Op",
+            "recordCount": 19,
+            "contractSha256": "2267c6ebf368cd4fbff721b512f7ad541c252c68c236e1f07cf4535a8d1112ca"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpList",
+            "recordCount": 10,
+            "contractSha256": "2be39dbfcb94201de3d2394ee3e59ad27b29f2d40c7cbfdf8fc27979e3830ba8"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpLogi",
+            "recordCount": 8,
+            "contractSha256": "5a9bda3e8d6169cfd1721b3d39cd3fcf14171262d5edbcfb4ec8d3904603f90c"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpNot",
+            "recordCount": 5,
+            "contractSha256": "f819b281307ecf5e852aeb8a0817c89907a59dc72a66f30474fe9440b398cd78"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpOr",
+            "recordCount": 5,
+            "contractSha256": "eaf398f8ee49bac5b780a942242bba5f2a044e5e3e61abbadce37c91b432b9be"
+          },
+          {
+            "type": "Fs.Fox.Cad.OptionalDirAttrib",
+            "recordCount": 5,
+            "contractSha256": "6bf57fa16f1dcfb0605a9e700c9b1ad2297a0b2a69d6df7cad94342d166de893"
+          },
+          {
+            "type": "Fs.Fox.Cad.OptionalDirAttrib+DirAttrib",
+            "recordCount": 4,
+            "contractSha256": "5c29496695e3e4adee852c90b21e923ea476963725abab6c11b150c19ae42cb9"
+          },
+          {
+            "type": "Fs.Fox.Cad.OptionalHeader",
+            "recordCount": 34,
+            "contractSha256": "428f458c886080c0e77007dd30cfc0cde3a6ed9cfc2fa4bb1a2cdbea6b328935"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpXor",
+            "recordCount": 9,
+            "contractSha256": "afe3ae0e17e86d1bc7a21747315f97597f9b173a553b82a3f0fea6f7b9e82ffe"
+          },
+          {
+            "type": "Fs.Fox.Cad.OrientationType",
+            "recordCount": 5,
+            "contractSha256": "d7c4ea950ef18a717f1423415ab5bd5d06c1fd6635e4ca10a371ca13f20a6226"
+          },
+          {
+            "type": "Fs.Fox.Cad.PaneEx",
+            "recordCount": 4,
+            "contractSha256": "ec07dda70874bc76b1c0e4129d6d273bd8e239fb8503c19637688956e52c2da9"
+          },
+          {
+            "type": "Fs.Fox.Cad.PaneMarginType",
+            "recordCount": 5,
+            "contractSha256": "dbcd9022d6f39faf0b81a2b120d9398c9a1049ab653c9da93c2b7240152baa5c"
+          },
+          {
+            "type": "Fs.Fox.Cad.PathConverterModes",
+            "recordCount": 4,
+            "contractSha256": "2cbf8f3679a1f78960c03e4d3f39732631b38fd93aefd40f21890f3763314f4c"
+          },
+          {
+            "type": "Fs.Fox.Cad.PeFunction",
+            "recordCount": 9,
+            "contractSha256": "93b603c4e1ae5ead084bab15c6ccfdf69ddbbef51d11a9c1855bac1a560e144c"
+          },
+          {
+            "type": "Fs.Fox.Cad.PEHeader",
+            "recordCount": 12,
+            "contractSha256": "acff68645a4be0f807ca624cf2334a0514ac233df77ace6b88711773c82c1977"
+          },
+          {
+            "type": "Fs.Fox.Cad.PeInfo",
+            "recordCount": 24,
+            "contractSha256": "3a3228b22beaba7f867aeabcb9b13229c5d35da47dd766b71be270f05b7ae3c6"
+          },
+          {
+            "type": "Fs.Fox.Cad.PlaneEx",
+            "recordCount": 4,
+            "contractSha256": "ae986d7765d474a18cc935dbcf6c696574db09fe765a4bb97a7ee286e39c32c4"
+          },
+          {
+            "type": "Fs.Fox.Cad.PointEx",
+            "recordCount": 22,
+            "contractSha256": "28ef136750a626537da612c66624190927725e1d6b1d78c2223b5389e9da7fdb"
+          },
+          {
+            "type": "Fs.Fox.Cad.PointOnRegionType",
+            "recordCount": 6,
+            "contractSha256": "4e9c7e1e10993792aabb0446c0ed8db277a92b7235f93eec63c4a0f47c70598a"
+          },
+          {
+            "type": "Fs.Fox.Cad.PolylineEx",
+            "recordCount": 9,
+            "contractSha256": "c48bfdefb465abe0538f6a47fcb2c38a6d1dabfd08471dae9cf0b586d93790a5"
+          },
+          {
+            "type": "Fs.Fox.Cad.PostCmd",
+            "recordCount": 5,
+            "contractSha256": "7ca938ddd47bfa1b66f48c42a199a7e418f3b2a3629ce41731912f1990c35605"
+          },
+          {
+            "type": "Fs.Fox.Cad.PostCmd+RunCmdFlag",
+            "recordCount": 8,
+            "contractSha256": "0097d44610c88fa68ba25c6c7a915bcd84b5747b5a8fcf3f51afcaebed7c4e56"
+          },
+          {
+            "type": "Fs.Fox.Cad.ProgressMeterUtils",
+            "recordCount": 4,
+            "contractSha256": "dab4f5465f7273921e317cb54322c73741d0c41809f00a78d71251f57a687ccf"
+          },
+          {
+            "type": "Fs.Fox.Cad.PromptOptionsEx",
+            "recordCount": 3,
+            "contractSha256": "77cdfc7852e8b503c14aceb80560aa40fedf24d7963b01b3a95e222624dc90ae"
+          },
+          {
+            "type": "Fs.Fox.Cad.QuadEntity",
+            "recordCount": 2,
+            "contractSha256": "7adcc8e9ed7bc9ee99333b616fa37a8d7c408f35e3b199e773ffe91fbc226d76"
+          },
+          {
+            "type": "Fs.Fox.Cad.QuadTree`1",
+            "recordCount": 11,
+            "contractSha256": "21a15914f7e3da9debe0a1af7fde7e03fe802ed07c91114348ff76aed9c1f74e"
+          },
+          {
+            "type": "Fs.Fox.Cad.QuadTree`1+QTAction",
+            "recordCount": 5,
+            "contractSha256": "a09ffed07030472139cfd18ebc6290198571c0bc93b3486cb94e69c0a591ddfd"
+          },
+          {
+            "type": "Fs.Fox.Cad.QuadTreeEvn",
+            "recordCount": 6,
+            "contractSha256": "d529384dfd39c5461d45c00ec1af273c560d82c952a28cd11b7fb0bc348d14f4"
+          },
+          {
+            "type": "Fs.Fox.Cad.QuadTreeFindMode",
+            "recordCount": 6,
+            "contractSha256": "30746341b43d57f6687e13cae74eba3e91eb18503c86a0f02301e1dc49742aca"
+          },
+          {
+            "type": "Fs.Fox.Cad.QuadTreeNode`1",
+            "recordCount": 19,
+            "contractSha256": "dba1b8ef041c52685f650f05f9761ee6a14dd6097873ed5850defb44a8d2e073"
+          },
+          {
+            "type": "Fs.Fox.Cad.QuadTreeSelectMode",
+            "recordCount": 4,
+            "contractSha256": "0771682ace891ef1b83449332623089b118d71a884a474bcbfb4a3e42f6e8dfe"
+          },
+          {
+            "type": "Fs.Fox.Cad.Rect",
+            "recordCount": 76,
+            "contractSha256": "efd0ed98611443d849d72eb93a960eb85365e41d77bb340dad1b57ddd577eb1a"
+          },
+          {
+            "type": "Fs.Fox.Cad.RedrawEx",
+            "recordCount": 4,
+            "contractSha256": "77ee09a048a82ece1bfbcb0bc3978d1e7db07d234d3bd224ec6e89723adafb69"
+          },
+          {
+            "type": "Fs.Fox.Cad.RegionEx",
+            "recordCount": 1,
+            "contractSha256": "2a3ea2cdc67062eaa6c818a34b35e92da061e9d666c0ee0d2a209f68b0df1637"
+          },
+          {
+            "type": "Fs.Fox.Cad.ResourceDirectory",
+            "recordCount": 12,
+            "contractSha256": "6d3111fb3d171365ba3f3cf92d16db41375468516d14f60df9184f193797894e"
+          },
+          {
+            "type": "Fs.Fox.Cad.ResourceDirectory+DirectoryEntry",
+            "recordCount": 6,
+            "contractSha256": "7c55ce5d6319c5e051f71b6156b65cd7f6f6006909d7dd428cb70cbe72b69f8a"
+          },
+          {
+            "type": "Fs.Fox.Cad.ResourceDirectory+DirectoryEntry+DataEntry",
+            "recordCount": 8,
+            "contractSha256": "76fc0a678f9a6a27e70c97bbf91420564f7c5197025bb589a5c30396f10d6e39"
+          },
+          {
+            "type": "Fs.Fox.Cad.SectionTable",
+            "recordCount": 5,
+            "contractSha256": "d97c1a5ce63dbfc5806f02447006e1f4b57da24c62533394c829eec97d63941c"
+          },
+          {
+            "type": "Fs.Fox.Cad.SectionTable+SectionData",
+            "recordCount": 12,
+            "contractSha256": "552f4d52375559327a891b0ca04d8adbe221c54b943f0f93761faa87d05366bb"
+          },
+          {
+            "type": "Fs.Fox.Cad.SelectionSetEx",
+            "recordCount": 6,
+            "contractSha256": "a9eb706bcc3217294ae2b21d8b4dde6c0d3a382fd0ff378886497c53cf13d409"
+          },
+          {
+            "type": "Fs.Fox.Cad.Sequence",
+            "recordCount": 4,
+            "contractSha256": "3e9b1f2e90efca4ded4a0680eadbe208d221ff8c852759b9edfca9daf8c6959b"
+          },
+          {
+            "type": "Fs.Fox.Cad.SingleKeyWordHook",
+            "recordCount": 19,
+            "contractSha256": "1559055dd288416aadf284a8021726776e5c0f326f547b6e2cbff1f795d6988a"
+          },
+          {
+            "type": "Fs.Fox.Cad.SingleKeywordHookEx",
+            "recordCount": 2,
+            "contractSha256": "2c7c0ba90e94e201b91b13c5ba958349a8d7b81a886442287a3bc4fa72ed14ca"
+          },
+          {
+            "type": "Fs.Fox.Cad.SingleKeyWordWorkType",
+            "recordCount": 5,
+            "contractSha256": "eb237fe3f969148d0611fbdffcd6bb8f329bb322b2b2ae02d559ef994b0d8fcf"
+          },
+          {
+            "type": "Fs.Fox.Cad.SwitchDatabase",
+            "recordCount": 3,
+            "contractSha256": "37eee5386ac64171ad42856819d80c3288ba6ef8b84242d3e41e464f8e619050"
+          },
+          {
+            "type": "Fs.Fox.Cad.SymbolTable`2",
+            "recordCount": 23,
+            "contractSha256": "8481b4cbc54736a40b3da6e0aaf53196270f0a1583f6fde315804aa3be90e42e"
+          },
+          {
+            "type": "Fs.Fox.Cad.SymbolTableEx",
+            "recordCount": 16,
+            "contractSha256": "1d287bbc1e767237d8bab0dc4858d1e65cf2fd2da557a829ee074e24672be98a"
+          },
+          {
+            "type": "Fs.Fox.Cad.SymbolTableRecordEx",
+            "recordCount": 15,
+            "contractSha256": "4c6dd7a926bdf969f1e5f5a723c11cd5587d902d34aae6bd4898d067d797b9d1"
+          },
+          {
+            "type": "Fs.Fox.Cad.SymModes",
+            "recordCount": 14,
+            "contractSha256": "90a4b221afe17637bca4d2820730ed2da92469b3ace38563b974469fec036bb0"
+          },
+          {
+            "type": "Fs.Fox.Cad.SystemVariableManager",
+            "recordCount": 106,
+            "contractSha256": "2906d187c8087ba54c454a66afd9f08add9e0d9844feccce48a919c602b5de22"
+          },
+          {
+            "type": "Fs.Fox.Cad.TangentEx",
+            "recordCount": 2,
+            "contractSha256": "d38aa9cda156c7ca0091781e679e97eff4509fbcf20a179c6448925262e1148b"
+          },
+          {
+            "type": "Fs.Fox.Cad.TolerancePoint2d",
+            "recordCount": 4,
+            "contractSha256": "13374884d34cf79bc7bb42aa0f91468d0c2db4a689dfc6894600cfd7d2871df1"
+          },
+          {
+            "type": "Fs.Fox.Cad.TransactionEx",
+            "recordCount": 3,
+            "contractSha256": "9c0c0397a0fcd4dca7851854e4fbfc054b73fb0ee55dd5511e66537eb89f9a8d"
+          },
+          {
+            "type": "Fs.Fox.Cad.TypedValueList",
+            "recordCount": 9,
+            "contractSha256": "ef826aa5c376cdfa772de165d1efea76c6f15095db822ad4353b2ea891706cdd"
+          },
+          {
+            "type": "Fs.Fox.Cad.VectorEx",
+            "recordCount": 7,
+            "contractSha256": "5ea0ad031242ad92c4628cd5690a2d863b8628fff6ce10d8a87d8e53753fad27"
+          },
+          {
+            "type": "Fs.Fox.Cad.WindowEx",
+            "recordCount": 6,
+            "contractSha256": "e3ad7c49060ce3498bf756cb5d987ca711a13c19bcae60c26f3b3e1a997349db"
+          },
+          {
+            "type": "Fs.Fox.Cad.WorldDrawEvent",
+            "recordCount": 5,
+            "contractSha256": "25f8e2cf36eb6580bd218c20255cb8c0373cc3e14d66c575f2a2e3ed267b6345"
+          },
+          {
+            "type": "Fs.Fox.Cad.XDataList",
+            "recordCount": 12,
+            "contractSha256": "3dfbc7160bbbba58c832aa02e41c3ee022f8f1db252b3e3824d85da2a3fcc552"
+          },
+          {
+            "type": "Fs.Fox.Cad.XRecordDataList",
+            "recordCount": 9,
+            "contractSha256": "361c3e0f81e2d52abc0a97bf11e886d067aa5f7d609d16bd7c053c764090e1ba"
+          },
+          {
+            "type": "Fs.Fox.Cad.XrefEx",
+            "recordCount": 2,
+            "contractSha256": "cb4046945c30706daf072b06d700dfb59a20394cdbe0bcfd824741e6139d0642"
+          },
+          {
+            "type": "Fs.Fox.Cad.XrefFactory",
+            "recordCount": 13,
+            "contractSha256": "425d05e1e32543e80e578417c17ff8f16769d0a0bb91d4f672891a1acbdd361a"
+          },
+          {
+            "type": "Fs.Fox.Cad.XrefModes",
+            "recordCount": 6,
+            "contractSha256": "8b0ebe1c2521ad862fc2a9902fc1b404df8ad9b342bb23a6ec2352b2d9ba97b9"
+          },
+          {
+            "type": "Fs.Fox.Cad.XrefPath",
+            "recordCount": 14,
+            "contractSha256": "3492c0326e7e4114ac26a6052c4a92963c1ed43a9bc3016dc8fe8ca9af24aa01"
+          }
+        ]
+      },
+      "package": {
+        "id": "IFox.CAD.GCAD2022",
+        "version": "0.9.2-preview6",
+        "repository": {
+          "type": "git",
+          "url": "https://github.com/FsDiG/Fs.Fox.CAD.git"
+        },
+        "dependencies": [
+          {
+            "targetFramework": ".NETFramework4.8",
+            "items": [
+              {
+                "id": "GStarCad.Net",
+                "version": "20.22.0",
+                "include": "",
+                "exclude": "Runtime,Build,Analyzers"
+              }
+            ]
+          }
+        ],
+        "frameworkReferences": [],
+        "assets": [
+          {
+            "path": "GlobalUsings.cs",
+            "length": 6290,
+            "hashKind": "raw-sha256",
+            "contentSha256": "fb44c605d38fc6a9bbad1fc7e743ade33a3dffc293cd3defc7e21435b072daa6",
+            "binarySource": null
+          },
+          {
+            "path": "lib/net48/Fs.Fox.Gcad.dll",
+            "length": null,
+            "hashKind": "matches-build-output-sha256",
+            "contentSha256": null,
+            "binarySource": "Build/GC_2022_Release/Fs.Fox.Gcad.dll"
+          },
+          {
+            "path": "lib/net48/Fs.Fox.Gcad.xml",
+            "length": 474999,
+            "hashKind": "canonical-xml-v1",
+            "contentSha256": "e09d49eab2c4e72d65785eaa9b0b30f2a01329fd6365949d46614cdde48c8d4d",
+            "binarySource": null
+          },
+          {
+            "path": "lib/net48/TestGcad2022.dll",
+            "length": null,
+            "hashKind": "matches-build-output-sha256",
+            "contentSha256": null,
+            "binarySource": "Build/GC_2022_Release/TestGcad2022.dll"
+          },
+          {
+            "path": "LICENSE",
+            "length": 1091,
+            "hashKind": "raw-sha256",
+            "contentSha256": "a2943fc061379a06f57c4a7ea027980ffd3b1f29488cb00519402fd27113d3fd",
+            "binarySource": null
+          },
+          {
+            "path": "readme.md",
+            "length": 7873,
+            "hashKind": "raw-sha256",
+            "contentSha256": "00ccca236e22a69663270c28e1fd111575561d3708e5ff863b469273cbdc9b9a",
+            "binarySource": null
+          }
+        ]
+      }
+    },
+    {
+      "name": "GC_2023",
+      "assembly": {
+        "identity": {
+          "name": "Fs.Fox.Gcad",
+          "version": "0.9.2.0",
+          "culture": "",
+          "publicKeyToken": ""
+        },
+        "references": [
+          {
+            "name": "gmap",
+            "version": "1.0.8441.23956",
+            "culture": "",
+            "publicKeyOrToken": "",
+            "flags": 0
+          },
+          {
+            "name": "gmdb",
+            "version": "3.5.0.23944",
+            "culture": "",
+            "publicKeyOrToken": "",
+            "flags": 0
+          },
+          {
+            "name": "Microsoft.CSharp",
+            "version": "4.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b03f5f7f11d50a3a",
+            "flags": 0
+          },
+          {
+            "name": "mscorlib",
+            "version": "4.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b77a5c561934e089",
+            "flags": 0
+          },
+          {
+            "name": "PresentationCore",
+            "version": "4.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "31bf3856ad364e35",
+            "flags": 0
+          },
+          {
+            "name": "PresentationFramework",
+            "version": "4.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "31bf3856ad364e35",
+            "flags": 0
+          },
+          {
+            "name": "System",
+            "version": "4.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b77a5c561934e089",
+            "flags": 0
+          },
+          {
+            "name": "System.Core",
+            "version": "4.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b77a5c561934e089",
+            "flags": 0
+          },
+          {
+            "name": "System.Data",
+            "version": "4.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b77a5c561934e089",
+            "flags": 0
+          },
+          {
+            "name": "System.Drawing",
+            "version": "4.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b03f5f7f11d50a3a",
+            "flags": 0
+          },
+          {
+            "name": "System.Windows.Forms",
+            "version": "4.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b77a5c561934e089",
+            "flags": 0
+          },
+          {
+            "name": "WindowsBase",
+            "version": "4.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "31bf3856ad364e35",
+            "flags": 0
+          }
+        ],
+        "publicApiRecordCount": 2262,
+        "publicApi": [
+          {
+            "type": "Fs.Fox.Basal.ArgumentNullEx",
+            "recordCount": 2,
+            "contractSha256": "37ab9b08d69718b4850a40cf43c82340d6baf09836b548bd2b8f6745b127b2d9"
+          },
+          {
+            "type": "Fs.Fox.Basal.ArrayEx",
+            "recordCount": 3,
+            "contractSha256": "a7d7c30392cefc860eb668371ee65f531b692b01dc043cd691e9662a4f8cb1fc"
+          },
+          {
+            "type": "Fs.Fox.Basal.DebugEx",
+            "recordCount": 2,
+            "contractSha256": "e6e81cdbb92cacd0da7f4e8135c5bbbbe336a69164df4acf78320642f911c849"
+          },
+          {
+            "type": "Fs.Fox.Basal.EnumEx",
+            "recordCount": 6,
+            "contractSha256": "8f67523a6f5389fbd9d8aa065c8dc598037ae480ea1841cb992c2516aeec6815"
+          },
+          {
+            "type": "Fs.Fox.Basal.GetWindowCmd",
+            "recordCount": 9,
+            "contractSha256": "7f72f56c0d744ea607d715ae4dd5a68a74421bb414a27bca9f574943a7f1f607"
+          },
+          {
+            "type": "Fs.Fox.Basal.GWL",
+            "recordCount": 9,
+            "contractSha256": "96a77b6035380bca43533199e18d6841d36bf118d73f8c5edb0231748411e8a8"
+          },
+          {
+            "type": "Fs.Fox.Basal.HookType",
+            "recordCount": 18,
+            "contractSha256": "32f677ba3290ad90a17ec392e659ffa3b35bac63000ead25915bac3c85f677ff"
+          },
+          {
+            "type": "Fs.Fox.Basal.LinqEx",
+            "recordCount": 12,
+            "contractSha256": "fa41fee63890ca237f6ef3678480635849824b8e397f854d64f5e5d797f0cd7b"
+          },
+          {
+            "type": "Fs.Fox.Basal.LoopList`1",
+            "recordCount": 37,
+            "contractSha256": "7aab7667dbae54bfd47b4eda8d14d11b0cd1f79e3525ee5003c6d9e2c16f7e9a"
+          },
+          {
+            "type": "Fs.Fox.Basal.LoopListNode`1",
+            "recordCount": 10,
+            "contractSha256": "3914f5f56c2655f0d12445e25f8d585aaf3738f0789530cd912561fec0e8e1dd"
+          },
+          {
+            "type": "Fs.Fox.Basal.LoopState",
+            "recordCount": 17,
+            "contractSha256": "36f37eabec6a916404ddedec4817f221c39dc5a6f7b60c95c7e8459dbb02a506"
+          },
+          {
+            "type": "Fs.Fox.Basal.MOUSEEVENTF",
+            "recordCount": 11,
+            "contractSha256": "3a7d09836e1a3306ba58275281877537fa71113a79c30aae65acd2d2953ae53b"
+          },
+          {
+            "type": "Fs.Fox.Basal.NCmdShow",
+            "recordCount": 15,
+            "contractSha256": "62036a3e7697d2e0c22615b89b1daac246e9bcd77b7e399ffcd6d7cbb33e2fbe"
+          },
+          {
+            "type": "Fs.Fox.Basal.PInvokeUser32",
+            "recordCount": 24,
+            "contractSha256": "b92bde454918268e67be7cb66e7a65293152817ac038f4f6af3f6d720f8139dd"
+          },
+          {
+            "type": "Fs.Fox.Basal.PInvokeUser32+GuiThreadInfo",
+            "recordCount": 11,
+            "contractSha256": "4d0f4a1cc09dad6e83377bd7ae52224a729df768d0f7b44cc00f82dfcc49924f"
+          },
+          {
+            "type": "Fs.Fox.Basal.ProState",
+            "recordCount": 20,
+            "contractSha256": "f87608e21811e725f000fec4a608c6bcfe2f6013761565fb1a20691f13a24134"
+          },
+          {
+            "type": "Fs.Fox.Basal.RandomEx",
+            "recordCount": 16,
+            "contractSha256": "a54558ec16d423cbc9fd3ae53f4099d648cea39d1cfc63109f9b3a0f095d630d"
+          },
+          {
+            "type": "Fs.Fox.Basal.SC",
+            "recordCount": 6,
+            "contractSha256": "c093f92356be05017ebb765b18ebae11c97fb74ceb13c80214a5c7fefb1cc5fb"
+          },
+          {
+            "type": "Fs.Fox.Basal.SystemEx",
+            "recordCount": 3,
+            "contractSha256": "8f8d5b54f31c8a84e244984e8dabcfbd932db93d19bc2bbaafc1469d098b9e4b"
+          },
+          {
+            "type": "Fs.Fox.Basal.TH32CS",
+            "recordCount": 9,
+            "contractSha256": "f6851b16b314b43b3fa1cad9c8fec62d8f9231ab1722b21f874187b58b8f6361"
+          },
+          {
+            "type": "Fs.Fox.Basal.VK",
+            "recordCount": 153,
+            "contractSha256": "fc31ec9b483754682740786322d9c48239e31d0818d170683aa51b109a105624"
+          },
+          {
+            "type": "Fs.Fox.Basal.WindowsAPI",
+            "recordCount": 22,
+            "contractSha256": "a60d29b218040084cc7aa2138fc945bd2a3a213cdf858b44291487d0d6790282"
+          },
+          {
+            "type": "Fs.Fox.Basal.WindowsAPI+CallBack",
+            "recordCount": 5,
+            "contractSha256": "4c9148381c3b42b00153346d5ebf888834d21d021b82394e4514ee285666d082"
+          },
+          {
+            "type": "Fs.Fox.Basal.WindowsAPI+IntRect",
+            "recordCount": 23,
+            "contractSha256": "15cd54b1efab39cfbde8d7043400386fdf9082ea799563a6c1c62d9d16890565"
+          },
+          {
+            "type": "Fs.Fox.Basal.WindowsAPI+IntSize",
+            "recordCount": 5,
+            "contractSha256": "ef7f61c641181ab6eea9ec19152c95fec6cac28feb793daa2fdf32dde5ae3309"
+          },
+          {
+            "type": "Fs.Fox.Basal.WindowsAPI+KeyboardHookStruct",
+            "recordCount": 8,
+            "contractSha256": "c175f9e10d5d541cc065ce4295cca4261f2d13c3dd5f4a4c3dbf065a8777aee3"
+          },
+          {
+            "type": "Fs.Fox.Basal.WindowsAPI+Point3D",
+            "recordCount": 13,
+            "contractSha256": "72e089d8029a6d813f1216d93326cb5ad27c3c0edfb1a67b6a4f544becb8c4fd"
+          },
+          {
+            "type": "Fs.Fox.Basal.WM",
+            "recordCount": 122,
+            "contractSha256": "c9dbcc9dcab7efccdeb3afc398098b55b35205f0c72eac6826e2334e067b2cbe"
+          },
+          {
+            "type": "Fs.Fox.Basal.WS",
+            "recordCount": 51,
+            "contractSha256": "b85848b39ac568b83b526b53cf61cc15419190ccb6af7bd0fb4e5420eed7ae45"
+          },
+          {
+            "type": "Fs.Fox.Cad.AcadPeEnum",
+            "recordCount": 6,
+            "contractSha256": "ee9c1f62ddc81aa4a657d85dd420adf7a23d381cc13027b83b35cae41db2699a"
+          },
+          {
+            "type": "Fs.Fox.Cad.AcadPeInfo",
+            "recordCount": 12,
+            "contractSha256": "7c787cda61cb60177d5cfc0010e7d6944820179f9eddf8215fba97ebcb431097"
+          },
+          {
+            "type": "Fs.Fox.Cad.AcPreferences",
+            "recordCount": 1,
+            "contractSha256": "08f7e98479c23f3056f9a6b681109a64f5d2dfe754c13a7879ca648bd477e5e2"
+          },
+          {
+            "type": "Fs.Fox.Cad.AcPreferences+Display",
+            "recordCount": 76,
+            "contractSha256": "77790ad25685bc31b2f41b5cc8171bdea3a555ae780630fbe223a700a088bbec"
+          },
+          {
+            "type": "Fs.Fox.Cad.ArcEx",
+            "recordCount": 5,
+            "contractSha256": "cb9ef4924f797b264dcf08b04d9f83e078de4c6ff92680d320fcd92866618079"
+          },
+          {
+            "type": "Fs.Fox.Cad.AssemInfo",
+            "recordCount": 7,
+            "contractSha256": "490d411d643f699a40aa104dc41327e4ce881fac717e7118d9f1bab71995e568"
+          },
+          {
+            "type": "Fs.Fox.Cad.AssemLoadType",
+            "recordCount": 5,
+            "contractSha256": "6207205f86dc5a3f75eca9afc3c37baa874bde1437cb116fbc9c0334c2820126"
+          },
+          {
+            "type": "Fs.Fox.Cad.AutoReflection",
+            "recordCount": 5,
+            "contractSha256": "e3ea17af04dbe78fc1fffb28810f6bafd9b439e864fb038453a060e0214a19c1"
+          },
+          {
+            "type": "Fs.Fox.Cad.AutoReg",
+            "recordCount": 7,
+            "contractSha256": "342c917b1a1f879e090c1ca59fa322c37b3e6fed91aa56eea40ff77456bca1c5"
+          },
+          {
+            "type": "Fs.Fox.Cad.AutoRegAssem",
+            "recordCount": 10,
+            "contractSha256": "9c9cbb36689b540b0805a2acbd27b8f64e6db3e1f65472e2595180ef4a7a70ef"
+          },
+          {
+            "type": "Fs.Fox.Cad.AutoRegConfig",
+            "recordCount": 8,
+            "contractSha256": "c9982c1e28610fab72752096cf0b926134a54ef71809dd286c06b961c5be35df"
+          },
+          {
+            "type": "Fs.Fox.Cad.BaseEx",
+            "recordCount": 2,
+            "contractSha256": "5835442b10982b6f5ded05775fabdbafe45896b72c9e4924b86dda14089ad1bb"
+          },
+          {
+            "type": "Fs.Fox.Cad.BlockReferenceEx",
+            "recordCount": 16,
+            "contractSha256": "0acd6af9177a891abe23f8acf0d80412edc5514c8875b7c5e9a0022b0e75ba30"
+          },
+          {
+            "type": "Fs.Fox.Cad.BlockVisibilityInfo",
+            "recordCount": 11,
+            "contractSha256": "1617abe3cfefe47e81fea5cfd552d335e7ac78b7c06cf54547081b796ac66bf7"
+          },
+          {
+            "type": "Fs.Fox.Cad.BoundingBox9",
+            "recordCount": 45,
+            "contractSha256": "7124a745d1f7b8ee3e71a363b8903e4eb8e6e4c11e24db8bf1198179d5dc839e"
+          },
+          {
+            "type": "Fs.Fox.Cad.BrightEditor",
+            "recordCount": 7,
+            "contractSha256": "17cb91e16a8a422fb9cef1e9d733f3bf413e074ebea48a1407b295da40417d66"
+          },
+          {
+            "type": "Fs.Fox.Cad.BrightEntity",
+            "recordCount": 10,
+            "contractSha256": "b5adc602bcb8a226aa351d5bbd8a0e7430be283896316b84146d79a83aec4d74"
+          },
+          {
+            "type": "Fs.Fox.Cad.BulgeVertexWidth",
+            "recordCount": 14,
+            "contractSha256": "d754323c16bc6039e1cf2301f2b0cfa038a2235f1d6b445a376f42cba4adb6b1"
+          },
+          {
+            "type": "Fs.Fox.Cad.CircleEx",
+            "recordCount": 4,
+            "contractSha256": "3ff949587dc1787e1f2cb60a24931f083b45d861c83a3f22d6e0e04c9b1fe93b"
+          },
+          {
+            "type": "Fs.Fox.Cad.CollectionEx",
+            "recordCount": 17,
+            "contractSha256": "25748b9fcba1d1652111d4aeb72fe7b488ca885db865738a11fbb1f0943ca9aa"
+          },
+          {
+            "type": "Fs.Fox.Cad.CollectionEx+KeywordName",
+            "recordCount": 5,
+            "contractSha256": "0e476eb404cae5ec16980c3a70f32e124deb91fc4049e9b798a214aa5c2491ef"
+          },
+          {
+            "type": "Fs.Fox.Cad.CoordinateSystemCode",
+            "recordCount": 6,
+            "contractSha256": "21d78d42bd0ba2b7bddd7f3cb9f5b2d63ae52cf0af4bab5dea19242b929b8006"
+          },
+          {
+            "type": "Fs.Fox.Cad.Curve2dEx",
+            "recordCount": 16,
+            "contractSha256": "fec5ad670f3c087ff4c78c9d125f5a4e32ce5ea25d528acab40cf0c30d9b7c77"
+          },
+          {
+            "type": "Fs.Fox.Cad.Curve3dEx",
+            "recordCount": 21,
+            "contractSha256": "b07fa7207265d6635211d57b7acf526972320460712e1cb3e8ae502ad9c2095e"
+          },
+          {
+            "type": "Fs.Fox.Cad.CurveEx",
+            "recordCount": 30,
+            "contractSha256": "6d5c160bf0bfcd354bb13e5e5383a20d0f1b4fb96cff140009762fc0ded14777"
+          },
+          {
+            "type": "Fs.Fox.Cad.DatabaseEx",
+            "recordCount": 4,
+            "contractSha256": "e14770c7f545e70ffe5021954ddf7c13416aea3c6b5797b4551b8b08f66e7fde"
+          },
+          {
+            "type": "Fs.Fox.Cad.DBDictionaryEx",
+            "recordCount": 17,
+            "contractSha256": "71f038f076172af9935c9dd819af9a8dd8e3c0c6b4fafc3a619a163d59931e72"
+          },
+          {
+            "type": "Fs.Fox.Cad.DBmod",
+            "recordCount": 8,
+            "contractSha256": "41fd10e14be804efcaaf2ba78dc834b1b42d3edf052f7193f62609c7c0cb803e"
+          },
+          {
+            "type": "Fs.Fox.Cad.DBmodEx",
+            "recordCount": 7,
+            "contractSha256": "34c9958880c752cecb15a83d0e5342a01ded0fbcc333f67fc18dd05d79890e53"
+          },
+          {
+            "type": "Fs.Fox.Cad.DBObjectEx",
+            "recordCount": 8,
+            "contractSha256": "cda6bae18b8511d86b77a50ae12996c22ada1aaa67122fbf0c902f4d9b75e34f"
+          },
+          {
+            "type": "Fs.Fox.Cad.DBObjectEx+UpgradeOpenManager",
+            "recordCount": 2,
+            "contractSha256": "eb5b41894fa7dae9db8a95405bd7db6d8ae5e6fdc96c84cf02c0d2fc81a8521a"
+          },
+          {
+            "type": "Fs.Fox.Cad.DBTextEx",
+            "recordCount": 3,
+            "contractSha256": "031a0bc06f0fad4224b8f73962a44ffeba6f757aaf5704569277fcef6f912878"
+          },
+          {
+            "type": "Fs.Fox.Cad.DBTrans",
+            "recordCount": 77,
+            "contractSha256": "9c8c1994bf2c34539366d2de0148f5ab06673f7eb60025117e588a845c0d4b87"
+          },
+          {
+            "type": "Fs.Fox.Cad.DBTransEx",
+            "recordCount": 2,
+            "contractSha256": "e902b23084197a04ee9df3d889a667ada7b40505e10eb372a1d7356d42fe910d"
+          },
+          {
+            "type": "Fs.Fox.Cad.DocumentLockManager",
+            "recordCount": 4,
+            "contractSha256": "040a34bf9cdd72c76711e4074b8b38c160753e675b476370b2fb2a55dcc37e0f"
+          },
+          {
+            "type": "Fs.Fox.Cad.DocumentLockManagerExtension",
+            "recordCount": 2,
+            "contractSha256": "4abe7522989adbe80a2ec05632c9cca0cd1b116df0544de9c903e80372653aff"
+          },
+          {
+            "type": "Fs.Fox.Cad.DosHeader",
+            "recordCount": 23,
+            "contractSha256": "44ba4b052a82acd688c36308f576f4f66580a041f9054738b4f32583a285dd38"
+          },
+          {
+            "type": "Fs.Fox.Cad.DosStub",
+            "recordCount": 5,
+            "contractSha256": "ac8c134727febdc5e14f51c14eb0e1d8ac8f20160e2cc6e9cfde106ac4dfcddc"
+          },
+          {
+            "type": "Fs.Fox.Cad.DwgMark",
+            "recordCount": 4,
+            "contractSha256": "d7e4e904d44eac02f2f5366b901761d87dce1d8f86ad97957d6b738450971034"
+          },
+          {
+            "type": "Fs.Fox.Cad.EditorEx",
+            "recordCount": 45,
+            "contractSha256": "b5b656a4ce5c7ff0cd3784942feb6eadf0d6044c662575ca5006ae677a83224d"
+          },
+          {
+            "type": "Fs.Fox.Cad.EditorEx+RunLispFlag",
+            "recordCount": 5,
+            "contractSha256": "74be99d96511b543df75ff5f8c51dd4df9215c19b3f623ef1ab9907c7e58de58"
+          },
+          {
+            "type": "Fs.Fox.Cad.EntityEx",
+            "recordCount": 12,
+            "contractSha256": "32b1b9fd37e4f98f159d01265b40bb6fc412e9fc0380974ae7d0d44619840bc4"
+          },
+          {
+            "type": "Fs.Fox.Cad.Env",
+            "recordCount": 53,
+            "contractSha256": "1ea02969ebf03fac2b580bbe5a992fdfb74654022d932602a46841e98091bdde"
+          },
+          {
+            "type": "Fs.Fox.Cad.Env+DimblkType",
+            "recordCount": 22,
+            "contractSha256": "cb48f90659b636bc212a50288746a474e9d8bf538e98370218dcc74cf358c533"
+          },
+          {
+            "type": "Fs.Fox.Cad.Env+OSModeType",
+            "recordCount": 17,
+            "contractSha256": "a57d84d6128fa4d0aebf46c15b8cddace4586c279e9c2db58664ded73ff53de9"
+          },
+          {
+            "type": "Fs.Fox.Cad.ErrorInfoEx",
+            "recordCount": 1,
+            "contractSha256": "97e4447eff291fab9e90167c13dc90eac8f76788e2bee5e38862964d9e7094d8"
+          },
+          {
+            "type": "Fs.Fox.Cad.ExportDirectory",
+            "recordCount": 20,
+            "contractSha256": "f4b2f0c1fca5d1da34d1d6ffa738dd512ef7d5a7c2b3a05ff9a7d395186e43f9"
+          },
+          {
+            "type": "Fs.Fox.Cad.FontTTF",
+            "recordCount": 7,
+            "contractSha256": "fe7bdc88937dec1d667324c4ee0a7f1b142407eadae4543f6f4d0ccc56e64294"
+          },
+          {
+            "type": "Fs.Fox.Cad.GeometryEx",
+            "recordCount": 26,
+            "contractSha256": "e4cf1a9e9e5066061ed4565b427c6294a9eaa9d507c9c6d0102b9d96d3ba2a0a"
+          },
+          {
+            "type": "Fs.Fox.Cad.GetMethodErrorNum",
+            "recordCount": 5,
+            "contractSha256": "ba67e854a6ae17a7a473473e7cfc3f9125d8bc8f9af0f748cba016331f4d8a3c"
+          },
+          {
+            "type": "Fs.Fox.Cad.GetPeMethodException",
+            "recordCount": 7,
+            "contractSha256": "bcb21ec8b39f2534aac2826faae1f39fb15392c6b26c99f26c609cc4791da539"
+          },
+          {
+            "type": "Fs.Fox.Cad.HatchConverter",
+            "recordCount": 9,
+            "contractSha256": "c87b91d8972ab4bdeb72f7d395bf470c118ebdb488d778d56046328de0868460"
+          },
+          {
+            "type": "Fs.Fox.Cad.HatchEx",
+            "recordCount": 5,
+            "contractSha256": "4d17e1142e9e818e0127a139f95ba4b11fc1387547d0d409005388e87d62b8ff"
+          },
+          {
+            "type": "Fs.Fox.Cad.HatchInfo",
+            "recordCount": 12,
+            "contractSha256": "e9e5b85123013ae21b7388d6e4ddd75e2de40a466ce162d01ac1d839e3d8e895"
+          },
+          {
+            "type": "Fs.Fox.Cad.HatchInfo+GradientName",
+            "recordCount": 11,
+            "contractSha256": "7c6ae7c0a32a06c7a856c2119e91afaf7805f34f6fe430ad39113b0a7488899e"
+          },
+          {
+            "type": "Fs.Fox.Cad.IdleAction",
+            "recordCount": 4,
+            "contractSha256": "0929683bd6f4b38ade8f79e3a2398cc497be30d4b5d1272c5a720a50dc9442ab"
+          },
+          {
+            "type": "Fs.Fox.Cad.IdleNoCmdAction",
+            "recordCount": 4,
+            "contractSha256": "310a3f61097f8dbfec1148c9f2918c88cb8518acc246a4b01dd5caacd84eab6a"
+          },
+          {
+            "type": "Fs.Fox.Cad.IFoxAutoGo",
+            "recordCount": 4,
+            "contractSha256": "1b8dbb4c3ef3da9f8cdb4213157e1733460257d32140ff7114b9f091b15055c8"
+          },
+          {
+            "type": "Fs.Fox.Cad.IFoxInitializeAttribute",
+            "recordCount": 2,
+            "contractSha256": "054ed97e0f085f66e0c92fe5ab96f5977fa2a668cb77b9ca42d09c1ff723b442"
+          },
+          {
+            "type": "Fs.Fox.Cad.IFoxUtils",
+            "recordCount": 6,
+            "contractSha256": "839482ba7efed99e8ea490f03a001b0958cd8e9c732a7b3d865e3d402b76553b"
+          },
+          {
+            "type": "Fs.Fox.Cad.ImportDirectory",
+            "recordCount": 5,
+            "contractSha256": "6d4e5a55e97439ea86f6957a78bb7a9604ec597569276baf6599018b9cf61413"
+          },
+          {
+            "type": "Fs.Fox.Cad.ImportDirectory+ImportDate",
+            "recordCount": 9,
+            "contractSha256": "f30ae2a6abbb81fcb19882b9da3677735eda4b9406bdbef84a3ff14084452d79"
+          },
+          {
+            "type": "Fs.Fox.Cad.ImportDirectory+ImportDate+FunctionList",
+            "recordCount": 5,
+            "contractSha256": "88d28bc2401b5c285439d221f2569b75da85fb4f79e4e69321bbac72680e26cd"
+          },
+          {
+            "type": "Fs.Fox.Cad.IXrefBindModes",
+            "recordCount": 5,
+            "contractSha256": "69cde853405c248356844326fdcb11242b383438fa4164066a8716c7e975ced6"
+          },
+          {
+            "type": "Fs.Fox.Cad.JigEx",
+            "recordCount": 22,
+            "contractSha256": "97eca7efc5f9aefe7722c1a2b9083159e6cfae1c1d03da657e2f7239276654ce"
+          },
+          {
+            "type": "Fs.Fox.Cad.KeywordException",
+            "recordCount": 4,
+            "contractSha256": "437cec6478060a228d3581fd9d650d191b39f4b6f8503ff0165cc937b7d78cde"
+          },
+          {
+            "type": "Fs.Fox.Cad.LispList",
+            "recordCount": 23,
+            "contractSha256": "046042e196ff1ad9ba62bb04020d09ca724a05d2f5b42e6cd500b11605ca743b"
+          },
+          {
+            "type": "Fs.Fox.Cad.MTextEx",
+            "recordCount": 4,
+            "contractSha256": "33c7d00c0a6931a1758bd10f8193730b8ba9a24bcc9339ffe225e0ba44368140"
+          },
+          {
+            "type": "Fs.Fox.Cad.ObjectIdEx",
+            "recordCount": 11,
+            "contractSha256": "7df3061c49edaa22846f161ba4212419b57c7655e5572d91bcc3e7497726f735"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpAnd",
+            "recordCount": 5,
+            "contractSha256": "647a2ddfec1dfdd9114a0272b28c7b85a997c5a581fcec760df281c115551a16"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpComp",
+            "recordCount": 10,
+            "contractSha256": "441483ecac5751ff5b8bca84dd9a1ff5200d841f6a41441da7bcaf58f61cdd6c"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpEqual",
+            "recordCount": 11,
+            "contractSha256": "ea8f1a76cbb3f49120a4b592e371dbb6955f00d6cce3e1f164d99efa7ca90aa9"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpFilter",
+            "recordCount": 12,
+            "contractSha256": "2a2f0454f836ecb1476438d533abea9027b35b63595adb03a5d4206df197e6be"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpFilter+Op",
+            "recordCount": 19,
+            "contractSha256": "2267c6ebf368cd4fbff721b512f7ad541c252c68c236e1f07cf4535a8d1112ca"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpList",
+            "recordCount": 10,
+            "contractSha256": "2be39dbfcb94201de3d2394ee3e59ad27b29f2d40c7cbfdf8fc27979e3830ba8"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpLogi",
+            "recordCount": 8,
+            "contractSha256": "5a9bda3e8d6169cfd1721b3d39cd3fcf14171262d5edbcfb4ec8d3904603f90c"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpNot",
+            "recordCount": 5,
+            "contractSha256": "f819b281307ecf5e852aeb8a0817c89907a59dc72a66f30474fe9440b398cd78"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpOr",
+            "recordCount": 5,
+            "contractSha256": "eaf398f8ee49bac5b780a942242bba5f2a044e5e3e61abbadce37c91b432b9be"
+          },
+          {
+            "type": "Fs.Fox.Cad.OptionalDirAttrib",
+            "recordCount": 5,
+            "contractSha256": "6bf57fa16f1dcfb0605a9e700c9b1ad2297a0b2a69d6df7cad94342d166de893"
+          },
+          {
+            "type": "Fs.Fox.Cad.OptionalDirAttrib+DirAttrib",
+            "recordCount": 4,
+            "contractSha256": "5c29496695e3e4adee852c90b21e923ea476963725abab6c11b150c19ae42cb9"
+          },
+          {
+            "type": "Fs.Fox.Cad.OptionalHeader",
+            "recordCount": 34,
+            "contractSha256": "428f458c886080c0e77007dd30cfc0cde3a6ed9cfc2fa4bb1a2cdbea6b328935"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpXor",
+            "recordCount": 9,
+            "contractSha256": "afe3ae0e17e86d1bc7a21747315f97597f9b173a553b82a3f0fea6f7b9e82ffe"
+          },
+          {
+            "type": "Fs.Fox.Cad.OrientationType",
+            "recordCount": 5,
+            "contractSha256": "d7c4ea950ef18a717f1423415ab5bd5d06c1fd6635e4ca10a371ca13f20a6226"
+          },
+          {
+            "type": "Fs.Fox.Cad.PaneEx",
+            "recordCount": 4,
+            "contractSha256": "ec07dda70874bc76b1c0e4129d6d273bd8e239fb8503c19637688956e52c2da9"
+          },
+          {
+            "type": "Fs.Fox.Cad.PaneMarginType",
+            "recordCount": 5,
+            "contractSha256": "dbcd9022d6f39faf0b81a2b120d9398c9a1049ab653c9da93c2b7240152baa5c"
+          },
+          {
+            "type": "Fs.Fox.Cad.PathConverterModes",
+            "recordCount": 4,
+            "contractSha256": "2cbf8f3679a1f78960c03e4d3f39732631b38fd93aefd40f21890f3763314f4c"
+          },
+          {
+            "type": "Fs.Fox.Cad.PeFunction",
+            "recordCount": 9,
+            "contractSha256": "93b603c4e1ae5ead084bab15c6ccfdf69ddbbef51d11a9c1855bac1a560e144c"
+          },
+          {
+            "type": "Fs.Fox.Cad.PEHeader",
+            "recordCount": 12,
+            "contractSha256": "acff68645a4be0f807ca624cf2334a0514ac233df77ace6b88711773c82c1977"
+          },
+          {
+            "type": "Fs.Fox.Cad.PeInfo",
+            "recordCount": 24,
+            "contractSha256": "3a3228b22beaba7f867aeabcb9b13229c5d35da47dd766b71be270f05b7ae3c6"
+          },
+          {
+            "type": "Fs.Fox.Cad.PlaneEx",
+            "recordCount": 4,
+            "contractSha256": "ae986d7765d474a18cc935dbcf6c696574db09fe765a4bb97a7ee286e39c32c4"
+          },
+          {
+            "type": "Fs.Fox.Cad.PointEx",
+            "recordCount": 22,
+            "contractSha256": "28ef136750a626537da612c66624190927725e1d6b1d78c2223b5389e9da7fdb"
+          },
+          {
+            "type": "Fs.Fox.Cad.PointOnRegionType",
+            "recordCount": 6,
+            "contractSha256": "4e9c7e1e10993792aabb0446c0ed8db277a92b7235f93eec63c4a0f47c70598a"
+          },
+          {
+            "type": "Fs.Fox.Cad.PolylineEx",
+            "recordCount": 9,
+            "contractSha256": "c48bfdefb465abe0538f6a47fcb2c38a6d1dabfd08471dae9cf0b586d93790a5"
+          },
+          {
+            "type": "Fs.Fox.Cad.PostCmd",
+            "recordCount": 5,
+            "contractSha256": "7ca938ddd47bfa1b66f48c42a199a7e418f3b2a3629ce41731912f1990c35605"
+          },
+          {
+            "type": "Fs.Fox.Cad.PostCmd+RunCmdFlag",
+            "recordCount": 8,
+            "contractSha256": "0097d44610c88fa68ba25c6c7a915bcd84b5747b5a8fcf3f51afcaebed7c4e56"
+          },
+          {
+            "type": "Fs.Fox.Cad.ProgressMeterUtils",
+            "recordCount": 4,
+            "contractSha256": "dab4f5465f7273921e317cb54322c73741d0c41809f00a78d71251f57a687ccf"
+          },
+          {
+            "type": "Fs.Fox.Cad.PromptOptionsEx",
+            "recordCount": 3,
+            "contractSha256": "77cdfc7852e8b503c14aceb80560aa40fedf24d7963b01b3a95e222624dc90ae"
+          },
+          {
+            "type": "Fs.Fox.Cad.QuadEntity",
+            "recordCount": 2,
+            "contractSha256": "7adcc8e9ed7bc9ee99333b616fa37a8d7c408f35e3b199e773ffe91fbc226d76"
+          },
+          {
+            "type": "Fs.Fox.Cad.QuadTree`1",
+            "recordCount": 11,
+            "contractSha256": "21a15914f7e3da9debe0a1af7fde7e03fe802ed07c91114348ff76aed9c1f74e"
+          },
+          {
+            "type": "Fs.Fox.Cad.QuadTree`1+QTAction",
+            "recordCount": 5,
+            "contractSha256": "a09ffed07030472139cfd18ebc6290198571c0bc93b3486cb94e69c0a591ddfd"
+          },
+          {
+            "type": "Fs.Fox.Cad.QuadTreeEvn",
+            "recordCount": 6,
+            "contractSha256": "d529384dfd39c5461d45c00ec1af273c560d82c952a28cd11b7fb0bc348d14f4"
+          },
+          {
+            "type": "Fs.Fox.Cad.QuadTreeFindMode",
+            "recordCount": 6,
+            "contractSha256": "30746341b43d57f6687e13cae74eba3e91eb18503c86a0f02301e1dc49742aca"
+          },
+          {
+            "type": "Fs.Fox.Cad.QuadTreeNode`1",
+            "recordCount": 19,
+            "contractSha256": "dba1b8ef041c52685f650f05f9761ee6a14dd6097873ed5850defb44a8d2e073"
+          },
+          {
+            "type": "Fs.Fox.Cad.QuadTreeSelectMode",
+            "recordCount": 4,
+            "contractSha256": "0771682ace891ef1b83449332623089b118d71a884a474bcbfb4a3e42f6e8dfe"
+          },
+          {
+            "type": "Fs.Fox.Cad.Rect",
+            "recordCount": 76,
+            "contractSha256": "efd0ed98611443d849d72eb93a960eb85365e41d77bb340dad1b57ddd577eb1a"
+          },
+          {
+            "type": "Fs.Fox.Cad.RedrawEx",
+            "recordCount": 4,
+            "contractSha256": "77ee09a048a82ece1bfbcb0bc3978d1e7db07d234d3bd224ec6e89723adafb69"
+          },
+          {
+            "type": "Fs.Fox.Cad.RegionEx",
+            "recordCount": 1,
+            "contractSha256": "2a3ea2cdc67062eaa6c818a34b35e92da061e9d666c0ee0d2a209f68b0df1637"
+          },
+          {
+            "type": "Fs.Fox.Cad.ResourceDirectory",
+            "recordCount": 12,
+            "contractSha256": "6d3111fb3d171365ba3f3cf92d16db41375468516d14f60df9184f193797894e"
+          },
+          {
+            "type": "Fs.Fox.Cad.ResourceDirectory+DirectoryEntry",
+            "recordCount": 6,
+            "contractSha256": "7c55ce5d6319c5e051f71b6156b65cd7f6f6006909d7dd428cb70cbe72b69f8a"
+          },
+          {
+            "type": "Fs.Fox.Cad.ResourceDirectory+DirectoryEntry+DataEntry",
+            "recordCount": 8,
+            "contractSha256": "76fc0a678f9a6a27e70c97bbf91420564f7c5197025bb589a5c30396f10d6e39"
+          },
+          {
+            "type": "Fs.Fox.Cad.SectionTable",
+            "recordCount": 5,
+            "contractSha256": "d97c1a5ce63dbfc5806f02447006e1f4b57da24c62533394c829eec97d63941c"
+          },
+          {
+            "type": "Fs.Fox.Cad.SectionTable+SectionData",
+            "recordCount": 12,
+            "contractSha256": "552f4d52375559327a891b0ca04d8adbe221c54b943f0f93761faa87d05366bb"
+          },
+          {
+            "type": "Fs.Fox.Cad.SelectionSetEx",
+            "recordCount": 6,
+            "contractSha256": "a9eb706bcc3217294ae2b21d8b4dde6c0d3a382fd0ff378886497c53cf13d409"
+          },
+          {
+            "type": "Fs.Fox.Cad.Sequence",
+            "recordCount": 4,
+            "contractSha256": "3e9b1f2e90efca4ded4a0680eadbe208d221ff8c852759b9edfca9daf8c6959b"
+          },
+          {
+            "type": "Fs.Fox.Cad.SingleKeyWordHook",
+            "recordCount": 19,
+            "contractSha256": "1559055dd288416aadf284a8021726776e5c0f326f547b6e2cbff1f795d6988a"
+          },
+          {
+            "type": "Fs.Fox.Cad.SingleKeywordHookEx",
+            "recordCount": 2,
+            "contractSha256": "2c7c0ba90e94e201b91b13c5ba958349a8d7b81a886442287a3bc4fa72ed14ca"
+          },
+          {
+            "type": "Fs.Fox.Cad.SingleKeyWordWorkType",
+            "recordCount": 5,
+            "contractSha256": "eb237fe3f969148d0611fbdffcd6bb8f329bb322b2b2ae02d559ef994b0d8fcf"
+          },
+          {
+            "type": "Fs.Fox.Cad.SwitchDatabase",
+            "recordCount": 3,
+            "contractSha256": "37eee5386ac64171ad42856819d80c3288ba6ef8b84242d3e41e464f8e619050"
+          },
+          {
+            "type": "Fs.Fox.Cad.SymbolTable`2",
+            "recordCount": 23,
+            "contractSha256": "8481b4cbc54736a40b3da6e0aaf53196270f0a1583f6fde315804aa3be90e42e"
+          },
+          {
+            "type": "Fs.Fox.Cad.SymbolTableEx",
+            "recordCount": 16,
+            "contractSha256": "1d287bbc1e767237d8bab0dc4858d1e65cf2fd2da557a829ee074e24672be98a"
+          },
+          {
+            "type": "Fs.Fox.Cad.SymbolTableRecordEx",
+            "recordCount": 15,
+            "contractSha256": "4c6dd7a926bdf969f1e5f5a723c11cd5587d902d34aae6bd4898d067d797b9d1"
+          },
+          {
+            "type": "Fs.Fox.Cad.SymModes",
+            "recordCount": 14,
+            "contractSha256": "90a4b221afe17637bca4d2820730ed2da92469b3ace38563b974469fec036bb0"
+          },
+          {
+            "type": "Fs.Fox.Cad.SystemVariableManager",
+            "recordCount": 106,
+            "contractSha256": "2906d187c8087ba54c454a66afd9f08add9e0d9844feccce48a919c602b5de22"
+          },
+          {
+            "type": "Fs.Fox.Cad.TangentEx",
+            "recordCount": 2,
+            "contractSha256": "d38aa9cda156c7ca0091781e679e97eff4509fbcf20a179c6448925262e1148b"
+          },
+          {
+            "type": "Fs.Fox.Cad.TolerancePoint2d",
+            "recordCount": 4,
+            "contractSha256": "13374884d34cf79bc7bb42aa0f91468d0c2db4a689dfc6894600cfd7d2871df1"
+          },
+          {
+            "type": "Fs.Fox.Cad.TransactionEx",
+            "recordCount": 3,
+            "contractSha256": "9c0c0397a0fcd4dca7851854e4fbfc054b73fb0ee55dd5511e66537eb89f9a8d"
+          },
+          {
+            "type": "Fs.Fox.Cad.TypedValueList",
+            "recordCount": 9,
+            "contractSha256": "ef826aa5c376cdfa772de165d1efea76c6f15095db822ad4353b2ea891706cdd"
+          },
+          {
+            "type": "Fs.Fox.Cad.VectorEx",
+            "recordCount": 7,
+            "contractSha256": "5ea0ad031242ad92c4628cd5690a2d863b8628fff6ce10d8a87d8e53753fad27"
+          },
+          {
+            "type": "Fs.Fox.Cad.WindowEx",
+            "recordCount": 6,
+            "contractSha256": "e3ad7c49060ce3498bf756cb5d987ca711a13c19bcae60c26f3b3e1a997349db"
+          },
+          {
+            "type": "Fs.Fox.Cad.WorldDrawEvent",
+            "recordCount": 5,
+            "contractSha256": "25f8e2cf36eb6580bd218c20255cb8c0373cc3e14d66c575f2a2e3ed267b6345"
+          },
+          {
+            "type": "Fs.Fox.Cad.XDataList",
+            "recordCount": 12,
+            "contractSha256": "3dfbc7160bbbba58c832aa02e41c3ee022f8f1db252b3e3824d85da2a3fcc552"
+          },
+          {
+            "type": "Fs.Fox.Cad.XRecordDataList",
+            "recordCount": 9,
+            "contractSha256": "361c3e0f81e2d52abc0a97bf11e886d067aa5f7d609d16bd7c053c764090e1ba"
+          },
+          {
+            "type": "Fs.Fox.Cad.XrefEx",
+            "recordCount": 2,
+            "contractSha256": "cb4046945c30706daf072b06d700dfb59a20394cdbe0bcfd824741e6139d0642"
+          },
+          {
+            "type": "Fs.Fox.Cad.XrefFactory",
+            "recordCount": 13,
+            "contractSha256": "425d05e1e32543e80e578417c17ff8f16769d0a0bb91d4f672891a1acbdd361a"
+          },
+          {
+            "type": "Fs.Fox.Cad.XrefModes",
+            "recordCount": 6,
+            "contractSha256": "8b0ebe1c2521ad862fc2a9902fc1b404df8ad9b342bb23a6ec2352b2d9ba97b9"
+          },
+          {
+            "type": "Fs.Fox.Cad.XrefPath",
+            "recordCount": 14,
+            "contractSha256": "3492c0326e7e4114ac26a6052c4a92963c1ed43a9bc3016dc8fe8ca9af24aa01"
+          }
+        ]
+      },
+      "package": {
+        "id": "IFox.CAD.GCAD2023",
+        "version": "0.9.2-preview6",
+        "repository": {
+          "type": "git",
+          "url": "https://github.com/FsDiG/Fs.Fox.CAD.git"
+        },
+        "dependencies": [
+          {
+            "targetFramework": ".NETFramework4.8",
+            "items": [
+              {
+                "id": "GStarCad.Net",
+                "version": "20.23.0",
+                "include": "",
+                "exclude": "Runtime,Build,Analyzers"
+              }
+            ]
+          }
+        ],
+        "frameworkReferences": [],
+        "assets": [
+          {
+            "path": "GlobalUsings.cs",
+            "length": 6290,
+            "hashKind": "raw-sha256",
+            "contentSha256": "fb44c605d38fc6a9bbad1fc7e743ade33a3dffc293cd3defc7e21435b072daa6",
+            "binarySource": null
+          },
+          {
+            "path": "lib/net48/Fs.Fox.Gcad.dll",
+            "length": null,
+            "hashKind": "matches-build-output-sha256",
+            "contentSha256": null,
+            "binarySource": "Build/GC_2023_Release/Fs.Fox.Gcad.dll"
+          },
+          {
+            "path": "lib/net48/Fs.Fox.Gcad.xml",
+            "length": 474999,
+            "hashKind": "canonical-xml-v1",
+            "contentSha256": "e09d49eab2c4e72d65785eaa9b0b30f2a01329fd6365949d46614cdde48c8d4d",
+            "binarySource": null
+          },
+          {
+            "path": "lib/net48/TestGcad2023.dll",
+            "length": null,
+            "hashKind": "matches-build-output-sha256",
+            "contentSha256": null,
+            "binarySource": "Build/GC_2023_Release/TestGcad2023.dll"
+          },
+          {
+            "path": "LICENSE",
+            "length": 1091,
+            "hashKind": "raw-sha256",
+            "contentSha256": "a2943fc061379a06f57c4a7ea027980ffd3b1f29488cb00519402fd27113d3fd",
+            "binarySource": null
+          },
+          {
+            "path": "readme.md",
+            "length": 7873,
+            "hashKind": "raw-sha256",
+            "contentSha256": "00ccca236e22a69663270c28e1fd111575561d3708e5ff863b469273cbdc9b9a",
+            "binarySource": null
+          }
+        ]
+      }
+    },
+    {
+      "name": "GC_2026",
+      "assembly": {
+        "identity": {
+          "name": "Fs.Fox.Gcad",
+          "version": "0.9.2.0",
+          "culture": "",
+          "publicKeyToken": ""
+        },
+        "references": [
+          {
+            "name": "GcCoreMgd",
+            "version": "1.0.9307.32951",
+            "culture": "",
+            "publicKeyOrToken": "",
+            "flags": 0
+          },
+          {
+            "name": "GcDbMgd",
+            "version": "3.5.0.32891",
+            "culture": "",
+            "publicKeyOrToken": "",
+            "flags": 0
+          },
+          {
+            "name": "GcMgd",
+            "version": "1.0.9307.33009",
+            "culture": "",
+            "publicKeyOrToken": "",
+            "flags": 0
+          },
+          {
+            "name": "Microsoft.CSharp",
+            "version": "8.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b03f5f7f11d50a3a",
+            "flags": 0
+          },
+          {
+            "name": "Microsoft.Win32.Registry",
+            "version": "8.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b03f5f7f11d50a3a",
+            "flags": 0
+          },
+          {
+            "name": "PresentationCore",
+            "version": "8.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "31bf3856ad364e35",
+            "flags": 0
+          },
+          {
+            "name": "PresentationFramework",
+            "version": "8.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "31bf3856ad364e35",
+            "flags": 0
+          },
+          {
+            "name": "System.Collections",
+            "version": "8.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b03f5f7f11d50a3a",
+            "flags": 0
+          },
+          {
+            "name": "System.Collections.NonGeneric",
+            "version": "8.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b03f5f7f11d50a3a",
+            "flags": 0
+          },
+          {
+            "name": "System.ComponentModel.Primitives",
+            "version": "8.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b03f5f7f11d50a3a",
+            "flags": 0
+          },
+          {
+            "name": "System.Data.Common",
+            "version": "8.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b03f5f7f11d50a3a",
+            "flags": 0
+          },
+          {
+            "name": "System.Diagnostics.Process",
+            "version": "8.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b03f5f7f11d50a3a",
+            "flags": 0
+          },
+          {
+            "name": "System.Drawing.Common",
+            "version": "8.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "cc7b13ffcd2ddd51",
+            "flags": 0
+          },
+          {
+            "name": "System.Drawing.Primitives",
+            "version": "8.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b03f5f7f11d50a3a",
+            "flags": 0
+          },
+          {
+            "name": "System.IO.Packaging",
+            "version": "8.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b03f5f7f11d50a3a",
+            "flags": 0
+          },
+          {
+            "name": "System.Linq",
+            "version": "8.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b03f5f7f11d50a3a",
+            "flags": 0
+          },
+          {
+            "name": "System.Linq.Expressions",
+            "version": "8.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b03f5f7f11d50a3a",
+            "flags": 0
+          },
+          {
+            "name": "System.Memory",
+            "version": "8.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "cc7b13ffcd2ddd51",
+            "flags": 0
+          },
+          {
+            "name": "System.Runtime",
+            "version": "8.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b03f5f7f11d50a3a",
+            "flags": 0
+          },
+          {
+            "name": "System.Runtime.InteropServices",
+            "version": "8.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b03f5f7f11d50a3a",
+            "flags": 0
+          },
+          {
+            "name": "System.Threading",
+            "version": "8.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b03f5f7f11d50a3a",
+            "flags": 0
+          },
+          {
+            "name": "System.Threading.Thread",
+            "version": "8.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b03f5f7f11d50a3a",
+            "flags": 0
+          },
+          {
+            "name": "System.Windows.Forms",
+            "version": "8.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "b77a5c561934e089",
+            "flags": 0
+          },
+          {
+            "name": "WindowsBase",
+            "version": "8.0.0.0",
+            "culture": "",
+            "publicKeyOrToken": "31bf3856ad364e35",
+            "flags": 0
+          }
+        ],
+        "publicApiRecordCount": 2285,
+        "publicApi": [
+          {
+            "type": "Fs.Fox.Basal.ArrayEx",
+            "recordCount": 3,
+            "contractSha256": "9165a9b1658ae7d39bce3306fafdaf0e5693937b204a4b1972e49ca78d622d11"
+          },
+          {
+            "type": "Fs.Fox.Basal.DebugEx",
+            "recordCount": 2,
+            "contractSha256": "e6e81cdbb92cacd0da7f4e8135c5bbbbe336a69164df4acf78320642f911c849"
+          },
+          {
+            "type": "Fs.Fox.Basal.EnumEx",
+            "recordCount": 6,
+            "contractSha256": "c0f95798b021662983000dee4164f8eb5931928a4b7e9561c4c23a30b7b10ada"
+          },
+          {
+            "type": "Fs.Fox.Basal.GetWindowCmd",
+            "recordCount": 9,
+            "contractSha256": "7f72f56c0d744ea607d715ae4dd5a68a74421bb414a27bca9f574943a7f1f607"
+          },
+          {
+            "type": "Fs.Fox.Basal.GWL",
+            "recordCount": 9,
+            "contractSha256": "96a77b6035380bca43533199e18d6841d36bf118d73f8c5edb0231748411e8a8"
+          },
+          {
+            "type": "Fs.Fox.Basal.HookType",
+            "recordCount": 18,
+            "contractSha256": "32f677ba3290ad90a17ec392e659ffa3b35bac63000ead25915bac3c85f677ff"
+          },
+          {
+            "type": "Fs.Fox.Basal.LinqEx",
+            "recordCount": 12,
+            "contractSha256": "99eea118df64766eadb67f48daa39dd43d4aa75596b0df9e44ee9c08e17554fe"
+          },
+          {
+            "type": "Fs.Fox.Basal.LoopList`1",
+            "recordCount": 37,
+            "contractSha256": "92dcd65a96bd437a5ac96c759386e54e2b7d5d91d82d863b1116e88773ecb5b4"
+          },
+          {
+            "type": "Fs.Fox.Basal.LoopListNode`1",
+            "recordCount": 10,
+            "contractSha256": "3914f5f56c2655f0d12445e25f8d585aaf3738f0789530cd912561fec0e8e1dd"
+          },
+          {
+            "type": "Fs.Fox.Basal.LoopState",
+            "recordCount": 17,
+            "contractSha256": "36f37eabec6a916404ddedec4817f221c39dc5a6f7b60c95c7e8459dbb02a506"
+          },
+          {
+            "type": "Fs.Fox.Basal.MOUSEEVENTF",
+            "recordCount": 11,
+            "contractSha256": "3a7d09836e1a3306ba58275281877537fa71113a79c30aae65acd2d2953ae53b"
+          },
+          {
+            "type": "Fs.Fox.Basal.NCmdShow",
+            "recordCount": 15,
+            "contractSha256": "62036a3e7697d2e0c22615b89b1daac246e9bcd77b7e399ffcd6d7cbb33e2fbe"
+          },
+          {
+            "type": "Fs.Fox.Basal.PInvokeUser32",
+            "recordCount": 24,
+            "contractSha256": "ff8dd847c4069116ccb342edbadc7ca734dacea692c14bf2df3514acc3c951ba"
+          },
+          {
+            "type": "Fs.Fox.Basal.PInvokeUser32+GuiThreadInfo",
+            "recordCount": 11,
+            "contractSha256": "9d59ea313e83144cc02cc4bb894f01ca4b602392a001099a9986b01e302f95bf"
+          },
+          {
+            "type": "Fs.Fox.Basal.ProState",
+            "recordCount": 20,
+            "contractSha256": "f87608e21811e725f000fec4a608c6bcfe2f6013761565fb1a20691f13a24134"
+          },
+          {
+            "type": "Fs.Fox.Basal.RandomEx",
+            "recordCount": 16,
+            "contractSha256": "1693bdbf213d68affc865ef00710de3e544a282fc9fae272132bc4a0cfb67956"
+          },
+          {
+            "type": "Fs.Fox.Basal.SC",
+            "recordCount": 6,
+            "contractSha256": "c093f92356be05017ebb765b18ebae11c97fb74ceb13c80214a5c7fefb1cc5fb"
+          },
+          {
+            "type": "Fs.Fox.Basal.SystemEx",
+            "recordCount": 3,
+            "contractSha256": "8f8d5b54f31c8a84e244984e8dabcfbd932db93d19bc2bbaafc1469d098b9e4b"
+          },
+          {
+            "type": "Fs.Fox.Basal.TH32CS",
+            "recordCount": 9,
+            "contractSha256": "f6851b16b314b43b3fa1cad9c8fec62d8f9231ab1722b21f874187b58b8f6361"
+          },
+          {
+            "type": "Fs.Fox.Basal.VK",
+            "recordCount": 153,
+            "contractSha256": "fc31ec9b483754682740786322d9c48239e31d0818d170683aa51b109a105624"
+          },
+          {
+            "type": "Fs.Fox.Basal.WindowsAPI",
+            "recordCount": 22,
+            "contractSha256": "b1bd0ecdda2767410a99f44fbfd7626084e8b5f71d81f9fcdea2ca46d4fa3d1d"
+          },
+          {
+            "type": "Fs.Fox.Basal.WindowsAPI+CallBack",
+            "recordCount": 5,
+            "contractSha256": "fac27982455951c25d9d4f3602f0f6b0f627cbfe16d5b69c49ab944e722bbb08"
+          },
+          {
+            "type": "Fs.Fox.Basal.WindowsAPI+IntRect",
+            "recordCount": 23,
+            "contractSha256": "5c30c1796794cce855f96c6a43ae54cdf58a75da5a1b6fcf30647dadeb5f5cd6"
+          },
+          {
+            "type": "Fs.Fox.Basal.WindowsAPI+IntSize",
+            "recordCount": 5,
+            "contractSha256": "2a65904f70d79f3f2a8526b50cf6e189a1ce348e1c5da49834cb5ec916619785"
+          },
+          {
+            "type": "Fs.Fox.Basal.WindowsAPI+KeyboardHookStruct",
+            "recordCount": 8,
+            "contractSha256": "c175f9e10d5d541cc065ce4295cca4261f2d13c3dd5f4a4c3dbf065a8777aee3"
+          },
+          {
+            "type": "Fs.Fox.Basal.WindowsAPI+Point3D",
+            "recordCount": 13,
+            "contractSha256": "27f024d49fc1a62a272fff4caf817d61c768d33ba8bae393cb84d44ee075cdc9"
+          },
+          {
+            "type": "Fs.Fox.Basal.WM",
+            "recordCount": 122,
+            "contractSha256": "c9dbcc9dcab7efccdeb3afc398098b55b35205f0c72eac6826e2334e067b2cbe"
+          },
+          {
+            "type": "Fs.Fox.Basal.WS",
+            "recordCount": 51,
+            "contractSha256": "b85848b39ac568b83b526b53cf61cc15419190ccb6af7bd0fb4e5420eed7ae45"
+          },
+          {
+            "type": "Fs.Fox.Cad.AcadPeEnum",
+            "recordCount": 6,
+            "contractSha256": "ee9c1f62ddc81aa4a657d85dd420adf7a23d381cc13027b83b35cae41db2699a"
+          },
+          {
+            "type": "Fs.Fox.Cad.AcadPeInfo",
+            "recordCount": 12,
+            "contractSha256": "918a76d50e4e193dcefc6552197dc403517ea59479629c83c719d083b04619d0"
+          },
+          {
+            "type": "Fs.Fox.Cad.AcPreferences",
+            "recordCount": 1,
+            "contractSha256": "08f7e98479c23f3056f9a6b681109a64f5d2dfe754c13a7879ca648bd477e5e2"
+          },
+          {
+            "type": "Fs.Fox.Cad.AcPreferences+Display",
+            "recordCount": 76,
+            "contractSha256": "4ea37db8a911862c755599c99fc52620b6cadd88854ae2e860da448fd0bb3609"
+          },
+          {
+            "type": "Fs.Fox.Cad.ArcEx",
+            "recordCount": 5,
+            "contractSha256": "f110068d26c674931f106cbac7408faa024c3dd928786c33b869ce3dc95c9f09"
+          },
+          {
+            "type": "Fs.Fox.Cad.AssemInfo",
+            "recordCount": 7,
+            "contractSha256": "6c4710a803af58d59b47c99b8acc4e32dd81345844ba011462000664e1ba73a3"
+          },
+          {
+            "type": "Fs.Fox.Cad.AssemLoadType",
+            "recordCount": 5,
+            "contractSha256": "6207205f86dc5a3f75eca9afc3c37baa874bde1437cb116fbc9c0334c2820126"
+          },
+          {
+            "type": "Fs.Fox.Cad.Assoc.AssocPersSubentityIdPEEx",
+            "recordCount": 4,
+            "contractSha256": "92d295f27503f7e412a3085a55bdad5c9bab14edc2e36fca323e8d3876763984"
+          },
+          {
+            "type": "Fs.Fox.Cad.AutoReflection",
+            "recordCount": 5,
+            "contractSha256": "96fd97768beb9bc22ca06814513bc76fbe9976cd6eb0d77fe4dd43d9273d3fa5"
+          },
+          {
+            "type": "Fs.Fox.Cad.AutoReg",
+            "recordCount": 7,
+            "contractSha256": "7aed14baedcda39fcf489142ee67302a89f95f734600ed9f5282519b62f21c77"
+          },
+          {
+            "type": "Fs.Fox.Cad.AutoRegAssem",
+            "recordCount": 10,
+            "contractSha256": "9b9c515b442a0f7614ca42f32169d2f8de9298225a7799184c3f4c07ef9289b1"
+          },
+          {
+            "type": "Fs.Fox.Cad.AutoRegConfig",
+            "recordCount": 8,
+            "contractSha256": "c9982c1e28610fab72752096cf0b926134a54ef71809dd286c06b961c5be35df"
+          },
+          {
+            "type": "Fs.Fox.Cad.BaseEx",
+            "recordCount": 2,
+            "contractSha256": "5835442b10982b6f5ded05775fabdbafe45896b72c9e4924b86dda14089ad1bb"
+          },
+          {
+            "type": "Fs.Fox.Cad.BlockReferenceEx",
+            "recordCount": 16,
+            "contractSha256": "9be5c29356247bfa4211ea909f13c57b8c97cc337a26e259cdb70d0615c4f083"
+          },
+          {
+            "type": "Fs.Fox.Cad.BlockVisibilityInfo",
+            "recordCount": 11,
+            "contractSha256": "4662bcc4f30f34523679e83bec82fe4784f0ca78ed5e190702e1246394821db8"
+          },
+          {
+            "type": "Fs.Fox.Cad.BoundingBox9",
+            "recordCount": 45,
+            "contractSha256": "a924029943cb3214dfb49273e250de0e3afa8df2873eb50617184b4e42d41892"
+          },
+          {
+            "type": "Fs.Fox.Cad.BrightEditor",
+            "recordCount": 7,
+            "contractSha256": "17cb91e16a8a422fb9cef1e9d733f3bf413e074ebea48a1407b295da40417d66"
+          },
+          {
+            "type": "Fs.Fox.Cad.BrightEntity",
+            "recordCount": 10,
+            "contractSha256": "b5adc602bcb8a226aa351d5bbd8a0e7430be283896316b84146d79a83aec4d74"
+          },
+          {
+            "type": "Fs.Fox.Cad.BulgeVertexWidth",
+            "recordCount": 14,
+            "contractSha256": "3c5dd2f8eff4af741fb20b47a3ab12aa24faafe63eccaaf2deeb5328b6cb120c"
+          },
+          {
+            "type": "Fs.Fox.Cad.CircleEx",
+            "recordCount": 4,
+            "contractSha256": "f768f8b2542ea4ab98470ff893b11d2e0293fd9fc724ac4abd4d0640312f2ba4"
+          },
+          {
+            "type": "Fs.Fox.Cad.CollectionEx",
+            "recordCount": 17,
+            "contractSha256": "fbe124d12bc440a79c20af3f888e9073411c0b18d4b12bbc1e1214769aab220b"
+          },
+          {
+            "type": "Fs.Fox.Cad.CollectionEx+KeywordName",
+            "recordCount": 5,
+            "contractSha256": "0e476eb404cae5ec16980c3a70f32e124deb91fc4049e9b798a214aa5c2491ef"
+          },
+          {
+            "type": "Fs.Fox.Cad.CoordinateSystemCode",
+            "recordCount": 6,
+            "contractSha256": "21d78d42bd0ba2b7bddd7f3cb9f5b2d63ae52cf0af4bab5dea19242b929b8006"
+          },
+          {
+            "type": "Fs.Fox.Cad.Curve2dEx",
+            "recordCount": 16,
+            "contractSha256": "b220e0feff9206d773545cb9bd76e294d8b7dc16fd32d7dccc0babe1ade7af54"
+          },
+          {
+            "type": "Fs.Fox.Cad.Curve3dEx",
+            "recordCount": 21,
+            "contractSha256": "25fc10ddfc8504e735d5c5ec4ba85353779d35f919e2c1c063f1977988a48dd0"
+          },
+          {
+            "type": "Fs.Fox.Cad.CurveEx",
+            "recordCount": 31,
+            "contractSha256": "df1ae8119f6186c84bd33e84bd8e16f25edb0c710479b992ee16fd71c78433fe"
+          },
+          {
+            "type": "Fs.Fox.Cad.DatabaseEx",
+            "recordCount": 4,
+            "contractSha256": "3dbbca28443ba7b8bf2c72b6bea5feac2b68c6b91518043ace6443fe0bc2fa1c"
+          },
+          {
+            "type": "Fs.Fox.Cad.DBDictionaryEx",
+            "recordCount": 17,
+            "contractSha256": "4d5689b3f09f199c864ae1391fd0cde5f9689be888e3223c6ca89e339bbb2ad3"
+          },
+          {
+            "type": "Fs.Fox.Cad.DBmod",
+            "recordCount": 8,
+            "contractSha256": "41fd10e14be804efcaaf2ba78dc834b1b42d3edf052f7193f62609c7c0cb803e"
+          },
+          {
+            "type": "Fs.Fox.Cad.DBmodEx",
+            "recordCount": 7,
+            "contractSha256": "751993e79de87756bba81de00571f32eb27fa34177f8b26f2621510d467abef4"
+          },
+          {
+            "type": "Fs.Fox.Cad.DBObjectEx",
+            "recordCount": 8,
+            "contractSha256": "f5211d0fa77049b283c2bd1b9193910a7f1f2d961f6b0e7c40d066312e6c8997"
+          },
+          {
+            "type": "Fs.Fox.Cad.DBObjectEx+UpgradeOpenManager",
+            "recordCount": 2,
+            "contractSha256": "eb5b41894fa7dae9db8a95405bd7db6d8ae5e6fdc96c84cf02c0d2fc81a8521a"
+          },
+          {
+            "type": "Fs.Fox.Cad.DBTextEx",
+            "recordCount": 3,
+            "contractSha256": "cfab6332999e9186a1a83285c2a9f872ae6e8b6a1e5648fa4a1de0e285523f3b"
+          },
+          {
+            "type": "Fs.Fox.Cad.DBTrans",
+            "recordCount": 77,
+            "contractSha256": "7b3433fbb61ab1dd0dd1be94d117635278d042beb84c7dab613db342787c09da"
+          },
+          {
+            "type": "Fs.Fox.Cad.DBTransEx",
+            "recordCount": 2,
+            "contractSha256": "e902b23084197a04ee9df3d889a667ada7b40505e10eb372a1d7356d42fe910d"
+          },
+          {
+            "type": "Fs.Fox.Cad.DocumentLockManager",
+            "recordCount": 4,
+            "contractSha256": "040a34bf9cdd72c76711e4074b8b38c160753e675b476370b2fb2a55dcc37e0f"
+          },
+          {
+            "type": "Fs.Fox.Cad.DocumentLockManagerExtension",
+            "recordCount": 2,
+            "contractSha256": "57a9013e74a9bafab152c3396eb2d6ea397cbe8603ccbd6df739a8d5c46751a7"
+          },
+          {
+            "type": "Fs.Fox.Cad.DosHeader",
+            "recordCount": 23,
+            "contractSha256": "44ba4b052a82acd688c36308f576f4f66580a041f9054738b4f32583a285dd38"
+          },
+          {
+            "type": "Fs.Fox.Cad.DosStub",
+            "recordCount": 5,
+            "contractSha256": "ac8c134727febdc5e14f51c14eb0e1d8ac8f20160e2cc6e9cfde106ac4dfcddc"
+          },
+          {
+            "type": "Fs.Fox.Cad.DwgMark",
+            "recordCount": 4,
+            "contractSha256": "61ed07f432e169f078938305d9778c8a070cfd37b4eb73d77d3816198eba1649"
+          },
+          {
+            "type": "Fs.Fox.Cad.EditorEx",
+            "recordCount": 45,
+            "contractSha256": "bf5acd52a6012e39107942973440b5e522bad493d031cf529640d482bcb9d4a7"
+          },
+          {
+            "type": "Fs.Fox.Cad.EditorEx+RunLispFlag",
+            "recordCount": 5,
+            "contractSha256": "74be99d96511b543df75ff5f8c51dd4df9215c19b3f623ef1ab9907c7e58de58"
+          },
+          {
+            "type": "Fs.Fox.Cad.EntityEx",
+            "recordCount": 12,
+            "contractSha256": "9bf8d3fb2f89b75400cd7512cfbb86036953e711d81f496cf63fdaec151e2a6d"
+          },
+          {
+            "type": "Fs.Fox.Cad.Env",
+            "recordCount": 53,
+            "contractSha256": "ee15b5d12119086feba6d44727faa1d8dbe795df9742c135c7e59db2f1bdbf05"
+          },
+          {
+            "type": "Fs.Fox.Cad.Env+DimblkType",
+            "recordCount": 22,
+            "contractSha256": "cb48f90659b636bc212a50288746a474e9d8bf538e98370218dcc74cf358c533"
+          },
+          {
+            "type": "Fs.Fox.Cad.Env+OSModeType",
+            "recordCount": 17,
+            "contractSha256": "a57d84d6128fa4d0aebf46c15b8cddace4586c279e9c2db58664ded73ff53de9"
+          },
+          {
+            "type": "Fs.Fox.Cad.ErrorInfoEx",
+            "recordCount": 1,
+            "contractSha256": "97e4447eff291fab9e90167c13dc90eac8f76788e2bee5e38862964d9e7094d8"
+          },
+          {
+            "type": "Fs.Fox.Cad.ExportDirectory",
+            "recordCount": 20,
+            "contractSha256": "d31721ee2a8575d65577984ffc2bd92213f86a455342c62481bb9c937faddf02"
+          },
+          {
+            "type": "Fs.Fox.Cad.FontTTF",
+            "recordCount": 7,
+            "contractSha256": "fe7bdc88937dec1d667324c4ee0a7f1b142407eadae4543f6f4d0ccc56e64294"
+          },
+          {
+            "type": "Fs.Fox.Cad.GeometryEx",
+            "recordCount": 26,
+            "contractSha256": "4650a9d1abbea58682faca7e8f1e9b096864f6d501d23464574a06bdefcfbcc2"
+          },
+          {
+            "type": "Fs.Fox.Cad.GetMethodErrorNum",
+            "recordCount": 5,
+            "contractSha256": "ba67e854a6ae17a7a473473e7cfc3f9125d8bc8f9af0f748cba016331f4d8a3c"
+          },
+          {
+            "type": "Fs.Fox.Cad.GetPeMethodException",
+            "recordCount": 7,
+            "contractSha256": "b2c8693b999d4656d6970c3ffa9abe0c1d6ba7ed0448c0054630e2a315196199"
+          },
+          {
+            "type": "Fs.Fox.Cad.HatchConverter",
+            "recordCount": 9,
+            "contractSha256": "3b6ce5ce594c5726530198bc4960331a845f182a2f38b127c52ec4b16a0ac034"
+          },
+          {
+            "type": "Fs.Fox.Cad.HatchEx",
+            "recordCount": 5,
+            "contractSha256": "e933048f8ab210054517e45ad856871cadeaf3a4c1bcf8917edb2407b38d7357"
+          },
+          {
+            "type": "Fs.Fox.Cad.HatchInfo",
+            "recordCount": 12,
+            "contractSha256": "237c7a0e692d2aa197c665dd023fdac16b9d5b441031f0136e5c9782076624cc"
+          },
+          {
+            "type": "Fs.Fox.Cad.HatchInfo+GradientName",
+            "recordCount": 11,
+            "contractSha256": "7c6ae7c0a32a06c7a856c2119e91afaf7805f34f6fe430ad39113b0a7488899e"
+          },
+          {
+            "type": "Fs.Fox.Cad.IdleAction",
+            "recordCount": 4,
+            "contractSha256": "e4616948af622b23b90787b22246f77c79ae67905f0d26cbec757fd84b1a256c"
+          },
+          {
+            "type": "Fs.Fox.Cad.IdleNoCmdAction",
+            "recordCount": 4,
+            "contractSha256": "2ec61d8a394468bc2f7c0de39f8d35b8efcb21e4076762bc375ffa45ee17fad6"
+          },
+          {
+            "type": "Fs.Fox.Cad.IFoxAutoGo",
+            "recordCount": 4,
+            "contractSha256": "1b8dbb4c3ef3da9f8cdb4213157e1733460257d32140ff7114b9f091b15055c8"
+          },
+          {
+            "type": "Fs.Fox.Cad.IFoxInitializeAttribute",
+            "recordCount": 2,
+            "contractSha256": "d85e1df8a5a0408529134555f6444006090c1784f5819dfc51900df3ffd629b9"
+          },
+          {
+            "type": "Fs.Fox.Cad.IFoxUtils",
+            "recordCount": 6,
+            "contractSha256": "de38b2744d2cc5021b5c7db4ecf6e086b40e17e9be21ec2a662f61d208444bdb"
+          },
+          {
+            "type": "Fs.Fox.Cad.ImportDirectory",
+            "recordCount": 5,
+            "contractSha256": "582a76d8a28b02836a6892e02eec8e04a3d03fac208c070b46e5cb1d2c0ac7ca"
+          },
+          {
+            "type": "Fs.Fox.Cad.ImportDirectory+ImportDate",
+            "recordCount": 9,
+            "contractSha256": "603434878da69b62a21c51dc00412a6ee628da4c4472db67b9c2ad048863a849"
+          },
+          {
+            "type": "Fs.Fox.Cad.ImportDirectory+ImportDate+FunctionList",
+            "recordCount": 5,
+            "contractSha256": "88d28bc2401b5c285439d221f2569b75da85fb4f79e4e69321bbac72680e26cd"
+          },
+          {
+            "type": "Fs.Fox.Cad.IXrefBindModes",
+            "recordCount": 5,
+            "contractSha256": "69cde853405c248356844326fdcb11242b383438fa4164066a8716c7e975ced6"
+          },
+          {
+            "type": "Fs.Fox.Cad.JigEx",
+            "recordCount": 22,
+            "contractSha256": "0e3f6b146aba081443471458b47dcfab9022715d3bc729ec703ca3caf550d738"
+          },
+          {
+            "type": "Fs.Fox.Cad.JigExTransient",
+            "recordCount": 20,
+            "contractSha256": "3ca511d2f1fe9714ae057c9b7b7df4a8ad165073af304b6ae25fe55393734f8e"
+          },
+          {
+            "type": "Fs.Fox.Cad.KeywordException",
+            "recordCount": 4,
+            "contractSha256": "437cec6478060a228d3581fd9d650d191b39f4b6f8503ff0165cc937b7d78cde"
+          },
+          {
+            "type": "Fs.Fox.Cad.LispList",
+            "recordCount": 23,
+            "contractSha256": "637a273a0e55f81762a5166a4392e7b804ab2af2a30837ee883c2beafe9b1570"
+          },
+          {
+            "type": "Fs.Fox.Cad.MTextEx",
+            "recordCount": 4,
+            "contractSha256": "f714a45d94adad691ccbc9574955a38b14c322b82ada5bac0e2b3cba10142dfc"
+          },
+          {
+            "type": "Fs.Fox.Cad.ObjectIdEx",
+            "recordCount": 11,
+            "contractSha256": "2a54f0ecd6f3c1672bd497b6a614004e424cf64a5de3c5a6c6eef20c12293627"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpAnd",
+            "recordCount": 5,
+            "contractSha256": "647a2ddfec1dfdd9114a0272b28c7b85a997c5a581fcec760df281c115551a16"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpComp",
+            "recordCount": 10,
+            "contractSha256": "26346b330344129bd7641faa7b0f2b9077a80d927de523125e7591a886524fe4"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpEqual",
+            "recordCount": 11,
+            "contractSha256": "e0d36a256626117f2c046f9c8979603780274a8c0574be038df95022aaae2b69"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpFilter",
+            "recordCount": 12,
+            "contractSha256": "97f574e9d638182f540d096b107a40b7553efcbc583fc84009357a037d315b8b"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpFilter+Op",
+            "recordCount": 19,
+            "contractSha256": "996a0299044d2a580afe8854d3d32cf2b3de61e713b42e88a46eec854dfffb20"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpList",
+            "recordCount": 10,
+            "contractSha256": "100b2c8b4a11739cf9f27a44d779a83fbac1b52d0abe6b3a3baa09877d9fcbb1"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpLogi",
+            "recordCount": 8,
+            "contractSha256": "ab537a5696d85edb2a85f599d5b6879d1f29c18c112f7d4778ca1240a24e6f57"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpNot",
+            "recordCount": 5,
+            "contractSha256": "7e238a2727b084cb9712f95cadcfee3f3ce76e6c43e09be334d1cce27822a162"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpOr",
+            "recordCount": 5,
+            "contractSha256": "eaf398f8ee49bac5b780a942242bba5f2a044e5e3e61abbadce37c91b432b9be"
+          },
+          {
+            "type": "Fs.Fox.Cad.OptionalDirAttrib",
+            "recordCount": 5,
+            "contractSha256": "eef7b48131a103cd93c80ea6bdb5ea7ccf7b3d9078e08703c28f017ea357027f"
+          },
+          {
+            "type": "Fs.Fox.Cad.OptionalDirAttrib+DirAttrib",
+            "recordCount": 4,
+            "contractSha256": "5c29496695e3e4adee852c90b21e923ea476963725abab6c11b150c19ae42cb9"
+          },
+          {
+            "type": "Fs.Fox.Cad.OptionalHeader",
+            "recordCount": 34,
+            "contractSha256": "428f458c886080c0e77007dd30cfc0cde3a6ed9cfc2fa4bb1a2cdbea6b328935"
+          },
+          {
+            "type": "Fs.Fox.Cad.OpXor",
+            "recordCount": 9,
+            "contractSha256": "fcf0f398137030a37187d3d51f02f6cbe821d86b4d8996c581bff4484bd6d8c6"
+          },
+          {
+            "type": "Fs.Fox.Cad.OrientationType",
+            "recordCount": 5,
+            "contractSha256": "d7c4ea950ef18a717f1423415ab5bd5d06c1fd6635e4ca10a371ca13f20a6226"
+          },
+          {
+            "type": "Fs.Fox.Cad.PaneEx",
+            "recordCount": 4,
+            "contractSha256": "cb0f1ec41a596da56b9ba289b0d7e72bcf6b86adc5de63d0d36cc977d346fc25"
+          },
+          {
+            "type": "Fs.Fox.Cad.PaneMarginType",
+            "recordCount": 5,
+            "contractSha256": "dbcd9022d6f39faf0b81a2b120d9398c9a1049ab653c9da93c2b7240152baa5c"
+          },
+          {
+            "type": "Fs.Fox.Cad.PathConverterModes",
+            "recordCount": 4,
+            "contractSha256": "2cbf8f3679a1f78960c03e4d3f39732631b38fd93aefd40f21890f3763314f4c"
+          },
+          {
+            "type": "Fs.Fox.Cad.PeFunction",
+            "recordCount": 9,
+            "contractSha256": "40422712e778e5048778534db6451ca792241dde4a2208589f575ed93e946d3e"
+          },
+          {
+            "type": "Fs.Fox.Cad.PEHeader",
+            "recordCount": 12,
+            "contractSha256": "acff68645a4be0f807ca624cf2334a0514ac233df77ace6b88711773c82c1977"
+          },
+          {
+            "type": "Fs.Fox.Cad.PeInfo",
+            "recordCount": 24,
+            "contractSha256": "4da1d32e8f28862b883f702a22227a711647d00c86dbcb5cf12c6302a912cfa3"
+          },
+          {
+            "type": "Fs.Fox.Cad.PlaneEx",
+            "recordCount": 4,
+            "contractSha256": "602006c8fdf644f57ef053bbc6422c52e5546b2fe49b1ae7e7a475790bc2100b"
+          },
+          {
+            "type": "Fs.Fox.Cad.PointEx",
+            "recordCount": 22,
+            "contractSha256": "9e1b41b7eed67f45012f34c154651b998be06bdf040aade17e826cc1000d0d9a"
+          },
+          {
+            "type": "Fs.Fox.Cad.PointOnRegionType",
+            "recordCount": 6,
+            "contractSha256": "4e9c7e1e10993792aabb0446c0ed8db277a92b7235f93eec63c4a0f47c70598a"
+          },
+          {
+            "type": "Fs.Fox.Cad.PolylineEx",
+            "recordCount": 9,
+            "contractSha256": "39e39ba8d4bcecca31a90851b7ad90e40175daa0fe3c73127848691d14c19486"
+          },
+          {
+            "type": "Fs.Fox.Cad.PostCmd",
+            "recordCount": 5,
+            "contractSha256": "40e04c02a345a0219f7792774b58d94e27ef753ec36c37aa4935ca2f1a0204b2"
+          },
+          {
+            "type": "Fs.Fox.Cad.PostCmd+RunCmdFlag",
+            "recordCount": 8,
+            "contractSha256": "0097d44610c88fa68ba25c6c7a915bcd84b5747b5a8fcf3f51afcaebed7c4e56"
+          },
+          {
+            "type": "Fs.Fox.Cad.ProgressMeterUtils",
+            "recordCount": 4,
+            "contractSha256": "dab4f5465f7273921e317cb54322c73741d0c41809f00a78d71251f57a687ccf"
+          },
+          {
+            "type": "Fs.Fox.Cad.PromptOptionsEx",
+            "recordCount": 3,
+            "contractSha256": "e1fabe332d503c99c803e180c5ec04588b1e8c8898262e25f5bee8aa875c7c37"
+          },
+          {
+            "type": "Fs.Fox.Cad.QuadEntity",
+            "recordCount": 2,
+            "contractSha256": "7adcc8e9ed7bc9ee99333b616fa37a8d7c408f35e3b199e773ffe91fbc226d76"
+          },
+          {
+            "type": "Fs.Fox.Cad.QuadTree`1",
+            "recordCount": 11,
+            "contractSha256": "ed57d488f93d84a30f3ad85ed59a6ac7df6d8d0a11a6f5f2305d038e2bad92a5"
+          },
+          {
+            "type": "Fs.Fox.Cad.QuadTree`1+QTAction",
+            "recordCount": 5,
+            "contractSha256": "56d6de05d797b0cd05231a22141f2ba10255f2d63804b1a8c7839437462021cf"
+          },
+          {
+            "type": "Fs.Fox.Cad.QuadTreeEvn",
+            "recordCount": 6,
+            "contractSha256": "d529384dfd39c5461d45c00ec1af273c560d82c952a28cd11b7fb0bc348d14f4"
+          },
+          {
+            "type": "Fs.Fox.Cad.QuadTreeFindMode",
+            "recordCount": 6,
+            "contractSha256": "30746341b43d57f6687e13cae74eba3e91eb18503c86a0f02301e1dc49742aca"
+          },
+          {
+            "type": "Fs.Fox.Cad.QuadTreeNode`1",
+            "recordCount": 19,
+            "contractSha256": "dc54de4337ee10f2465de4367c841487eea53d681cae6b05345d2f0cf8bcb0ac"
+          },
+          {
+            "type": "Fs.Fox.Cad.QuadTreeSelectMode",
+            "recordCount": 4,
+            "contractSha256": "0771682ace891ef1b83449332623089b118d71a884a474bcbfb4a3e42f6e8dfe"
+          },
+          {
+            "type": "Fs.Fox.Cad.Rect",
+            "recordCount": 76,
+            "contractSha256": "00d4f59d25b77b118e7b4dcc1defe59a76b2478c34aea50192757067db957252"
+          },
+          {
+            "type": "Fs.Fox.Cad.RedrawEx",
+            "recordCount": 4,
+            "contractSha256": "b09862b1f30b8edc2c5a3d022fc9fcf2bec3d233d1739d65b482849341f36bc7"
+          },
+          {
+            "type": "Fs.Fox.Cad.RegionEx",
+            "recordCount": 1,
+            "contractSha256": "2a3ea2cdc67062eaa6c818a34b35e92da061e9d666c0ee0d2a209f68b0df1637"
+          },
+          {
+            "type": "Fs.Fox.Cad.ResourceDirectory",
+            "recordCount": 12,
+            "contractSha256": "de0ba169b7c179d2ac81a3ea7575e2084f91f5822d8c44cf52a20b963af7bcb3"
+          },
+          {
+            "type": "Fs.Fox.Cad.ResourceDirectory+DirectoryEntry",
+            "recordCount": 6,
+            "contractSha256": "2ee392d7cfe04709e287cf574b481a1d213ffc908b1f167e3486c8dcdc0cacb4"
+          },
+          {
+            "type": "Fs.Fox.Cad.ResourceDirectory+DirectoryEntry+DataEntry",
+            "recordCount": 8,
+            "contractSha256": "76fc0a678f9a6a27e70c97bbf91420564f7c5197025bb589a5c30396f10d6e39"
+          },
+          {
+            "type": "Fs.Fox.Cad.SectionTable",
+            "recordCount": 5,
+            "contractSha256": "5f8613cef99c2a1068479465a5c5711c2a6aba617eba7bdd54cf4735a6f82659"
+          },
+          {
+            "type": "Fs.Fox.Cad.SectionTable+SectionData",
+            "recordCount": 12,
+            "contractSha256": "552f4d52375559327a891b0ca04d8adbe221c54b943f0f93761faa87d05366bb"
+          },
+          {
+            "type": "Fs.Fox.Cad.SelectionSetEx",
+            "recordCount": 6,
+            "contractSha256": "9bc8d47dba6df41b6d0bdb8f796275120fdb98ad3a5af200d00190180c64798a"
+          },
+          {
+            "type": "Fs.Fox.Cad.Sequence",
+            "recordCount": 4,
+            "contractSha256": "3e9b1f2e90efca4ded4a0680eadbe208d221ff8c852759b9edfca9daf8c6959b"
+          },
+          {
+            "type": "Fs.Fox.Cad.SingleKeyWordHook",
+            "recordCount": 19,
+            "contractSha256": "037f3482c5bd91b79be49709dfbc84e3c392c40eaa75b4b2a0b21fbec2b37514"
+          },
+          {
+            "type": "Fs.Fox.Cad.SingleKeywordHookEx",
+            "recordCount": 2,
+            "contractSha256": "d23013663b59ac7cb2f1c7c9a4c588c372f506fc5b04c71060297f45d8fef3d8"
+          },
+          {
+            "type": "Fs.Fox.Cad.SingleKeyWordWorkType",
+            "recordCount": 5,
+            "contractSha256": "eb237fe3f969148d0611fbdffcd6bb8f329bb322b2b2ae02d559ef994b0d8fcf"
+          },
+          {
+            "type": "Fs.Fox.Cad.SwitchDatabase",
+            "recordCount": 3,
+            "contractSha256": "4e2ee7c682f873ae2e4f18ee28b96a6c40f2e42be696b6a223494430a09fe60c"
+          },
+          {
+            "type": "Fs.Fox.Cad.SymbolTable`2",
+            "recordCount": 23,
+            "contractSha256": "45be4ebc8a15a6e0fe1e9a7aeec1eea7d03e65bdca74a5c7b622793b1aaddffe"
+          },
+          {
+            "type": "Fs.Fox.Cad.SymbolTableEx",
+            "recordCount": 16,
+            "contractSha256": "261bb5097a2bc93bf66d95a81be5270b48d593aeb3a65bf4b4faf64af70634b3"
+          },
+          {
+            "type": "Fs.Fox.Cad.SymbolTableRecordEx",
+            "recordCount": 15,
+            "contractSha256": "81a7743180534b469b7c5b6a9b6a4d38598be1641c68411b516b4f9faec6bad4"
+          },
+          {
+            "type": "Fs.Fox.Cad.SymModes",
+            "recordCount": 14,
+            "contractSha256": "90a4b221afe17637bca4d2820730ed2da92469b3ace38563b974469fec036bb0"
+          },
+          {
+            "type": "Fs.Fox.Cad.SystemVariableManager",
+            "recordCount": 106,
+            "contractSha256": "e4eaa814af3518c8ee4a38e6d0b8769bae3f8fdd3ee7fa7ad80aeef34c027246"
+          },
+          {
+            "type": "Fs.Fox.Cad.TangentEx",
+            "recordCount": 2,
+            "contractSha256": "d38aa9cda156c7ca0091781e679e97eff4509fbcf20a179c6448925262e1148b"
+          },
+          {
+            "type": "Fs.Fox.Cad.TolerancePoint2d",
+            "recordCount": 4,
+            "contractSha256": "583e82ad516397339234dd8117a437b38ccede8cffd0fd752e0d1919a6fb218d"
+          },
+          {
+            "type": "Fs.Fox.Cad.TransactionEx",
+            "recordCount": 3,
+            "contractSha256": "79819ae81318528b0379bd9a3ca3080bf4fe7dcae6aefcd1430460a1c0931a0d"
+          },
+          {
+            "type": "Fs.Fox.Cad.TypedValueList",
+            "recordCount": 9,
+            "contractSha256": "54d3be26d8733f5cf8925cf65b12c39023e90cadc56b7985b0a0b820b830ae52"
+          },
+          {
+            "type": "Fs.Fox.Cad.VectorEx",
+            "recordCount": 7,
+            "contractSha256": "3b3d93005087f676e17fff4ce5e74cefbb5dd1b5d70bffc98e13ccaf411b0337"
+          },
+          {
+            "type": "Fs.Fox.Cad.WindowEx",
+            "recordCount": 6,
+            "contractSha256": "dd691663e2445ffc2f7f2b10bd1c0ae222cd7ca2886d1fa649f26a8181821434"
+          },
+          {
+            "type": "Fs.Fox.Cad.WorldDrawEvent",
+            "recordCount": 5,
+            "contractSha256": "b04334c7dace48d4e5b75101effc1c8ae428ff80bea23db4dd63ae0f3a0d425c"
+          },
+          {
+            "type": "Fs.Fox.Cad.XDataList",
+            "recordCount": 12,
+            "contractSha256": "c2cba2155d281fdf62818789604936e4be5674ec992d217e5d505f150f0f8f1e"
+          },
+          {
+            "type": "Fs.Fox.Cad.XRecordDataList",
+            "recordCount": 9,
+            "contractSha256": "25ce63c69f45f939613b4d6fa62b77dd0615540479e77f62f8840dc2f23583ad"
+          },
+          {
+            "type": "Fs.Fox.Cad.XrefEx",
+            "recordCount": 2,
+            "contractSha256": "96a653778b87d532cfc3391c43b2fd5529754106d482b85d6172c2ecd82f7c58"
+          },
+          {
+            "type": "Fs.Fox.Cad.XrefFactory",
+            "recordCount": 13,
+            "contractSha256": "4b73d1b3a08662a9fb4971e5664e76a0fedd222188e813847046db64f3863ea7"
+          },
+          {
+            "type": "Fs.Fox.Cad.XrefModes",
+            "recordCount": 6,
+            "contractSha256": "8b0ebe1c2521ad862fc2a9902fc1b404df8ad9b342bb23a6ec2352b2d9ba97b9"
+          },
+          {
+            "type": "Fs.Fox.Cad.XrefPath",
+            "recordCount": 14,
+            "contractSha256": "96ce2023dcb11b7d364c4fe7e210768a630337bec7faf0479f8e420ac27d525c"
+          }
+        ]
+      },
+      "package": {
+        "id": "IFox.CAD.GCAD2026",
+        "version": "0.9.2-preview6",
+        "repository": {
+          "type": "git",
+          "url": "https://github.com/FsDiG/Fs.Fox.CAD.git"
+        },
+        "dependencies": [
+          {
+            "targetFramework": "net8.0-windows7.0",
+            "items": [
+              {
+                "id": "GStarCad.Net",
+                "version": "20.26.0",
+                "include": "",
+                "exclude": "Runtime,Build,Analyzers"
+              }
+            ]
+          }
+        ],
+        "frameworkReferences": [
+          {
+            "targetFramework": "net8.0-windows7.0",
+            "items": [
+              "Microsoft.WindowsDesktop.App"
+            ]
+          }
+        ],
+        "assets": [
+          {
+            "path": "GlobalUsings.cs",
+            "length": 6290,
+            "hashKind": "raw-sha256",
+            "contentSha256": "fb44c605d38fc6a9bbad1fc7e743ade33a3dffc293cd3defc7e21435b072daa6",
+            "binarySource": null
+          },
+          {
+            "path": "lib/net8.0-windows7.0/Fs.Fox.Gcad.dll",
+            "length": null,
+            "hashKind": "matches-build-output-sha256",
+            "contentSha256": null,
+            "binarySource": "Build/GC_2026_Release/Fs.Fox.Gcad.dll"
+          },
+          {
+            "path": "lib/net8.0-windows7.0/Fs.Fox.Gcad.runtimeconfig.json",
+            "length": 464,
+            "hashKind": "raw-sha256",
+            "contentSha256": "ccf34fe185a1c9a0114dae9b55958a70b3ccde47c8a236d361932c5b1efc5914",
+            "binarySource": null
+          },
+          {
+            "path": "lib/net8.0-windows7.0/Fs.Fox.Gcad.xml",
+            "length": 448266,
+            "hashKind": "canonical-xml-v1",
+            "contentSha256": "b3e04ac7ed213be3d65db0a92049f27c6df386f6c946a1dd7a303df433204bca",
+            "binarySource": null
+          },
+          {
+            "path": "lib/net8.0-windows7.0/TestGcad2026.dll",
+            "length": null,
+            "hashKind": "matches-build-output-sha256",
+            "contentSha256": null,
+            "binarySource": "Build/GC_2026_Release/TestGcad2026.dll"
           },
           {
             "path": "LICENSE",

--- a/Build/CADSharedCompatibilityBaseline.json
+++ b/Build/CADSharedCompatibilityBaseline.json
@@ -5101,9 +5101,9 @@
         "assets": [
           {
             "path": "GlobalUsings.cs",
-            "length": 6290,
+            "length": 6422,
             "hashKind": "raw-sha256",
-            "contentSha256": "fb44c605d38fc6a9bbad1fc7e743ade33a3dffc293cd3defc7e21435b072daa6",
+            "contentSha256": "eaf647a88c007f65a3bdb5a2f229bcdd6bdd8afd64117b08dc60d20e28056551",
             "binarySource": null
           },
           {
@@ -6092,9 +6092,9 @@
         "assets": [
           {
             "path": "GlobalUsings.cs",
-            "length": 6290,
+            "length": 6422,
             "hashKind": "raw-sha256",
-            "contentSha256": "fb44c605d38fc6a9bbad1fc7e743ade33a3dffc293cd3defc7e21435b072daa6",
+            "contentSha256": "eaf647a88c007f65a3bdb5a2f229bcdd6bdd8afd64117b08dc60d20e28056551",
             "binarySource": null
           },
           {
@@ -7179,9 +7179,9 @@
         "assets": [
           {
             "path": "GlobalUsings.cs",
-            "length": 6290,
+            "length": 6422,
             "hashKind": "raw-sha256",
-            "contentSha256": "fb44c605d38fc6a9bbad1fc7e743ade33a3dffc293cd3defc7e21435b072daa6",
+            "contentSha256": "eaf647a88c007f65a3bdb5a2f229bcdd6bdd8afd64117b08dc60d20e28056551",
             "binarySource": null
           },
           {

--- a/Build/CADSharedModuleBaseline.json
+++ b/Build/CADSharedModuleBaseline.json
@@ -75,7 +75,7 @@
           "count": 1
         }
       ],
-      "sourceSha256": "5d605cdc53d630e885af3334f8b9cba06fce1aab033d1ae7f1be4b2fc86e47df"
+      "sourceSha256": "1baf36618e23adfe49d1d7252dc1f0d4687486c773c7b759417d9c7d06e8dee5"
     },
     {
       "order": "0070",
@@ -85,7 +85,7 @@
         "BD-16"
       ],
       "boundaryFindings": [],
-      "sourceSha256": "feba2cacd8333ca69c144b78a8df291558a9b6050f09095434cb22dd32d6abb0"
+      "sourceSha256": "f135bedd46affae63ff4d212436606070fd07038a9e5d23c2e56e232212a71f2"
     },
     {
       "order": "0080",
@@ -167,7 +167,7 @@
       "module": "Foundation",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "6d48544f9318ea9f026a1758e60dcfbd61510937f549bcaaf33bd784cc81b420"
+      "sourceSha256": "f101b9258b4bb93a7aec89b7ecba5c12844ad9583ea3a26b2f88e89ca015a9ae"
     },
     {
       "order": "0160",
@@ -175,7 +175,7 @@
       "module": "Foundation",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "cfa334d82700cf37eed51a2f5fc705bb21b678575e5984ef4fc84de0d421e1f5"
+      "sourceSha256": "b0fb4e7e7ee12b20d070ce25b5f19aefb41c5f6e54adafec4e8b8d13f61e2d3d"
     },
     {
       "order": "0170",
@@ -315,7 +315,7 @@
         "BD-15"
       ],
       "boundaryFindings": [],
-      "sourceSha256": "ffb3c0ed98231ff115a46a9825c710e915dfcfa97836520cf6ba00d1845273a2"
+      "sourceSha256": "b802c447ec1ae1efb426a72fec806fdb45ac99903c9f0d457d46ed87f0d8d597"
     },
     {
       "order": "0210",
@@ -341,7 +341,7 @@
         "BD-01"
       ],
       "boundaryFindings": [],
-      "sourceSha256": "8e3e0082d1454ba78f5f7bddeedcd9d25a2e1538a197fcaa9d04532a7df892e9"
+      "sourceSha256": "c8ae7dd5061c7d60f90650a23ff0a1b2141f8b1d6b8a0cf9c934551e026acbf7"
     },
     {
       "order": "0240",
@@ -360,7 +360,7 @@
           "count": 2
         }
       ],
-      "sourceSha256": "6cbed08713176af5259e5cda20719d1b8b9793b392771c0d85f147695ab2f6d2"
+      "sourceSha256": "8e30f6ff80fa1bd0a5df7f7acc385cc3f7c5ee62ddb5e13886e579baadf977d8"
     },
     {
       "order": "0241",
@@ -446,7 +446,7 @@
       "module": "Cad.Database",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "1d63864a95d98187b54e92c02b33dd2870fa85e4ac951b1b2adc8e567ea1308c"
+      "sourceSha256": "d634490a9f0316e368f8f06da09a2057cbe70cf906adb8e3bef3a314afc7ef19"
     },
     {
       "order": "0320",
@@ -461,7 +461,7 @@
           "count": 1
         }
       ],
-      "sourceSha256": "16f05f2ef92fd84c20fe6cb0a65c5fcaadb9e0a166207f5f2255d17f23982339"
+      "sourceSha256": "159351cdc1e0aced1a9eb3418ddc2e91ca1e84ec8500669465fd12460e388a1f"
     },
     {
       "order": "0321",
@@ -493,7 +493,7 @@
       "module": "Cad.Database",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "d19c16f505f14013d492f62f7b2d2623b8263a68507081001d803511c6468e89"
+      "sourceSha256": "22899506a843bbd306f723681602559cc77e1eacee46db8beaa851fa6a384969"
     },
     {
       "order": "0360",
@@ -673,7 +673,7 @@
       "module": "Cad.Geometry",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "ff9a42062ff7a8a72db943f90fc2c48f0628150345de813464c43c7fec6ba36a"
+      "sourceSha256": "ec00a879c45af65a2b010e6807b0d546dea087764c4784dac5ac7fb7d4fd65ad"
     },
     {
       "order": "0480",
@@ -697,7 +697,7 @@
       "module": "Cad.Editor",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "2e0cf112fc2c65d163e59627adb06885813558922571bf9542473ed3982aaabd"
+      "sourceSha256": "d39a8ce9fe24a1d7fa4fdac4150ac34a169dc39e230a6353884b2e1e8d672d9c"
     },
     {
       "order": "0500",
@@ -705,7 +705,7 @@
       "module": "Cad.Editor",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "1d3eb6c05e094fd439c80848541cc9b3796fb699642ad555a9658085f58044dd"
+      "sourceSha256": "5339bf55f280d384f0791f7178625d084c4b26ceb2914c1e1a4dff9f86aa1d5c"
     },
     {
       "order": "0510",
@@ -792,7 +792,7 @@
       "module": "Cad.Editor",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "31f7c297a97b9bbfe4f15c9d6e1a6d36bb8315c2880583e0fe3de839ab521cf0"
+      "sourceSha256": "26bf208af1f2c3c14e1ecd191a75a2f4f52d9851a9685dcd732f7cc5eacbbccd"
     },
     {
       "order": "0570",
@@ -807,7 +807,7 @@
           "count": 1
         }
       ],
-      "sourceSha256": "6bb967f90aa513950e4d91f6d2bbe067b6607258dcb45c7c5df5fda23e0b908f"
+      "sourceSha256": "4bc7be2d044f8d177c9311301e84d4d2df00ea7297a0fceb55d825a707fc360e"
     },
     {
       "order": "0571",
@@ -841,7 +841,7 @@
         "BD-06"
       ],
       "boundaryFindings": [],
-      "sourceSha256": "ef8b4d5ca424a164bd0e6964cd06a32ce3e2289ca403cb5042a0d0483bfd87cc"
+      "sourceSha256": "b519c3873dadec8dfe2dfe54f8583aa4141db6b7f1f4710b26971608e8e7fd29"
     },
     {
       "order": "0600",
@@ -877,7 +877,7 @@
       "module": "Cad.UI",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "531598127532ca3eecf0eb50d27a8f83b960636dbfd62ab74dba27074e6e8920"
+      "sourceSha256": "d481832d15c1612c6530ce5f727e2039e64a4b05ab42d9f057af3b6cb157bee4"
     },
     {
       "order": "0640",
@@ -909,7 +909,7 @@
       "module": "Cad.Database",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "d8ef01f14e03792247aeb85753ab3d8701c448158f0a791dc833e160681de0a6"
+      "sourceSha256": "06597259263c4fd841eb50888d3c3dcdd6b5cda5ac6229795a8817ebca5cf702"
     },
     {
       "order": "0650",
@@ -917,7 +917,7 @@
       "module": "Cad.Database",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "606cf66639b2a83483f68c7e7cd7fcdea72276b528e72c9c44381c3450bbb8b2"
+      "sourceSha256": "aaba3fd6b390d83a18c657d40ca8d2b0ab3f2f90b318a7f9abf34ef8e3745848"
     },
     {
       "order": "0660",
@@ -947,7 +947,7 @@
           "count": 2
         }
       ],
-      "sourceSha256": "b26f7dc92981ec2ebf719aee5cbb508c65a55584a826d022c9f3c8d94e9d18fc"
+      "sourceSha256": "a0a5941bf1014de33f60173ce7ff21597b53b2cbe3638e7a0d22367745e0957a"
     },
     {
       "order": "0680",
@@ -997,7 +997,7 @@
       "module": "Cad.Runtime",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "8e588b0448aab6a595e366336a7179afd15967cde6dda9363194c62504ec92e9"
+      "sourceSha256": "759ca418525680649bd55e2f95e166a9edb8c259fcb0595d931d120401c4508f"
     },
     {
       "order": "0720",
@@ -1060,7 +1060,7 @@
       "module": "Cad.Runtime",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "1fb8424559ce73c4b1719b61a711d02e6b31cf7aa8c34100575d0c2e9b423761"
+      "sourceSha256": "20d702c1e05779edea25baeea0bf0db73bd35805f5ac04097cb7be52517cbcc4"
     },
     {
       "order": "0750",
@@ -1161,7 +1161,7 @@
           "count": 19
         }
       ],
-      "sourceSha256": "75f706dc330bb219ec9a643a6436e4851c3e18abe893ebd2a487833511b1e85b"
+      "sourceSha256": "29657079539812a161ab9369632ddaf3a8b884975e592f513c4b2c2fcc3ac9a2"
     },
     {
       "order": "0850",
@@ -1171,7 +1171,7 @@
         "BD-09"
       ],
       "boundaryFindings": [],
-      "sourceSha256": "1237cb0d2ac3f73ff95a8ecdf76b0bf5e2105e19dd5b1c4b4a0233b9e8232197"
+      "sourceSha256": "d4afc65a0f1f6c18f6f306b415133de2f298429d092c1ed08c5f282ba639cda8"
     },
     {
       "order": "0860",
@@ -1211,7 +1211,7 @@
         "BD-14"
       ],
       "boundaryFindings": [],
-      "sourceSha256": "cb262627cb8142284bf745892e9b1db6c48ea5e7b101d3bd33bba034f961f263"
+      "sourceSha256": "c51d980af311134b3f424f84d2fb65cf26f9e71a31a0a40ab639c743d3835f27"
     },
     {
       "order": "0890",
@@ -1219,7 +1219,7 @@
       "module": "Cad.UI",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "6c1c43467bbe9a709f2b5772946237236d8ced1a47f6108a2b0cca3c9352e37e"
+      "sourceSha256": "c78332fb5144157532a565bbdeb5872ad69cb9ada5018ae089b4196793f2e546"
     },
     {
       "order": "0900",
@@ -1227,7 +1227,7 @@
       "module": "Cad.Database",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "8f04f91d1764e65c6e4eed5741617081ade197772d9ef9384208c6c73d15e2fe"
+      "sourceSha256": "17b1a08f4ecc930c0a123ad9b749ccf60b5ab5c10f7e133a613d44dd85bccc65"
     },
     {
       "order": "0910",

--- a/Build/Verify-CADSharedCompatibility.ps1
+++ b/Build/Verify-CADSharedCompatibility.ps1
@@ -51,6 +51,27 @@ $targets = @(
         assembly = 'Build\ZW_2025_Release\Fs.Fox.ZwCad.dll'
         testAssembly = 'Build\ZW_2025_Release\TestZcad2025.dll'
         packageId = 'IFox.CAD.ZCAD2025'
+    },
+    [pscustomobject]@{
+        name = 'GC_2022'
+        project = 'src\Fs.Fox.Gcad2022\Fs.Fox.Gcad2022.csproj'
+        assembly = 'Build\GC_2022_Release\Fs.Fox.Gcad.dll'
+        testAssembly = 'Build\GC_2022_Release\TestGcad2022.dll'
+        packageId = 'IFox.CAD.GCAD2022'
+    },
+    [pscustomobject]@{
+        name = 'GC_2023'
+        project = 'src\Fs.Fox.Gcad2023\Fs.Fox.Gcad2023.csproj'
+        assembly = 'Build\GC_2023_Release\Fs.Fox.Gcad.dll'
+        testAssembly = 'Build\GC_2023_Release\TestGcad2023.dll'
+        packageId = 'IFox.CAD.GCAD2023'
+    },
+    [pscustomobject]@{
+        name = 'GC_2026'
+        project = 'src\Fs.Fox.Gcad2026\Fs.Fox.Gcad2026.csproj'
+        assembly = 'Build\GC_2026_Release\Fs.Fox.Gcad.dll'
+        testAssembly = 'Build\GC_2026_Release\TestGcad2026.dll'
+        packageId = 'IFox.CAD.GCAD2026'
     }
 )
 
@@ -881,7 +902,8 @@ function Assert-ReleaseAssembliesAreFresh {
         $inputPaths = @($commonInputs) + @(
             (Join-Path $repoRoot $target.project),
             (Join-Path $repoRoot 'src\IFoxCAD.AutoCad\GlobalUsings.cs'),
-            (Join-Path $repoRoot 'src\IFoxCAD.ZwCad\GlobalUsings.cs')
+            (Join-Path $repoRoot 'src\IFoxCAD.ZwCad\GlobalUsings.cs'),
+            (Join-Path $repoRoot 'src\IFoxCAD.Gcad\GlobalUsings.cs')
         )
         $latestInput = $inputPaths |
             ForEach-Object { Get-Item -LiteralPath $_ } |

--- a/IFoxCAD.sln
+++ b/IFoxCAD.sln
@@ -44,6 +44,18 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fs.Fox.ZwCad2022", "src\Fs.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fs.Fox.ZwCad2025", "src\Fs.Fox.ZwCad2025\Fs.Fox.ZwCad2025.csproj", "{DA70CC85-EF3A-DCD7-82E8-0F5DD38E3CC3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fs.Fox.Gcad2022", "src\Fs.Fox.Gcad2022\Fs.Fox.Gcad2022.csproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fs.Fox.Gcad2023", "src\Fs.Fox.Gcad2023\Fs.Fox.Gcad2023.csproj", "{B2C3D4E5-F6A7-8901-BCDE-F12345678901}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Fs.Fox.Gcad2026", "src\Fs.Fox.Gcad2026\Fs.Fox.Gcad2026.csproj", "{C3D4E5F6-A7B8-9012-CDEF-123456789012}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestGcad2022", "tests\TestGcad2022\TestGcad2022.csproj", "{D4E5F6A7-B8C9-0123-DEFA-234567890123}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestGcad2023", "tests\TestGcad2023\TestGcad2023.csproj", "{E5F6A7B8-C9D0-1234-EFAB-345678901234}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestGcad2026", "tests\TestGcad2026\TestGcad2026.csproj", "{F6A7B8C9-D0E1-2345-FABC-456789012345}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -82,6 +94,30 @@ Global
 		{DA70CC85-EF3A-DCD7-82E8-0F5DD38E3CC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DA70CC85-EF3A-DCD7-82E8-0F5DD38E3CC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DA70CC85-EF3A-DCD7-82E8-0F5DD38E3CC3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C3D4E5F6-A7B8-9012-CDEF-123456789012}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C3D4E5F6-A7B8-9012-CDEF-123456789012}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C3D4E5F6-A7B8-9012-CDEF-123456789012}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C3D4E5F6-A7B8-9012-CDEF-123456789012}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D4E5F6A7-B8C9-0123-DEFA-234567890123}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D4E5F6A7-B8C9-0123-DEFA-234567890123}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D4E5F6A7-B8C9-0123-DEFA-234567890123}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D4E5F6A7-B8C9-0123-DEFA-234567890123}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E5F6A7B8-C9D0-1234-EFAB-345678901234}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E5F6A7B8-C9D0-1234-EFAB-345678901234}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E5F6A7B8-C9D0-1234-EFAB-345678901234}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E5F6A7B8-C9D0-1234-EFAB-345678901234}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F6A7B8C9-D0E1-2345-FABC-456789012345}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F6A7B8C9-D0E1-2345-FABC-456789012345}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F6A7B8C9-D0E1-2345-FABC-456789012345}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F6A7B8C9-D0E1-2345-FABC-456789012345}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -97,6 +133,12 @@ Global
 		{C7030DC8-24BC-312C-56D2-406D1403D45A} = {AE09C3B7-58AC-4A68-9884-1F93FDA5D785}
 		{5F800223-DBD6-8077-CA61-EC644D6958AA} = {AE09C3B7-58AC-4A68-9884-1F93FDA5D785}
 		{DA70CC85-EF3A-DCD7-82E8-0F5DD38E3CC3} = {AE09C3B7-58AC-4A68-9884-1F93FDA5D785}
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890} = {AE09C3B7-58AC-4A68-9884-1F93FDA5D785}
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901} = {AE09C3B7-58AC-4A68-9884-1F93FDA5D785}
+		{C3D4E5F6-A7B8-9012-CDEF-123456789012} = {AE09C3B7-58AC-4A68-9884-1F93FDA5D785}
+		{D4E5F6A7-B8C9-0123-DEFA-234567890123} = {46F3EDA8-A6D1-4707-8D03-731CADB41A56}
+		{E5F6A7B8-C9D0-1234-EFAB-345678901234} = {46F3EDA8-A6D1-4707-8D03-731CADB41A56}
+		{F6A7B8C9-D0E1-2345-FABC-456789012345} = {46F3EDA8-A6D1-4707-8D03-731CADB41A56}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {57CA0128-08DE-436F-B9F1-82C64F49BF67}
@@ -112,5 +154,11 @@ Global
 		tests\TestShared\TestShared.projitems*{ced63d2d-0af6-4831-806d-5e8e9b0d0a07}*SharedItemsImports = 13
 		src\CADShared\CADShared.projitems*{da70cc85-ef3a-dcd7-82e8-0f5dd38e3cc3}*SharedItemsImports = 5
 		tests\TestShared\TestShared.projitems*{dbec8790-ac05-0884-60ad-84a0a93b4165}*SharedItemsImports = 5
+		src\CADShared\CADShared.projitems*{a1b2c3d4-e5f6-7890-abcd-ef1234567890}*SharedItemsImports = 5
+		src\CADShared\CADShared.projitems*{b2c3d4e5-f6a7-8901-bcde-f12345678901}*SharedItemsImports = 5
+		src\CADShared\CADShared.projitems*{c3d4e5f6-a7b8-9012-cdef-123456789012}*SharedItemsImports = 5
+		tests\TestShared\TestShared.projitems*{d4e5f6a7-b8c9-0123-defa-234567890123}*SharedItemsImports = 5
+		tests\TestShared\TestShared.projitems*{e5f6a7b8-c9d0-1234-efab-345678901234}*SharedItemsImports = 5
+		tests\TestShared\TestShared.projitems*{f6a7b8c9-d0e1-2345-fabc-456789012345}*SharedItemsImports = 5
 	EndGlobalSection
 EndGlobal

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,7 @@ front matter schema 和自动校验尚未落地。在迁移完成前，本页状
 | `guide.building` | `current` | [构建与项目结构](../编译说明.md) | maintainer | 正式项目、工具链、条件编译、输出和验证边界。 |
 | `guide.host-acceptance` | `current` | [CAD 真实宿主验收 Runner](../tools/HostAcceptance/README.md) | maintainer | 真实 CAD 验收的目标矩阵、证据契约、安全边界、当前限制和执行入口。 |
 | `reference.zwcad-compatibility` | `current` | [ZWCAD 版本兼容性与迁移说明](ZWCAD-version-compatibility.md) | user, maintainer | ZRXSDK 代际、当前发布策略、Build-only 边界和未验证状态。 |
+| `reference.gstarcad-support-design` | `current` | [GStarCAD 支持扩展设计](superpowers/specs/2026-08-03-gstarcad-support-design.md) | maintainer | 浩辰 CAD 2022/2023/2026 三版本支持架构。 |
 | `decision.autocad-2027-net8` | `current` | [AutoCAD 2027 .NET 8 兼容策略](AC_2027-net8-compatibility-decision.md) | maintainer | 预备项目当前使用 .NET 8 的原因、限制和回迁条件。 |
 | `concept.upstream-relationship` | `current` | [上游 IFoxCAD 与 Fs.Fox.CAD 的关系](<../IFoxCAD 说明.md>) | user, maintainer | 项目来源、独立维护边界和问题归属。 |
 | `guide.repository-maintenance` | `current` | [Fs.Fox.CAD 维护说明](../Fs分支说明.md) | maintainer | 命名、远程仓库和上游贡献边界。 |

--- a/docs/关于IFoxCAD的架构说明.md
+++ b/docs/关于IFoxCAD的架构说明.md
@@ -206,6 +206,14 @@ tests/
 
 版本项目是 SDK/API 代际边界，不要求每个产品年度都有一个项目。只有厂商 API、目标框架或二进制兼容性发生变化时才应新增项目；可兼容年度优先复用已有产物，并用兼容性文档记录依据和宿主验收状态。
 
+### GStarCAD（浩辰CAD）
+
+- 条件编译符号：`GCAD;GC_2022` / `GCAD;GC_2023` / `GCAD;GC_2026`
+- 命名空间：`Gssoft.Gscad.*`
+- GlobalUsings：`src/IFoxCAD.Gcad/GlobalUsings.cs`
+- NuGet：`GStarCad.Net`
+- 输出目录：`Build\GC_202x_$(Configuration)\`
+
 ## 6. 测试边界
 
 `TestShared` 同样以共享源码方式导入各宿主测试项目。这能验证同一功能是否可在不同平台编译，并提供 `NETLOAD` 后可执行的测试命令，但它不是脱离 CAD 进程运行的常规单元测试套件。

--- a/src/CADShared/Cad/Application/Context/Env.cs
+++ b/src/CADShared/Cad/Application/Context/Env.cs
@@ -1,5 +1,5 @@
 using System.Security;
-#if AC_NET48 || ZWCAD
+#if AC_NET48 || ZWCAD || GC_2022 || GC_2023
 using ArgumentNullException = Fs.Fox.Basal.ArgumentNullEx;
 #endif
 

--- a/src/CADShared/Cad/Database/Associativity/AssocPersSubentityIdPEEx.cs
+++ b/src/CADShared/Cad/Database/Associativity/AssocPersSubentityIdPEEx.cs
@@ -1,3 +1,4 @@
+#if !GC_2022 && !GC_2023
 namespace Fs.Fox.Cad.Assoc;
 
 /// <summary>
@@ -61,3 +62,4 @@ public static class AssocPersSubentityIdPEEx
 
 #endif
 }
+#endif

--- a/src/CADShared/Cad/Database/Collections/CollectionEx.cs
+++ b/src/CADShared/Cad/Database/Collections/CollectionEx.cs
@@ -213,10 +213,8 @@ public static class CollectionEx
         switch (keywordName)
         {
             case KeywordName.GlobalName:
-                for (var i = 0; i < collection.Count; i++)
+                foreach (Keyword item in collection)
                 {
-                    var item = collection[i];
-
                     if (item.GlobalName == name)
                     {
                         contains = true;
@@ -226,10 +224,8 @@ public static class CollectionEx
 
                 break;
             case KeywordName.LocalName:
-                for (var i = 0; i < collection.Count; i++)
+                foreach (Keyword item in collection)
                 {
-                    var item = collection[i];
-
                     if (item.LocalName == name)
                     {
                         contains = true;
@@ -239,10 +235,8 @@ public static class CollectionEx
 
                 break;
             case KeywordName.DisplayName:
-                for (var i = 0; i < collection.Count; i++)
+                foreach (Keyword item in collection)
                 {
-                    var item = collection[i];
-
                     if (item.DisplayName == name)
                     {
                         contains = true;
@@ -266,10 +260,8 @@ public static class CollectionEx
     public static Dictionary<string, string> ToDictionary(this KeywordCollection collection)
     {
         Dictionary<string, string> map = new();
-        for (var i = 0; i < collection.Count; i++)
+        foreach (Keyword item in collection)
         {
-            var item = collection[i];
-
             map.Add(item.GlobalName, item.DisplayName);
         }
 

--- a/src/CADShared/Cad/Database/DatabaseEx.cs
+++ b/src/CADShared/Cad/Database/DatabaseEx.cs
@@ -115,7 +115,7 @@ public static class DatabaseEx
         if (Path.GetExtension(saveAsFile)!.ToLower().Contains("dxf"))
         {
             // dxf用任何版本号都会报错
-#if ACAD || GCAD
+#if ACAD
             db.DxfOut(saveAsFile, 7, true);
 #endif
 

--- a/src/CADShared/Cad/Database/Entities/Blocks/BlockReferenceEx.cs
+++ b/src/CADShared/Cad/Database/Entities/Blocks/BlockReferenceEx.cs
@@ -1,4 +1,4 @@
-#if AC_NET48 || ZWCAD
+#if AC_NET48 || ZWCAD || GC_2022 || GC_2023
 using ArgumentNullException = Fs.Fox.Basal.ArgumentNullEx;
 #endif
 

--- a/src/CADShared/Cad/Database/Entities/Blocks/BlockReferenceEx.cs
+++ b/src/CADShared/Cad/Database/Entities/Blocks/BlockReferenceEx.cs
@@ -61,7 +61,7 @@ public static class BlockReferenceEx
             double.NegativeInfinity, true);
         var dict = brf.GetXDictionary().GetSubDictionary(true, [kFilterDictName])!;
         dict.SetData(kSpatialName, sf);
-#if !ACAD
+#if GC_2022 || GC_2023 || ZW_2022 || ZW_2025
         pts.Dispose();
 #endif
     }

--- a/src/CADShared/Cad/Database/Entities/Curves/ArcEx.cs
+++ b/src/CADShared/Cad/Database/Entities/Curves/ArcEx.cs
@@ -41,7 +41,19 @@ public static class ArcEx
         CircularArc3d geArc = new(startPoint, pointOnArc, endPoint);
         // 将几何类圆弧对象的圆心和半径赋值给圆弧
 
+#if !GC_2022 && !GC_2023
         return (Arc)Curve.CreateFromGeCurve(geArc);
+#else
+        // GStarCAD 2022/2023 不支持 Curve.CreateFromGeCurve，使用圆心半径方式重建
+        Arc arc = new();
+        arc.SetDatabaseDefaults();
+        arc.Center = geArc.Center;
+        arc.Radius = geArc.Radius;
+        arc.Normal = geArc.Normal;
+        arc.StartAngle = geArc.StartAngle;
+        arc.EndAngle = geArc.EndAngle;
+        return arc;
+#endif
     }
 
     /// <summary>

--- a/src/CADShared/Cad/Database/Entities/Curves/ArcEx.cs
+++ b/src/CADShared/Cad/Database/Entities/Curves/ArcEx.cs
@@ -40,12 +40,8 @@ public static class ArcEx
         // 创建一个几何类的圆弧对象
         CircularArc3d geArc = new(startPoint, pointOnArc, endPoint);
         // 将几何类圆弧对象的圆心和半径赋值给圆弧
-#if !GCAD
 
         return (Arc)Curve.CreateFromGeCurve(geArc);
-#else
-        return (Arc)geArc.ToCurve();
-#endif
     }
 
     /// <summary>

--- a/src/CADShared/Cad/Database/Entities/Curves/CurveEx.cs
+++ b/src/CADShared/Cad/Database/Entities/Curves/CurveEx.cs
@@ -248,7 +248,6 @@ public static class CurveEx
 
         return newCurves;
     }
-#if !GCAD
     /// <summary>
     /// 打段曲线2维By四叉树
     /// <code>
@@ -421,7 +420,6 @@ public static class CurveEx
             Rect = rect;
         }
     }
-#endif
     /// <summary>
     /// 获取非等比转换的曲线（旋转投影法）
     /// </summary>

--- a/src/CADShared/Cad/Database/Entities/Curves/CurveEx.cs
+++ b/src/CADShared/Cad/Database/Entities/Curves/CurveEx.cs
@@ -248,6 +248,7 @@ public static class CurveEx
 
         return newCurves;
     }
+#if !GC_2022 && !GC_2023
     /// <summary>
     /// 打段曲线2维By四叉树
     /// <code>
@@ -420,6 +421,7 @@ public static class CurveEx
             Rect = rect;
         }
     }
+#endif
     /// <summary>
     /// 获取非等比转换的曲线（旋转投影法）
     /// </summary>

--- a/src/CADShared/Cad/Database/Entities/Curves/CurveEx.cs
+++ b/src/CADShared/Cad/Database/Entities/Curves/CurveEx.cs
@@ -1,6 +1,6 @@
 // ReSharper disable ForCanBeConvertedToForeach
 
-#if AC_NET48 || ZWCAD
+#if AC_NET48 || ZWCAD || GC_2022 || GC_2023
 using ArgumentNullException = Fs.Fox.Basal.ArgumentNullEx;
 #endif
 

--- a/src/CADShared/Cad/Database/Entities/Hatch/HatchConverter.cs
+++ b/src/CADShared/Cad/Database/Entities/Hatch/HatchConverter.cs
@@ -1,7 +1,7 @@
 // ReSharper disable CompareOfFloatsByEqualityOperator
 // ReSharper disable ForCanBeConvertedToForeach
 
-#if AC_NET48 || ZWCAD
+#if AC_NET48 || ZWCAD || GC_2022 || GC_2023
 using ArgumentNullException = Fs.Fox.Basal.ArgumentNullEx;
 #endif
 

--- a/src/CADShared/Cad/Database/Entities/Hatch/HatchInfo.cs
+++ b/src/CADShared/Cad/Database/Entities/Hatch/HatchInfo.cs
@@ -1,6 +1,6 @@
 
 
-#if AC_NET48 || ZWCAD
+#if AC_NET48 || ZWCAD || GC_2022 || GC_2023
 using ArgumentNullException = Fs.Fox.Basal.ArgumentNullEx;
 #endif
 

--- a/src/CADShared/Cad/Database/SymbolTables/SymbolTable.cs
+++ b/src/CADShared/Cad/Database/SymbolTables/SymbolTable.cs
@@ -1,6 +1,6 @@
 // ReSharper disable RedundantNameQualifier
 
-#if AC_NET48 || ZWCAD
+#if AC_NET48 || ZWCAD || GC_2022 || GC_2023
 using ArgumentNullException = Fs.Fox.Basal.ArgumentNullEx;
 #endif
 

--- a/src/CADShared/Cad/Database/SymbolTables/SymbolTableRecordEx.cs
+++ b/src/CADShared/Cad/Database/SymbolTables/SymbolTableRecordEx.cs
@@ -1,5 +1,5 @@
 
-#if AC_NET48 || ZWCAD
+#if AC_NET48 || ZWCAD || GC_2022 || GC_2023
 using ArgumentNullException = Fs.Fox.Basal.ArgumentNullEx;
 #endif
 

--- a/src/CADShared/Cad/Database/Transactions/DBTrans.cs
+++ b/src/CADShared/Cad/Database/Transactions/DBTrans.cs
@@ -1,5 +1,5 @@
 namespace Fs.Fox.Cad;
-#if AC_NET48 || ZWCAD
+#if AC_NET48 || ZWCAD || GC_2022 || GC_2023
 using ArgumentNullException = Fs.Fox.Basal.ArgumentNullEx;
 #endif
 using System.Diagnostics;

--- a/src/CADShared/Cad/Database/Xrefs/XrefPath.cs
+++ b/src/CADShared/Cad/Database/Xrefs/XrefPath.cs
@@ -1,6 +1,6 @@
 // ReSharper disable ForCanBeConvertedToForeach
 
-#if AC_NET48 || ZWCAD
+#if AC_NET48 || ZWCAD || GC_2022 || GC_2023
 using ArgumentNullException = Fs.Fox.Basal.ArgumentNullEx;
 #endif
 

--- a/src/CADShared/Cad/Editor/Commands/PostCmd.cs
+++ b/src/CADShared/Cad/Editor/Commands/PostCmd.cs
@@ -115,6 +115,8 @@ public class PostCmd
         object[] commandArray = [args + "\n"];
 #if ZWCAD
         var com = CadApp.ZcadApplication;
+#elif GCAD
+        var com = CadApp.GcadApplication;
 #else
         var com = CadApp.AcadApplication;
 #endif

--- a/src/CADShared/Cad/Editor/Commands/PostCmd.cs
+++ b/src/CADShared/Cad/Editor/Commands/PostCmd.cs
@@ -115,8 +115,6 @@ public class PostCmd
         object[] commandArray = [args + "\n"];
 #if ZWCAD
         var com = CadApp.ZcadApplication;
-#elif GCAD
-        var com = CadApp.GcadApplication;
 #else
         var com = CadApp.AcadApplication;
 #endif

--- a/src/CADShared/Cad/Editor/EditorEx.cs
+++ b/src/CADShared/Cad/Editor/EditorEx.cs
@@ -1122,8 +1122,6 @@ public static class EditorEx
 
 #if ZWCAD
         dynamic com = CadApp.ZcadApplication;
-#elif GCAD
-        dynamic com = CadApp.GcadApplication;
 #else
         dynamic com = CadApp.AcadApplication;
 #endif

--- a/src/CADShared/Cad/Editor/EditorEx.cs
+++ b/src/CADShared/Cad/Editor/EditorEx.cs
@@ -1122,6 +1122,8 @@ public static class EditorEx
 
 #if ZWCAD
         dynamic com = CadApp.ZcadApplication;
+#elif GCAD
+        dynamic com = CadApp.GcadApplication;
 #else
         dynamic com = CadApp.AcadApplication;
 #endif

--- a/src/CADShared/Cad/Editor/Input/SingleKeyWordHook.cs
+++ b/src/CADShared/Cad/Editor/Input/SingleKeyWordHook.cs
@@ -160,7 +160,7 @@ public sealed class SingleKeyWordHook : IDisposable
             case SingleKeyWordWorkType.WRITE_LINE:
                 Utils.SetFocusToDwgView(); // 恢复焦点（如果前面关键字输入错误便会将焦点移至动态输入框）
 
-#if !ZW_2022
+#if !ZW_2022 && !GC_2022 && !GC_2023
                 Utils.WriteToCommandLine(Convert.ToChar(_key) + _enterStr);
 #else
                 Debug.Assert(false, "中望CAD2022未测试!");

--- a/src/CADShared/Cad/Editor/Jig/JigEx.cs
+++ b/src/CADShared/Cad/Editor/Jig/JigEx.cs
@@ -1,4 +1,4 @@
-#if AC_NET48 || ZWCAD
+#if AC_NET48 || ZWCAD || GC_2022 || GC_2023
 using ArgumentNullException = Fs.Fox.Basal.ArgumentNullEx;
 #endif
 

--- a/src/CADShared/Cad/Editor/Jig/JigExTransient.cs
+++ b/src/CADShared/Cad/Editor/Jig/JigExTransient.cs
@@ -4,7 +4,7 @@ namespace Fs.Fox.Cad;
 /// <summary>
 /// 瞬态容器
 /// </summary>
-public class JigExTransient
+public class JigExTransient : IDisposable
 {
     #region 私有字段
 

--- a/src/CADShared/Cad/Editor/Jig/JigExTransient.cs
+++ b/src/CADShared/Cad/Editor/Jig/JigExTransient.cs
@@ -1,9 +1,10 @@
+#if !GC_2022 && !GC_2023
 namespace Fs.Fox.Cad;
 
 /// <summary>
 /// 瞬态容器
 /// </summary>
-public class JigExTransient : IDisposable
+public class JigExTransient
 {
     #region 私有字段
 
@@ -181,3 +182,4 @@ public class JigExTransient : IDisposable
 
     #endregion
 }
+#endif

--- a/src/CADShared/Cad/Editor/Selection/SelectionSetEx.cs
+++ b/src/CADShared/Cad/Editor/Selection/SelectionSetEx.cs
@@ -1,4 +1,4 @@
-#if AC_NET48 || ZWCAD
+#if AC_NET48 || ZWCAD || GC_2022 || GC_2023
 using ArgumentNullException = Fs.Fox.Basal.ArgumentNullEx;
 #endif
 

--- a/src/CADShared/Cad/Geometry/PointEx.cs
+++ b/src/CADShared/Cad/Geometry/PointEx.cs
@@ -1,4 +1,4 @@
-#if AC_NET48 || ZWCAD
+#if AC_NET48 || ZWCAD || GC_2022 || GC_2023
 using ArgumentNullException = Fs.Fox.Basal.ArgumentNullEx;
 #endif
 

--- a/src/CADShared/Cad/Geometry/SpatialIndex/QuadTree/Rect.cs
+++ b/src/CADShared/Cad/Geometry/SpatialIndex/QuadTree/Rect.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
-#if AC_NET48 || ZWCAD
+#if AC_NET48 || ZWCAD || GC_2022 || GC_2023
 using ArgumentNullException = Fs.Fox.Basal.ArgumentNullEx;
 #endif
 namespace Fs.Fox.Cad;

--- a/src/CADShared/Cad/Interop/Native/PInvokeCad.cs
+++ b/src/CADShared/Cad/Interop/Native/PInvokeCad.cs
@@ -53,37 +53,30 @@ internal static class PInvokeCad
         return ZcdbEntUpd(ref adsName);
     }
 #elif GCAD
-    // GStarCAD native P/Invoke - gcad specific DLL and mangled entry points
-    // Versions 2022/2023/2026 may use same DLL name pattern
-    #if GC_2022
-        const string AcDbModule = "gcad22.dll";
-    #elif GC_2023
-        const string AcDbModule = "gcad23.dll";
-    #elif GC_2026
-        const string AcDbModule = "gcad26.dll";
-    #else
-        #error Unsupported GStarCAD target. Define GC_2022, GC_2023, or GC_2026.
-    #endif
+    // GStarCAD native P/Invoke
+    // The GetAdsName/EntGet/EntMod/EntUpd interop is not supported on GStarCAD
+    // because the native entry points and ADS name structures differ per version.
+    // These stubs prevent CS0117 on callers; callers must guard with #if !GCAD.
+    internal static int GetAdsName(ObjectId objectId, out CadAdsName adsName)
+    {
+        adsName = default;
+        return 0;
+    }
 
-    [System.Security.SuppressUnmanagedCodeSecurity]
-    [DllImport(AcDbModule, CallingConvention = CallingConvention.Cdecl,
-        EntryPoint = "?gcadGetAdsName@@YAHPEB_WPEAUads_name@@@Z")]
-    internal static extern int acdbGetAdsName(string name, out AdsName result);
+    internal static IntPtr EntGet(ref CadAdsName adsName)
+    {
+        return IntPtr.Zero;
+    }
 
-    [System.Security.SuppressUnmanagedCodeSecurity]
-    [DllImport("gced.dll", CallingConvention = CallingConvention.Cdecl,
-        EntryPoint = "gcedEntGet")]
-    internal static extern int acdbEntGet(AdsName objId);
+    internal static int EntMod(IntPtr buffer)
+    {
+        return 0;
+    }
 
-    [System.Security.SuppressUnmanagedCodeSecurity]
-    [DllImport("gced.dll", CallingConvention = CallingConvention.Cdecl,
-        EntryPoint = "gcedEntMod")]
-    internal static extern int acdbEntMod(AdsName objId, ResultBuffer rb);
-
-    [System.Security.SuppressUnmanagedCodeSecurity]
-    [DllImport("gced.dll", CallingConvention = CallingConvention.Cdecl,
-        EntryPoint = "gcedEntUpd")]
-    internal static extern int acdbEntUpd(AdsName objId);
+    internal static int EntUpd(ref CadAdsName adsName)
+    {
+        return 0;
+    }
 #else
 #if AC_2019
     private const string AcDbModule = "acdb23.dll";

--- a/src/CADShared/Cad/Interop/Native/PInvokeCad.cs
+++ b/src/CADShared/Cad/Interop/Native/PInvokeCad.cs
@@ -52,6 +52,38 @@ internal static class PInvokeCad
     {
         return ZcdbEntUpd(ref adsName);
     }
+#elif GCAD
+    // GStarCAD native P/Invoke - gcad specific DLL and mangled entry points
+    // Versions 2022/2023/2026 may use same DLL name pattern
+    #if GC_2022
+        const string AcDbModule = "gcad22.dll";
+    #elif GC_2023
+        const string AcDbModule = "gcad23.dll";
+    #elif GC_2026
+        const string AcDbModule = "gcad26.dll";
+    #else
+        #error Unsupported GStarCAD target. Define GC_2022, GC_2023, or GC_2026.
+    #endif
+
+    [System.Security.SuppressUnmanagedCodeSecurity]
+    [DllImport(AcDbModule, CallingConvention = CallingConvention.Cdecl,
+        EntryPoint = "?gcadGetAdsName@@YAHPEB_WPEAUads_name@@@Z")]
+    internal static extern int acdbGetAdsName(string name, out AdsName result);
+
+    [System.Security.SuppressUnmanagedCodeSecurity]
+    [DllImport("gced.dll", CallingConvention = CallingConvention.Cdecl,
+        EntryPoint = "gcedEntGet")]
+    internal static extern int acdbEntGet(AdsName objId);
+
+    [System.Security.SuppressUnmanagedCodeSecurity]
+    [DllImport("gced.dll", CallingConvention = CallingConvention.Cdecl,
+        EntryPoint = "gcedEntMod")]
+    internal static extern int acdbEntMod(AdsName objId, ResultBuffer rb);
+
+    [System.Security.SuppressUnmanagedCodeSecurity]
+    [DllImport("gced.dll", CallingConvention = CallingConvention.Cdecl,
+        EntryPoint = "gcedEntUpd")]
+    internal static extern int acdbEntUpd(AdsName objId);
 #else
 #if AC_2019
     private const string AcDbModule = "acdb23.dll";

--- a/src/CADShared/Cad/Runtime/Initialization/MethodInfoHelper.cs
+++ b/src/CADShared/Cad/Runtime/Initialization/MethodInfoHelper.cs
@@ -1,4 +1,4 @@
-#if AC_NET48 || ZWCAD
+#if AC_NET48 || ZWCAD || GC_2022 || GC_2023
 using ArgumentNullException = Fs.Fox.Basal.ArgumentNullEx;
 #endif
 

--- a/src/CADShared/Cad/Runtime/Registration/AutoRegAssem.cs
+++ b/src/CADShared/Cad/Runtime/Registration/AutoRegAssem.cs
@@ -1,4 +1,4 @@
-#if AC_NET48 || ZWCAD
+#if AC_NET48 || ZWCAD || GC_2022 || GC_2023
 using ArgumentNullException = Fs.Fox.Basal.ArgumentNullEx;
 #endif
 

--- a/src/CADShared/Cad/UI/StatusBar/ProgressMeterUtils.cs
+++ b/src/CADShared/Cad/UI/StatusBar/ProgressMeterUtils.cs
@@ -1,4 +1,4 @@
-#if AC_NET48 || ZWCAD
+#if AC_NET48 || ZWCAD || GC_2022 || GC_2023
 using ArgumentNullException = Fs.Fox.Basal.ArgumentNullEx;
 #endif
 

--- a/src/CADShared/Cad/UI/StatusBar/ProgressMeterUtils.cs
+++ b/src/CADShared/Cad/UI/StatusBar/ProgressMeterUtils.cs
@@ -28,6 +28,8 @@ public static class ProgressMeterUtils
 #if ZWCAD
         EnsureZwcadSuccess(ZcedSetStatusBarProgressMeter(label, minimum, maximum),
             "create the status-bar progress meter");
+#elif GCAD
+        // GStarCAD: fallback to no-op until native API verified
 #else
         Utils.SetApplicationStatusBarProgressMeter(label, minimum, maximum);
 #endif
@@ -42,6 +44,8 @@ public static class ProgressMeterUtils
 #if ZWCAD
         EnsureZwcadSuccess(ZcedSetStatusBarProgressMeterPos(position),
             "update the status-bar progress meter");
+#elif GCAD
+        // GStarCAD: fallback to no-op until native API verified
 #else
         Utils.SetApplicationStatusBarProgressMeter(position);
 #endif
@@ -54,6 +58,8 @@ public static class ProgressMeterUtils
     {
 #if ZWCAD
         ZcedRestoreStatusBar();
+#elif GCAD
+        // GStarCAD: fallback to no-op until native API verified
 #else
         Utils.RestoreApplicationStatusBar();
 #endif

--- a/src/CADShared/Cad/UI/Windows/WindowEx.cs
+++ b/src/CADShared/Cad/UI/Windows/WindowEx.cs
@@ -88,7 +88,7 @@ public static class WindowEx
             newHeight = size.Height;
         }
 
-#if !ZW_2022
+#if !ZW_2022 && !GC_2022 && !GC_2023
 // paletteSet.SetSize(new Size(newWidth, newHeight));   // 中望2025 这样调用报错找不到setsize函数
         WindowExtension.SetSize(paletteSet, new Size(newWidth, newHeight)); // 中望2025这样调用没有问题
 #else

--- a/src/CADShared/Foundation/Compatibility/ArgumentNullEx.cs
+++ b/src/CADShared/Foundation/Compatibility/ArgumentNullEx.cs
@@ -1,5 +1,5 @@
 
-#if AC_NET48 || ZWCAD
+#if AC_NET48 || ZWCAD || GC_2022 || GC_2023
 namespace Fs.Fox.Basal;
 
 /// <summary>

--- a/src/CADShared/Foundation/Compatibility/CallerArgumentExpressionAttribute.cs
+++ b/src/CADShared/Foundation/Compatibility/CallerArgumentExpressionAttribute.cs
@@ -1,5 +1,5 @@
 
-#if AC_NET48 || ZWCAD
+#if AC_NET48 || ZWCAD || GC_2022 || GC_2023
 namespace System.Runtime.CompilerServices;
 /// <summary>
 /// 指示参数将为另一个参数传递的表达式捕获为字符串。

--- a/src/CADShared/Platform/Windows/Interop/WindowsAPI.cs
+++ b/src/CADShared/Platform/Windows/Interop/WindowsAPI.cs
@@ -1,6 +1,6 @@
 #pragma warning disable CS1591 // 缺少对公共可见类型或成员的 XML 注释
 #define Marshal
-#if AC_NET48 || ZWCAD
+#if AC_NET48 || ZWCAD || GC_2022 || GC_2023
 using ArgumentNullException = Fs.Fox.Basal.ArgumentNullEx;
 #endif
 namespace Fs.Fox.Basal;

--- a/src/Fs.Fox.AutoCad2025/Fs.Fox.AutoCad2025.csproj
+++ b/src/Fs.Fox.AutoCad2025/Fs.Fox.AutoCad2025.csproj
@@ -69,7 +69,7 @@
     <!-- AutoCAD 2025 的 NuGet 包引用 -->
     <ItemGroup>
         <PackageReference Include="AutoCAD.NET" Version="25.0.1" ExcludeAssets="runtime" />
-        <PackageReference Include="PolySharp" Version="1.15.0">
+        <PackageReference Include="PolySharp" Version="1.16.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Fs.Fox.Gcad2022/Fs.Fox.Gcad2022.csproj
+++ b/src/Fs.Fox.Gcad2022/Fs.Fox.Gcad2022.csproj
@@ -1,0 +1,72 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFrameworks>net48</TargetFrameworks>
+        <GCADVersion>2022</GCADVersion>
+        <AssemblyName>Fs.Fox.Gcad</AssemblyName>
+        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+        <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1900</WarningsNotAsErrors>
+    </PropertyGroup>
+    
+    <!--nuget package-->
+    <PropertyGroup>
+        <PackageId>IFox.CAD.GCAD2022</PackageId>
+        <Title>Fs.Fox.CAD for GStarCAD 2022</Title>
+        <Product>IFox.CAD.GCAD2022</Product>
+        <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+        <Description>面向 GStarCAD 2022 x64 API 代际和 .NET Framework 4.8 的 CAD 二次开发基础类库，基于 GStarCad.Net 20.22.0。源于 IFoxCAD，由 Fs 团队维护。</Description>
+        <Copyright>FS Team</Copyright>
+        <PackageReleaseNotes>初始发布，新增 GStarCAD 2022 支持</PackageReleaseNotes>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+        <DebugType>none</DebugType>
+        <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+        <OutputPath>..\..\Build\GC_$(GCADVersion)_$(Configuration)\</OutputPath>
+        <DocumentationFile>..\..\Build\GC_$(GCADVersion)_$(Configuration)\Fs.Fox.Gcad.xml</DocumentationFile>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+        <DebugType>none</DebugType>
+        <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+        <OutputPath>..\..\Build\GC_$(GCADVersion)_$(Configuration)\</OutputPath>
+        <DocumentationFile>..\..\Build\GC_$(GCADVersion)_$(Configuration)\Fs.Fox.Gcad.xml</DocumentationFile>
+    </PropertyGroup>
+
+    <!-- 条件编译符号 -->
+    <PropertyGroup>
+        <DefineConstants>$(Configuration);GCAD;GC_2022</DefineConstants>
+        <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Compile Include="..\..\src\IFoxCAD.Gcad\GlobalUsings.cs">
+            <Pack>True</Pack>
+            <PackagePath>\</PackagePath>
+        </Compile>
+        <None Include="..\..\LICENSE">
+            <Pack>True</Pack>
+            <PackagePath>\</PackagePath>
+        </None>
+        <None Include="..\..\readme.md">
+            <Pack>True</Pack>
+            <PackagePath>\</PackagePath>
+        </None>
+        <!-- Include Test DLL in NuGet package -->
+        <None Include="..\..\Build\GC_$(GCADVersion)_$(Configuration)\TestGcad2022.dll" Condition="Exists('..\..\Build\GC_$(GCADVersion)_$(Configuration)\TestGcad2022.dll')">
+            <Pack>True</Pack>
+            <PackagePath>lib\net48\</PackagePath>
+        </None>
+    </ItemGroup>
+
+    <!-- GStarCAD 2022 NuGet 包 + PolySharp -->
+    <ItemGroup>
+        <PackageReference Include="GStarCad.Net" Version="20.22.0" ExcludeAssets="runtime" />
+        <PackageReference Include="PolySharp" Version="1.16.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <Reference Include="Microsoft.CSharp" />
+    </ItemGroup>
+    
+    <Import Project="..\CADShared\CADShared.projitems" Label="Shared" />
+</Project>

--- a/src/Fs.Fox.Gcad2023/Fs.Fox.Gcad2023.csproj
+++ b/src/Fs.Fox.Gcad2023/Fs.Fox.Gcad2023.csproj
@@ -63,6 +63,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
+        <Reference Include="Microsoft.CSharp" />
     </ItemGroup>
 
     <Import Project="..\CADShared\CADShared.projitems" Label="Shared" />

--- a/src/Fs.Fox.Gcad2023/Fs.Fox.Gcad2023.csproj
+++ b/src/Fs.Fox.Gcad2023/Fs.Fox.Gcad2023.csproj
@@ -1,0 +1,69 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFrameworks>net48</TargetFrameworks>
+        <GCADVersion>2023</GCADVersion>
+        <AssemblyName>Fs.Fox.Gcad</AssemblyName>
+        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+        <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1900</WarningsNotAsErrors>
+    </PropertyGroup>
+
+    <!--nuget package-->
+    <PropertyGroup>
+        <PackageId>IFox.CAD.GCAD2023</PackageId>
+        <Title>Fs.Fox.CAD for GStarCAD 2023</Title>
+        <Product>IFox.CAD.GCAD2023</Product>
+        <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+        <Description>面向 GStarCAD 2023 x64 API 代际和 .NET Framework 4.8 的 CAD 二次开发基础类库。源于 IFoxCAD，由 Fs 团队维护。</Description>
+        <Copyright>FS Team</Copyright>
+        <PackageReleaseNotes>新增浩辰CAD 2023支持</PackageReleaseNotes>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+        <DebugType>none</DebugType>
+        <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+        <OutputPath>..\..\Build\GC_$(GCADVersion)_$(Configuration)\</OutputPath>
+        <DocumentationFile>..\..\Build\GC_$(GCADVersion)_$(Configuration)\Fs.Fox.Gcad.xml</DocumentationFile>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+        <DebugType>none</DebugType>
+        <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+        <OutputPath>..\..\Build\GC_$(GCADVersion)_$(Configuration)\</OutputPath>
+        <DocumentationFile>..\..\Build\GC_$(GCADVersion)_$(Configuration)\Fs.Fox.Gcad.xml</DocumentationFile>
+    </PropertyGroup>
+
+    <!-- 条件编译符号 -->
+    <PropertyGroup>
+        <DefineConstants>$(Configuration);GCAD;GC_2023</DefineConstants>
+        <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Compile Include="..\..\src\IFoxCAD.Gcad\GlobalUsings.cs">
+            <Pack>True</Pack>
+            <PackagePath>\</PackagePath>
+        </Compile>
+        <None Include="..\..\LICENSE">
+            <Pack>True</Pack>
+            <PackagePath>\</PackagePath>
+        </None>
+        <None Include="..\..\readme.md">
+            <Pack>True</Pack>
+            <PackagePath>\</PackagePath>
+        </None>
+        <None Include="..\..\Build\GC_$(GCADVersion)_$(Configuration)\TestGcad2023.dll" Condition="Exists('..\..\Build\GC_$(GCADVersion)_$(Configuration)\TestGcad2023.dll')">
+            <Pack>True</Pack>
+            <PackagePath>lib\net48\</PackagePath>
+        </None>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="GStarCad.Net" Version="20.23.0" ExcludeAssets="runtime" />
+        <PackageReference Include="PolySharp" Version="1.15.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <Import Project="..\CADShared\CADShared.projitems" Label="Shared" />
+</Project>

--- a/src/Fs.Fox.Gcad2023/Fs.Fox.Gcad2023.csproj
+++ b/src/Fs.Fox.Gcad2023/Fs.Fox.Gcad2023.csproj
@@ -59,7 +59,7 @@
 
     <ItemGroup>
         <PackageReference Include="GStarCad.Net" Version="20.23.0" ExcludeAssets="runtime" />
-        <PackageReference Include="PolySharp" Version="1.15.0">
+        <PackageReference Include="PolySharp" Version="1.16.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Fs.Fox.Gcad2026/Fs.Fox.Gcad2026.csproj
+++ b/src/Fs.Fox.Gcad2026/Fs.Fox.Gcad2026.csproj
@@ -58,7 +58,7 @@
 
     <ItemGroup>
         <PackageReference Include="GStarCad.Net" Version="20.26.0" ExcludeAssets="runtime" />
-        <PackageReference Include="PolySharp" Version="1.15.0">
+        <PackageReference Include="PolySharp" Version="1.16.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Fs.Fox.Gcad2026/Fs.Fox.Gcad2026.csproj
+++ b/src/Fs.Fox.Gcad2026/Fs.Fox.Gcad2026.csproj
@@ -1,0 +1,68 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFrameworks>net8.0-windows7.0</TargetFrameworks>
+        <GCADVersion>2026</GCADVersion>
+        <AssemblyName>Fs.Fox.Gcad</AssemblyName>
+        <EnableDynamicLoading>true</EnableDynamicLoading>
+        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    </PropertyGroup>
+
+    <!--nuget package-->
+    <PropertyGroup>
+        <PackageId>IFox.CAD.GCAD2026</PackageId>
+        <Title>Fs.Fox.CAD for GStarCAD 2026</Title>
+        <Product>IFox.CAD.GCAD2026</Product>
+        <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+        <Description>面向 GStarCAD 2026 x64 API 代际和 .NET 8 的 CAD 二次开发基础类库。源于 IFoxCAD，由 Fs 团队维护。</Description>
+        <Copyright>FS Team</Copyright>
+        <PackageReleaseNotes>新增浩辰CAD 2026支持</PackageReleaseNotes>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+        <DebugType>none</DebugType>
+        <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+        <OutputPath>..\..\Build\GC_$(GCADVersion)_$(Configuration)\</OutputPath>
+        <DocumentationFile>..\..\Build\GC_$(GCADVersion)_$(Configuration)\Fs.Fox.Gcad.xml</DocumentationFile>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+        <DebugType>none</DebugType>
+        <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+        <OutputPath>..\..\Build\GC_$(GCADVersion)_$(Configuration)\</OutputPath>
+        <DocumentationFile>..\..\Build\GC_$(GCADVersion)_$(Configuration)\Fs.Fox.Gcad.xml</DocumentationFile>
+    </PropertyGroup>
+
+    <!-- 条件编译符号 -->
+    <PropertyGroup>
+        <DefineConstants>$(Configuration);GCAD;GC_2026</DefineConstants>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Compile Include="..\..\src\IFoxCAD.Gcad\GlobalUsings.cs">
+            <Pack>True</Pack>
+            <PackagePath>\</PackagePath>
+        </Compile>
+        <None Include="..\..\LICENSE">
+            <Pack>True</Pack>
+            <PackagePath>\</PackagePath>
+        </None>
+        <None Include="..\..\readme.md">
+            <Pack>True</Pack>
+            <PackagePath>\</PackagePath>
+        </None>
+        <None Include="..\..\Build\GC_$(GCADVersion)_$(Configuration)\TestGcad2026.dll" Condition="Exists('..\..\Build\GC_$(GCADVersion)_$(Configuration)\TestGcad2026.dll')">
+            <Pack>True</Pack>
+            <PackagePath>lib\net8.0-windows7.0\</PackagePath>
+        </None>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="GStarCad.Net" Version="20.26.0" ExcludeAssets="runtime" />
+        <PackageReference Include="PolySharp" Version="1.15.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <Import Project="..\CADShared\CADShared.projitems" Label="Shared" />
+</Project>

--- a/src/Fs.Fox.ZwCad2025/Fs.Fox.ZwCad2025.csproj
+++ b/src/Fs.Fox.ZwCad2025/Fs.Fox.ZwCad2025.csproj
@@ -60,7 +60,7 @@
     <!-- ZWCAD 2025 的 NuGet 包引用 -->
     <ItemGroup>
         <PackageReference Include="ZWCAD.NetApi" Version="20.25.0" ExcludeAssets="runtime" />
-        <PackageReference Include="PolySharp" Version="1.15.0">
+        <PackageReference Include="PolySharp" Version="1.16.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/IFoxCAD.Gcad/GlobalUsings.cs
+++ b/src/IFoxCAD.Gcad/GlobalUsings.cs
@@ -1,8 +1,11 @@
 // ============================================================================
 // IFoxCAD.Gcad GlobalUsings.cs - GStarCAD（浩辰CAD）平台
+// GStarCAD 2022/2023 (net48): GrxCAD.* 命名空间
+// GStarCAD 2026+  (net8.0):   Gssoft.Gscad.* 命名空间
 // ============================================================================
 
-// GStarCAD 命名空间
+#if GC_2026
+// GStarCAD 2026 命名空间 (Gssoft.Gscad.*)
 global using Gssoft.Gscad.ApplicationServices;
 global using Gssoft.Gscad.DatabaseServices;
 global using Gssoft.Gscad.EditorInput;
@@ -15,7 +18,7 @@ global using Gssoft.Gscad.DatabaseServices.Filters;
 global using Gssoft.Gscad.GraphicsSystem;
 
 // ============================================================================
-// Cad 前缀标准别名
+// Cad 前缀标准别名 - GStarCAD 2026
 // ============================================================================
 global using CadApp = Gssoft.Gscad.ApplicationServices.Application;
 global using CadCoreApp = Gssoft.Gscad.ApplicationServices.Core.Application;
@@ -29,10 +32,11 @@ global using CadErrorStatus = Gssoft.Gscad.Runtime.ErrorStatus;
 global using CadDwgFiler = Gssoft.Gscad.DatabaseServices.DwgFiler;
 global using CadDxfFiler = Gssoft.Gscad.DatabaseServices.DxfFiler;
 global using CadOpenFileDialog = Gssoft.Gscad.Windows.OpenFileDialog;
-global using Marshaler = Gssoft.Gscad.Runtime.Marshaler;
+global using Marshaler = Gssoft.Gscad.ApplicationServices.Marshaler;
+global using Utils = Gssoft.Gscad.Internal.Utils;
 
 // ============================================================================
-// 解决命名冲突
+// 解决命名冲突 - GStarCAD 2026
 // ============================================================================
 global using LineWeight = Gssoft.Gscad.DatabaseServices.LineWeight;
 global using Viewport = Gssoft.Gscad.DatabaseServices.Viewport;
@@ -48,6 +52,57 @@ global using Exception = System.Exception;
 global using DrawingColor = System.Drawing.Color;
 global using Registry = Microsoft.Win32.Registry;
 global using RegistryKey = Microsoft.Win32.RegistryKey;
+
+#else
+// GStarCAD 2022/2023 命名空间 (GrxCAD.*)
+global using GrxCAD.ApplicationServices;
+global using GrxCAD.DatabaseServices;
+global using GrxCAD.EditorInput;
+global using GrxCAD.Geometry;
+global using GrxCAD.GraphicsInterface;
+global using GrxCAD.Runtime;
+global using GrxCAD.Windows;
+global using GrxCAD.Colors;
+global using GrxCAD.DatabaseServices.Filters;
+global using GrxCAD.GraphicsSystem;
+
+// ============================================================================
+// Cad 前缀标准别名 - GStarCAD 2022/2023
+// GrxCAD 没有 Core.Application，DocumentManager/GetSystemVariable 直接在 Application 上
+// ============================================================================
+global using CadApp = GrxCAD.ApplicationServices.Application;
+global using CadCoreApp = GrxCAD.ApplicationServices.Application;
+global using CadDbServices = GrxCAD.DatabaseServices;
+global using CadGI = GrxCAD.GraphicsInterface;
+global using CadGS = GrxCAD.GraphicsSystem;
+global using CadRuntime = GrxCAD.Runtime;
+global using CadWindow = GrxCAD.Windows;
+global using CadException = GrxCAD.Runtime.Exception;
+global using CadErrorStatus = GrxCAD.Runtime.ErrorStatus;
+global using CadDwgFiler = GrxCAD.DatabaseServices.DwgFiler;
+global using CadDxfFiler = GrxCAD.DatabaseServices.DxfFiler;
+global using CadOpenFileDialog = GrxCAD.Windows.OpenFileDialog;
+global using Marshaler = GrxCAD.ApplicationServices.Marshaler;
+global using Utils = GrxCAD.Internal.Utils;
+
+// ============================================================================
+// 解决命名冲突 - GStarCAD 2022/2023
+// ============================================================================
+global using LineWeight = GrxCAD.DatabaseServices.LineWeight;
+global using Viewport = GrxCAD.DatabaseServices.Viewport;
+global using Color = GrxCAD.Colors.Color;
+global using Polyline = GrxCAD.DatabaseServices.Polyline;
+global using Group = GrxCAD.DatabaseServices.Group;
+global using CursorType = GrxCAD.EditorInput.CursorType;
+global using ColorDialog = GrxCAD.Windows.ColorDialog;
+global using StatusBar = GrxCAD.Windows.StatusBar;
+global using SystemVariableChangedEventArgs = GrxCAD.ApplicationServices.SystemVariableChangedEventArgs;
+global using Region = GrxCAD.DatabaseServices.Region;
+global using Exception = System.Exception;
+global using DrawingColor = System.Drawing.Color;
+global using Registry = Microsoft.Win32.Registry;
+global using RegistryKey = Microsoft.Win32.RegistryKey;
+#endif
 
 // ============================================================================
 // 系统命名空间

--- a/src/IFoxCAD.Gcad/GlobalUsings.cs
+++ b/src/IFoxCAD.Gcad/GlobalUsings.cs
@@ -1,0 +1,77 @@
+// ============================================================================
+// IFoxCAD.Gcad GlobalUsings.cs - GStarCAD（浩辰CAD）平台
+// ============================================================================
+
+// GStarCAD 命名空间
+global using Gssoft.Gscad.ApplicationServices;
+global using Gssoft.Gscad.DatabaseServices;
+global using Gssoft.Gscad.EditorInput;
+global using Gssoft.Gscad.Geometry;
+global using Gssoft.Gscad.GraphicsInterface;
+global using Gssoft.Gscad.Runtime;
+global using Gssoft.Gscad.Windows;
+global using Gssoft.Gscad.Colors;
+global using Gssoft.Gscad.DatabaseServices.Filters;
+global using Gssoft.Gscad.GraphicsSystem;
+
+// ============================================================================
+// Cad 前缀标准别名
+// ============================================================================
+global using CadApp = Gssoft.Gscad.ApplicationServices.Application;
+global using CadCoreApp = Gssoft.Gscad.ApplicationServices.Core.Application;
+global using CadDbServices = Gssoft.Gscad.DatabaseServices;
+global using CadGI = Gssoft.Gscad.GraphicsInterface;
+global using CadGS = Gssoft.Gscad.GraphicsSystem;
+global using CadRuntime = Gssoft.Gscad.Runtime;
+global using CadWindow = Gssoft.Windows;
+global using CadException = Gssoft.Gscad.Runtime.Exception;
+global using CadErrorStatus = Gssoft.Gscad.Runtime.ErrorStatus;
+global using CadDwgFiler = Gssoft.Gscad.DatabaseServices.DwgFiler;
+global using CadDxfFiler = Gssoft.Gscad.DatabaseServices.DxfFiler;
+global using CadOpenFileDialog = Gssoft.Gscad.Windows.OpenFileDialog;
+global using Marshaler = Gssoft.Gscad.Runtime.Marshaler;
+
+// ============================================================================
+// 解决命名冲突
+// ============================================================================
+global using LineWeight = Gssoft.Gscad.DatabaseServices.LineWeight;
+global using Viewport = Gssoft.Gscad.DatabaseServices.Viewport;
+global using Color = Gssoft.Gscad.Colors.Color;
+global using Polyline = Gssoft.Gscad.DatabaseServices.Polyline;
+global using Group = Gssoft.Gscad.DatabaseServices.Group;
+global using CursorType = Gssoft.Gscad.EditorInput.CursorType;
+global using ColorDialog = Gssoft.Gscad.Windows.ColorDialog;
+global using StatusBar = Gssoft.Gscad.Windows.StatusBar;
+global using SystemVariableChangedEventArgs = Gssoft.Gscad.ApplicationServices.SystemVariableChangedEventArgs;
+global using Region = Gssoft.Gscad.DatabaseServices.Region;
+global using Exception = System.Exception;
+global using DrawingColor = System.Drawing.Color;
+global using Registry = Microsoft.Win32.Registry;
+global using RegistryKey = Microsoft.Win32.RegistryKey;
+
+// ============================================================================
+// 系统命名空间
+// ============================================================================
+global using System;
+global using System.Reflection;
+global using System.Collections;
+global using System.Collections.Generic;
+global using System.IO;
+global using System.Linq;
+global using System.Threading;
+global using System.Text;
+global using System.Runtime.InteropServices;
+global using System.ComponentModel;
+global using Microsoft.Win32;
+global using System.Linq.Expressions;
+global using System.Collections.ObjectModel;
+global using System.Text.RegularExpressions;
+global using System.Runtime.CompilerServices;
+global using System.Windows.Input;
+global using System.Globalization;
+global using System.Diagnostics;
+global using System.Net;
+global using System.Diagnostics.CodeAnalysis;
+
+// IFoxCAD
+global using Fs.Fox.Basal;

--- a/tests/TestAcad2019/TestAcad2019.csproj
+++ b/tests/TestAcad2019/TestAcad2019.csproj
@@ -32,12 +32,12 @@
 
 	<ItemGroup>
 		<PackageReference Include="AutoCAD.NET" Version="23.0.0" ExcludeAssets="runtime" />
-		<PackageReference Include="System.Text.Json" Version="9.0.9" />
+		<PackageReference Include="System.Text.Json" Version="10.0.10" />
 		<Reference Include="Microsoft.CSharp" />
 	</ItemGroup>
 	
 	<ItemGroup>
-	  <PackageReference Include="PolySharp" Version="1.15.0">
+	  <PackageReference Include="PolySharp" Version="1.16.0">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>

--- a/tests/TestAcad2025/TestAcad2025.csproj
+++ b/tests/TestAcad2025/TestAcad2025.csproj
@@ -36,7 +36,7 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-	  <PackageReference Include="PolySharp" Version="1.15.0">
+	  <PackageReference Include="PolySharp" Version="1.16.0">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>

--- a/tests/TestGcad2022/GlobalUsings.cs
+++ b/tests/TestGcad2022/GlobalUsings.cs
@@ -1,0 +1,50 @@
+/// 系统引用
+global using System;
+global using System.Collections;
+global using System.Collections.Generic;
+global using System.IO;
+global using System.Linq;
+global using System.Text;
+global using System.Reflection;
+global using System.Text.RegularExpressions;
+global using Microsoft.Win32;
+global using System.ComponentModel;
+global using System.Runtime.InteropServices;
+global using System.Collections.Specialized;
+global using System.Threading;
+global using System.Diagnostics;
+global using Exception = System.Exception;
+global using System.Runtime.CompilerServices;
+global using Registry = Microsoft.Win32.Registry;
+global using RegistryKey = Microsoft.Win32.RegistryKey;
+
+// cad 引用 (GStarCAD 2022 - GrxCAD.*)
+global using GrxCAD.ApplicationServices;
+global using GrxCAD.EditorInput;
+global using GrxCAD.Colors;
+global using GrxCAD.DatabaseServices;
+global using GrxCAD.Geometry;
+global using GrxCAD.Runtime;
+global using GrxCAD.DatabaseServices.Filters;
+global using GrxCAD.GraphicsInterface;
+global using GrxCAD.GraphicsSystem;
+global using CadApp = GrxCAD.ApplicationServices.Application;
+global using CadCoreApp = GrxCAD.ApplicationServices.Application;
+global using CadException = GrxCAD.Runtime.Exception;
+global using CadErrorStatus = GrxCAD.Runtime.ErrorStatus;
+global using CadGI = GrxCAD.GraphicsInterface;
+global using CadDwgFiler = GrxCAD.DatabaseServices.DwgFiler;
+global using CadDxfFiler = GrxCAD.DatabaseServices.DxfFiler;
+// jig命名空间会引起Viewport/Polyline等等重义,最好逐个引入 using GrxCAD.GraphicsInterface
+global using WorldDraw = GrxCAD.GraphicsInterface.WorldDraw;
+global using Manager = GrxCAD.GraphicsSystem.Manager;
+global using Group = GrxCAD.DatabaseServices.Group;
+global using Viewport = GrxCAD.DatabaseServices.Viewport;
+global using Polyline = GrxCAD.DatabaseServices.Polyline;
+
+
+/// ifoxcad
+global using Fs.Fox.Cad;
+global using Fs.Fox.Basal;
+
+global using Test;

--- a/tests/TestGcad2022/TestGcad2022.csproj
+++ b/tests/TestGcad2022/TestGcad2022.csproj
@@ -23,11 +23,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="PolySharp" Version="1.15.0">
+        <PackageReference Include="PolySharp" Version="1.16.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="System.Text.Json" Version="9.0.9" />
+        <PackageReference Include="System.Text.Json" Version="10.0.10" />
         <PackageReference Include="GStarCad.Net" Version="20.22.0" ExcludeAssets="runtime" />
     </ItemGroup>
 

--- a/tests/TestGcad2022/TestGcad2022.csproj
+++ b/tests/TestGcad2022/TestGcad2022.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+    <PropertyGroup>
+        <LangVersion>preview</LangVersion>
+        <Nullable>enable</Nullable>
+        <TargetFramework>NET48</TargetFramework>
+        <UseWPF>true</UseWPF>
+        <UseWindowsForms>true</UseWindowsForms>
+        <PlatformTarget>x64</PlatformTarget>
+        <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+        <OutputPath>..\..\Build\GC_2022_Debug\</OutputPath>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+        <OutputPath>..\..\Build\GC_2022_Release\</OutputPath>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <DefineConstants>$(Configuration);GCAD;GC_2022</DefineConstants>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="PolySharp" Version="1.15.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="System.Text.Json" Version="9.0.9" />
+        <PackageReference Include="GStarCad.Net" Version="20.22.0" ExcludeAssets="runtime" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Fs.Fox.Gcad2022\Fs.Fox.Gcad2022.csproj" />
+    </ItemGroup>
+    <Import Project="..\TestShared\TestShared.projitems" Label="Shared" />
+</Project>

--- a/tests/TestGcad2023/GlobalUsings.cs
+++ b/tests/TestGcad2023/GlobalUsings.cs
@@ -1,0 +1,50 @@
+/// 系统引用
+global using System;
+global using System.Collections;
+global using System.Collections.Generic;
+global using System.IO;
+global using System.Linq;
+global using System.Text;
+global using System.Reflection;
+global using System.Text.RegularExpressions;
+global using Microsoft.Win32;
+global using System.ComponentModel;
+global using System.Runtime.InteropServices;
+global using System.Collections.Specialized;
+global using System.Threading;
+global using System.Diagnostics;
+global using Exception = System.Exception;
+global using System.Runtime.CompilerServices;
+global using Registry = Microsoft.Win32.Registry;
+global using RegistryKey = Microsoft.Win32.RegistryKey;
+
+// cad 引用 (GStarCAD 2023 - GrxCAD.*)
+global using GrxCAD.ApplicationServices;
+global using GrxCAD.EditorInput;
+global using GrxCAD.Colors;
+global using GrxCAD.DatabaseServices;
+global using GrxCAD.Geometry;
+global using GrxCAD.Runtime;
+global using GrxCAD.DatabaseServices.Filters;
+global using GrxCAD.GraphicsInterface;
+global using GrxCAD.GraphicsSystem;
+global using CadApp = GrxCAD.ApplicationServices.Application;
+global using CadCoreApp = GrxCAD.ApplicationServices.Application;
+global using CadException = GrxCAD.Runtime.Exception;
+global using CadErrorStatus = GrxCAD.Runtime.ErrorStatus;
+global using CadGI = GrxCAD.GraphicsInterface;
+global using CadDwgFiler = GrxCAD.DatabaseServices.DwgFiler;
+global using CadDxfFiler = GrxCAD.DatabaseServices.DxfFiler;
+// jig命名空间会引起Viewport/Polyline等等重义,最好逐个引入 using GrxCAD.GraphicsInterface
+global using WorldDraw = GrxCAD.GraphicsInterface.WorldDraw;
+global using Manager = GrxCAD.GraphicsSystem.Manager;
+global using Group = GrxCAD.DatabaseServices.Group;
+global using Viewport = GrxCAD.DatabaseServices.Viewport;
+global using Polyline = GrxCAD.DatabaseServices.Polyline;
+
+
+/// ifoxcad
+global using Fs.Fox.Cad;
+global using Fs.Fox.Basal;
+
+global using Test;

--- a/tests/TestGcad2023/TestGcad2023.csproj
+++ b/tests/TestGcad2023/TestGcad2023.csproj
@@ -23,11 +23,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="PolySharp" Version="1.15.0">
+        <PackageReference Include="PolySharp" Version="1.16.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="System.Text.Json" Version="9.0.9" />
+        <PackageReference Include="System.Text.Json" Version="10.0.10" />
         <PackageReference Include="GStarCad.Net" Version="20.23.0" ExcludeAssets="runtime" />
     </ItemGroup>
 

--- a/tests/TestGcad2023/TestGcad2023.csproj
+++ b/tests/TestGcad2023/TestGcad2023.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+    <PropertyGroup>
+        <LangVersion>preview</LangVersion>
+        <Nullable>enable</Nullable>
+        <TargetFramework>NET48</TargetFramework>
+        <UseWPF>true</UseWPF>
+        <UseWindowsForms>true</UseWindowsForms>
+        <PlatformTarget>x64</PlatformTarget>
+        <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+        <OutputPath>..\..\Build\GC_2023_Debug\</OutputPath>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+        <OutputPath>..\..\Build\GC_2023_Release\</OutputPath>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <DefineConstants>$(Configuration);GCAD;GC_2023</DefineConstants>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="PolySharp" Version="1.15.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="System.Text.Json" Version="9.0.9" />
+        <PackageReference Include="GStarCad.Net" Version="20.23.0" ExcludeAssets="runtime" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Fs.Fox.Gcad2023\Fs.Fox.Gcad2023.csproj" />
+    </ItemGroup>
+    <Import Project="..\TestShared\TestShared.projitems" Label="Shared" />
+</Project>

--- a/tests/TestGcad2026/GlobalUsings.cs
+++ b/tests/TestGcad2026/GlobalUsings.cs
@@ -1,0 +1,51 @@
+/// 系统引用
+global using System;
+global using System.Collections;
+global using System.Collections.Generic;
+global using System.IO;
+global using System.Linq;
+global using System.Text;
+global using System.Reflection;
+global using System.Text.RegularExpressions;
+global using Microsoft.Win32;
+global using System.ComponentModel;
+global using System.Runtime.InteropServices;
+global using System.Collections.Specialized;
+global using System.Threading;
+global using System.Diagnostics;
+global using Exception = System.Exception;
+global using System.Runtime.CompilerServices;
+global using Registry = Microsoft.Win32.Registry;
+global using RegistryKey = Microsoft.Win32.RegistryKey;
+
+// cad 引用 (GStarCAD 2026 - Gssoft.Gscad.*)
+global using Gssoft.Gscad.ApplicationServices;
+global using Gssoft.Gscad.EditorInput;
+global using Gssoft.Gscad.Colors;
+global using Gssoft.Gscad.DatabaseServices;
+global using Gssoft.Gscad.Geometry;
+global using Gssoft.Gscad.Runtime;
+global using Gssoft.Gscad.DatabaseServices.Filters;
+global using Gssoft.Gscad.GraphicsInterface;
+global using Gssoft.Gscad.GraphicsSystem;
+global using CadApp = Gssoft.Gscad.ApplicationServices.Application;
+global using CadCoreApp = Gssoft.Gscad.ApplicationServices.Core.Application;
+global using CadException = Gssoft.Gscad.Runtime.Exception;
+global using CadErrorStatus = Gssoft.Gscad.Runtime.ErrorStatus;
+global using CadGI = Gssoft.Gscad.GraphicsInterface;
+global using CadDwgFiler = Gssoft.Gscad.DatabaseServices.DwgFiler;
+global using CadDxfFiler = Gssoft.Gscad.DatabaseServices.DxfFiler;
+// jig命名空间会引起Viewport/Polyline等等重义,最好逐个引入 using Gssoft.Gscad.GraphicsInterface
+global using WorldDraw = Gssoft.Gscad.GraphicsInterface.WorldDraw;
+global using Manager = Gssoft.Gscad.GraphicsSystem.Manager;
+global using Group = Gssoft.Gscad.DatabaseServices.Group;
+global using Viewport = Gssoft.Gscad.DatabaseServices.Viewport;
+global using Polyline = Gssoft.Gscad.DatabaseServices.Polyline;
+global using LineWeight = Gssoft.Gscad.DatabaseServices.LineWeight;
+
+
+/// ifoxcad
+global using Fs.Fox.Cad;
+global using Fs.Fox.Basal;
+
+global using Test;

--- a/tests/TestGcad2026/TestGcad2026.csproj
+++ b/tests/TestGcad2026/TestGcad2026.csproj
@@ -32,7 +32,7 @@
 
     <ItemGroup>
         <PackageReference Include="GStarCad.Net" Version="20.26.0" ExcludeAssets="runtime" />
-        <PackageReference Include="PolySharp" Version="1.15.0">
+        <PackageReference Include="PolySharp" Version="1.16.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/tests/TestGcad2026/TestGcad2026.csproj
+++ b/tests/TestGcad2026/TestGcad2026.csproj
@@ -1,0 +1,45 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <LangVersion>preview</LangVersion>
+        <Nullable>enable</Nullable>
+        <TargetFramework>net8.0-windows7.0</TargetFramework>
+        <UseWPF>true</UseWPF>
+        <UseWindowsForms>true</UseWindowsForms>
+        <PlatformTarget>x64</PlatformTarget>
+        <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+        <AssemblyVersion>1.0.0.*</AssemblyVersion>
+        <FileVersion>1.0.0.0</FileVersion>
+        <Deterministic>false</Deterministic>
+        <EnableDynamicLoading>true</EnableDynamicLoading>
+        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+        <DebugType>none</DebugType>
+        <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+        <OutputPath>..\..\Build\GC_2026_Debug\</OutputPath>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+        <DebugType>none</DebugType>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <OutputPath>..\..\Build\GC_2026_Release\</OutputPath>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <DefineConstants>$(Configuration);GCAD;GC_2026</DefineConstants>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="GStarCad.Net" Version="20.26.0" ExcludeAssets="runtime" />
+        <PackageReference Include="PolySharp" Version="1.15.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Fs.Fox.Gcad2026\Fs.Fox.Gcad2026.csproj" />
+    </ItemGroup>
+    <Import Project="..\TestShared\TestShared.projitems" Label="Shared" />
+</Project>

--- a/tests/TestShared/TestEnv.cs
+++ b/tests/TestShared/TestEnv.cs
@@ -89,7 +89,7 @@ public class Testenv
     //}
 
 
-#if !ZWCAD
+#if !ZWCAD && !GCAD
     // 通过此功能获取全部变量,尚不清楚此处如何设置,没有通过测试
     [CommandMethod(nameof(Test_GetvarAll))]
     public static void Test_GetvarAll()

--- a/tests/TestShared/TestExtents.cs
+++ b/tests/TestShared/TestExtents.cs
@@ -82,6 +82,7 @@ public class TestExtents
                
                 if (e is Curve spline)
                 {
+#if !GCAD
                     var ge = spline.GetGeCurve();
                     var box = ge.BoundBlock;
                     List<Point3d> lst = 
@@ -96,6 +97,7 @@ public class TestExtents
                         e.ColorIndex = 6;
                         e.Closed = true;
                     }));
+#endif
                 }
                 
             }

--- a/tests/TestShared/TestJigExTransient.cs
+++ b/tests/TestShared/TestJigExTransient.cs
@@ -1,4 +1,4 @@
-
+#if !GC_2022 && !GC_2023
 namespace Test;
 
 public partial class Test
@@ -86,3 +86,4 @@ public partial class Test
         tr.CurrentSpace.AddEntity(dimension);
     }
 }
+#endif

--- a/tests/TestZcad2022/TestZcad2022.csproj
+++ b/tests/TestZcad2022/TestZcad2022.csproj
@@ -23,11 +23,11 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="PolySharp" Version="1.15.0">
+        <PackageReference Include="PolySharp" Version="1.16.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="System.Text.Json" Version="9.0.9" />
+        <PackageReference Include="System.Text.Json" Version="10.0.10" />
         <PackageReference Include="ZWCAD.NetApi" Version="20.22.0" ExcludeAssets="compile;runtime" />
         <Reference Include="ZwDatabaseMgd">
             <HintPath>$(FsLibsDir)SDK\ZRX2022\lib-x64\ZwDatabaseMgd.dll</HintPath>

--- a/tests/TestZcad2025/TestZcad2025.csproj
+++ b/tests/TestZcad2025/TestZcad2025.csproj
@@ -23,11 +23,11 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="PolySharp" Version="1.15.0">
+        <PackageReference Include="PolySharp" Version="1.16.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="System.Text.Json" Version="9.0.9" />
+        <PackageReference Include="System.Text.Json" Version="10.0.10" />
         <PackageReference Include="ZWCAD.NetApi" Version="20.25.0" ExcludeAssets="runtime" />
     </ItemGroup>
     

--- a/编译说明.md
+++ b/编译说明.md
@@ -79,6 +79,21 @@ msbuild .\tests\TestZcad2025\TestZcad2025.csproj '/t:Restore;Build' `
 dotnet build .\tests\TestAcad2025\TestAcad2025.csproj -c Release
 ```
 
+### GStarCAD（浩辰CAD）2022
+```powershell
+msbuild tests/TestGcad2022/TestGcad2022.csproj /t:Restore;Build /p:Configuration=Debug /p:Platform="Any CPU" /verbosity:minimal
+```
+
+### GStarCAD（浩辰CAD）2023
+```powershell
+msbuild tests/TestGcad2023/TestGcad2023.csproj /t:Restore;Build /p:Configuration=Debug /p:Platform="Any CPU" /verbosity:minimal
+```
+
+### GStarCAD（浩辰CAD）2026
+```powershell
+dotnet build tests/TestGcad2026/TestGcad2026.csproj --configuration Debug
+```
+
 也可以在 Visual Studio 中打开 `IFoxCAD.sln` 构建当前四个目标。CI 的精确命令见 [构建检查工作流](.github/workflows/build-and-deploy.yml)。
 
 ## 输出目录


### PR DESCRIPTION
为 Fs.Fox.CAD 新增了对**浩辰CAD（GStarCAD）2022、2023、2026**三个版本的支持。主要内容包括：

- 新增 3 个平台库项目（`Fs.Fox.Gcad2022/2023/2026`，其中 2022/2023 为 .NET Framework 4.8，2026 为 .NET 8.0）及对应的测试项目。
- 在共享代码中大量加入 `#if GC_2022` / `#if GC_2023` 条件编译，处理不同平台间的 API 差异（如 Arc 构造方式、DXF 导出等）。
- PInvokeCad 针对浩辰平台改用存根方法（无 native interop），同时清理了残留的休眠 GCAD 条件编译。
- CI 构建和发布流程同步扩展，覆盖新增的三个 GCAD 目标。
- 附带依赖包版本升级（PolySharp 1.15→1.16、System.Text.Json 9.0.9→10.0.10）。