### PR TITLE
feat: add geometry query primitives

### DIFF
--- a/Build/CADSharedCompatibilityBaseline.json
+++ b/Build/CADSharedCompatibilityBaseline.json
@@ -103,7 +103,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2298,
+        "publicApiRecordCount": 2305,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -382,8 +382,8 @@
           },
           {
             "type": "Fs.Fox.Cad.CurveEx",
-            "recordCount": 31,
-            "contractSha256": "808602652496dd6369b0c200c9d01e262c7d43834bdeffdbb4898ff8b1d20afa"
+            "recordCount": 34,
+            "contractSha256": "a71a48987dc50e58ad55a5da3d91dde0803a539e3bea679e29071ee35f3d40df"
           },
           {
             "type": "Fs.Fox.Cad.DatabaseEx",
@@ -722,8 +722,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PointEx",
-            "recordCount": 22,
-            "contractSha256": "0474742d333a6ba048ac2ac6ee688f00197be90d5e7576ce2eae3ece75de1bfe"
+            "recordCount": 24,
+            "contractSha256": "dcc41ddcb6149ae4a3d4daff0b2007faee124c437633af1c6382862b85c3a4db"
           },
           {
             "type": "Fs.Fox.Cad.PointOnRegionType",
@@ -732,8 +732,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PolylineEx",
-            "recordCount": 9,
-            "contractSha256": "e129eeb7832d061e4ea1eda94b82884ca132d52723279d975c9d81a113fbd2d7"
+            "recordCount": 11,
+            "contractSha256": "3aff3a32a0fd63e63a3fedd7d857e29b00c7c002681f994ca296401080f746e4"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -1004,9 +1004,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.AutoCad.xml",
-            "length": 490259,
+            "length": 496065,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "36e5b2e9e09b7e16204a1f14bcfe49d90702e427e16cd6302d6418e86531c518",
+            "contentSha256": "9461882745dedbe7016b924690be883406f565c2a625e158b42be430d2899e4b",
             "binarySource": null
           },
           {
@@ -1212,7 +1212,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2296,
+        "publicApiRecordCount": 2303,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArrayEx",
@@ -1486,8 +1486,8 @@
           },
           {
             "type": "Fs.Fox.Cad.CurveEx",
-            "recordCount": 31,
-            "contractSha256": "c519ffa156d4728f44a97369e058a68b40e0ba552997df87cd9d446fc9b97c2c"
+            "recordCount": 34,
+            "contractSha256": "0994521d70817ce2572d33ad54c70c54fa0f9426dee34f3c034d0cc1a3e2f198"
           },
           {
             "type": "Fs.Fox.Cad.DatabaseEx",
@@ -1826,8 +1826,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PointEx",
-            "recordCount": 22,
-            "contractSha256": "8a19c2ca319e98a3d074d2e83dbcbc944a6f291744f008fbeb5f306b6294ecaa"
+            "recordCount": 24,
+            "contractSha256": "230d7251a6cd2ce982cf485d63d333e82adc382250d79ef96a72da19ae56f068"
           },
           {
             "type": "Fs.Fox.Cad.PointOnRegionType",
@@ -1836,8 +1836,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PolylineEx",
-            "recordCount": 9,
-            "contractSha256": "4430d7ea55289925fc1b82f97752ae3f864cde94ca85f25068e6b682777d5585"
+            "recordCount": 11,
+            "contractSha256": "0b848fbd8d8de9e5afab4011e48ebbff5f3c40fef73397309099b21c71e9b22c"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -2122,9 +2122,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.AutoCad.xml",
-            "length": 454532,
+            "length": 460341,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "aa68fd8bb0daf214b90c22a556f2a13cbd863f15975938ae9f7005e1c605520c",
+            "contentSha256": "5bb03f051842bf76f8ff2c4de829ec3afd37892d88af374b9de1e07703634939",
             "binarySource": null
           },
           {
@@ -2246,7 +2246,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2275,
+        "publicApiRecordCount": 2282,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -2520,8 +2520,8 @@
           },
           {
             "type": "Fs.Fox.Cad.CurveEx",
-            "recordCount": 31,
-            "contractSha256": "fea592d09e7b86c7dea633fbe6a44bfbf71eec0630f82206fb707cb03743e838"
+            "recordCount": 34,
+            "contractSha256": "25c1f8cc9aa458138ad9573f3b35d5e37ebad8478681d741946da05fd0d0c7a0"
           },
           {
             "type": "Fs.Fox.Cad.DatabaseEx",
@@ -2855,8 +2855,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PointEx",
-            "recordCount": 22,
-            "contractSha256": "8f7b20d4748f03a49aec486fde1d33e86c4619de841ea5e8284627f3d6769f93"
+            "recordCount": 24,
+            "contractSha256": "09c2fc5cef4edc22b2c0a8697d360f57f24f5a0609b09d6276fe8ad92e1ad68c"
           },
           {
             "type": "Fs.Fox.Cad.PointOnRegionType",
@@ -2865,8 +2865,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PolylineEx",
-            "recordCount": 9,
-            "contractSha256": "c1be91bbcb040a8bf88c570793631cf1c2eff04866472a4f89a882715a6a1b82"
+            "recordCount": 11,
+            "contractSha256": "921aa6b2e802236c7d86808c13aac916d7ff87d1ea8d559f04dc62157179af0b"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -3123,9 +3123,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 481181,
+            "length": 486947,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "227da6292324b41e087ff2ecba86c571afe92480aa755994322874a9c675cfc4",
+            "contentSha256": "0a8895a513d432ecd02f44b190b9af6cab32ae20e79b8c1b21255ec21a6c53b2",
             "binarySource": null
           },
           {
@@ -3247,7 +3247,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2278,
+        "publicApiRecordCount": 2285,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -3521,8 +3521,8 @@
           },
           {
             "type": "Fs.Fox.Cad.CurveEx",
-            "recordCount": 31,
-            "contractSha256": "fea592d09e7b86c7dea633fbe6a44bfbf71eec0630f82206fb707cb03743e838"
+            "recordCount": 34,
+            "contractSha256": "25c1f8cc9aa458138ad9573f3b35d5e37ebad8478681d741946da05fd0d0c7a0"
           },
           {
             "type": "Fs.Fox.Cad.DatabaseEx",
@@ -3856,8 +3856,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PointEx",
-            "recordCount": 22,
-            "contractSha256": "8f7b20d4748f03a49aec486fde1d33e86c4619de841ea5e8284627f3d6769f93"
+            "recordCount": 24,
+            "contractSha256": "09c2fc5cef4edc22b2c0a8697d360f57f24f5a0609b09d6276fe8ad92e1ad68c"
           },
           {
             "type": "Fs.Fox.Cad.PointOnRegionType",
@@ -3866,8 +3866,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PolylineEx",
-            "recordCount": 9,
-            "contractSha256": "c1be91bbcb040a8bf88c570793631cf1c2eff04866472a4f89a882715a6a1b82"
+            "recordCount": 11,
+            "contractSha256": "921aa6b2e802236c7d86808c13aac916d7ff87d1ea8d559f04dc62157179af0b"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -4124,9 +4124,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 482570,
+            "length": 488336,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "526f11c0944505de2c5b5380e27ba7c2b9334303d04cc990d78c86ec60da54f0",
+            "contentSha256": "9f732de88936fbeb1bb2ab35a07d612a49b4eadd2d31f70856116798ca14b14a",
             "binarySource": null
           },
           {
@@ -4248,7 +4248,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2262,
+        "publicApiRecordCount": 2269,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -4517,8 +4517,8 @@
           },
           {
             "type": "Fs.Fox.Cad.CurveEx",
-            "recordCount": 30,
-            "contractSha256": "6d5c160bf0bfcd354bb13e5e5383a20d0f1b4fb96cff140009762fc0ded14777"
+            "recordCount": 33,
+            "contractSha256": "9d63ec03e1ef6dabc845d8a8342427598c4b8de648cbcf44c68b0685c46e73d8"
           },
           {
             "type": "Fs.Fox.Cad.DatabaseEx",
@@ -4847,8 +4847,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PointEx",
-            "recordCount": 22,
-            "contractSha256": "28ef136750a626537da612c66624190927725e1d6b1d78c2223b5389e9da7fdb"
+            "recordCount": 24,
+            "contractSha256": "75646268c6496a2dd5a4967e254ea0a9da100d2ea297f0fe0a3e7685ed584f3c"
           },
           {
             "type": "Fs.Fox.Cad.PointOnRegionType",
@@ -4857,8 +4857,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PolylineEx",
-            "recordCount": 9,
-            "contractSha256": "c48bfdefb465abe0538f6a47fcb2c38a6d1dabfd08471dae9cf0b586d93790a5"
+            "recordCount": 11,
+            "contractSha256": "962fade718ca34104f38ae77c680c953f048a511ad15a53e8b48f4a187ae6e53"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -5115,9 +5115,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 474999,
+            "length": 480705,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "e09d49eab2c4e72d65785eaa9b0b30f2a01329fd6365949d46614cdde48c8d4d",
+            "contentSha256": "abe116c62e5b5f01291e209db42efc483580f1b8f1596d45e00274cc36f3d715",
             "binarySource": null
           },
           {
@@ -5239,7 +5239,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2262,
+        "publicApiRecordCount": 2269,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -5508,8 +5508,8 @@
           },
           {
             "type": "Fs.Fox.Cad.CurveEx",
-            "recordCount": 30,
-            "contractSha256": "6d5c160bf0bfcd354bb13e5e5383a20d0f1b4fb96cff140009762fc0ded14777"
+            "recordCount": 33,
+            "contractSha256": "9d63ec03e1ef6dabc845d8a8342427598c4b8de648cbcf44c68b0685c46e73d8"
           },
           {
             "type": "Fs.Fox.Cad.DatabaseEx",
@@ -5838,8 +5838,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PointEx",
-            "recordCount": 22,
-            "contractSha256": "28ef136750a626537da612c66624190927725e1d6b1d78c2223b5389e9da7fdb"
+            "recordCount": 24,
+            "contractSha256": "75646268c6496a2dd5a4967e254ea0a9da100d2ea297f0fe0a3e7685ed584f3c"
           },
           {
             "type": "Fs.Fox.Cad.PointOnRegionType",
@@ -5848,8 +5848,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PolylineEx",
-            "recordCount": 9,
-            "contractSha256": "c48bfdefb465abe0538f6a47fcb2c38a6d1dabfd08471dae9cf0b586d93790a5"
+            "recordCount": 11,
+            "contractSha256": "962fade718ca34104f38ae77c680c953f048a511ad15a53e8b48f4a187ae6e53"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -6106,9 +6106,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 474999,
+            "length": 480705,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "e09d49eab2c4e72d65785eaa9b0b30f2a01329fd6365949d46614cdde48c8d4d",
+            "contentSha256": "abe116c62e5b5f01291e209db42efc483580f1b8f1596d45e00274cc36f3d715",
             "binarySource": null
           },
           {
@@ -6314,7 +6314,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2285,
+        "publicApiRecordCount": 2292,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArrayEx",
@@ -6583,8 +6583,8 @@
           },
           {
             "type": "Fs.Fox.Cad.CurveEx",
-            "recordCount": 31,
-            "contractSha256": "df1ae8119f6186c84bd33e84bd8e16f25edb0c710479b992ee16fd71c78433fe"
+            "recordCount": 34,
+            "contractSha256": "2f619d24c6db81e053feddb3febad16a5e5410f2cd5c565e5f0933d16f122c6a"
           },
           {
             "type": "Fs.Fox.Cad.DatabaseEx",
@@ -6918,8 +6918,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PointEx",
-            "recordCount": 22,
-            "contractSha256": "9e1b41b7eed67f45012f34c154651b998be06bdf040aade17e826cc1000d0d9a"
+            "recordCount": 24,
+            "contractSha256": "42e375a21d084aa3234fe082a46821b8c0048244cc5a18137545c0da548b0f6c"
           },
           {
             "type": "Fs.Fox.Cad.PointOnRegionType",
@@ -6928,8 +6928,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PolylineEx",
-            "recordCount": 9,
-            "contractSha256": "39e39ba8d4bcecca31a90851b7ad90e40175daa0fe3c73127848691d14c19486"
+            "recordCount": 11,
+            "contractSha256": "adf152ac3d02026f80509b72cc38f36c780d9347e6e363a049a9cb3714ae19b6"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -7200,9 +7200,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.Gcad.xml",
-            "length": 448266,
+            "length": 454035,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "b3e04ac7ed213be3d65db0a92049f27c6df386f6c946a1dd7a303df433204bca",
+            "contentSha256": "3b89a540bf149aa9b5dddfb7b4fd46738154ea0857139bbffc212c5baa116910",
             "binarySource": null
           },
           {

--- a/Build/CADSharedModuleBaseline.json
+++ b/Build/CADSharedModuleBaseline.json
@@ -493,7 +493,7 @@
       "module": "Cad.Database",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "22899506a843bbd306f723681602559cc77e1eacee46db8beaa851fa6a384969"
+      "sourceSha256": "7ff0e743a6fbc8f7d7dd233e8fd8a49b586a681be34441c3d339aa03eaae5f07"
     },
     {
       "order": "0360",
@@ -540,7 +540,7 @@
       "module": "Cad.Database",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "73b7ebc51401133ae1bb75dddca60ea905bdb33450e500454e288caec6d29c32"
+      "sourceSha256": "4b4bb2512f86772953b7ae590d9276bfe0bf2a27de7b3eb11e400920b5e27a49"
     },
     {
       "order": "0410",
@@ -673,7 +673,7 @@
       "module": "Cad.Geometry",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "ec00a879c45af65a2b010e6807b0d546dea087764c4784dac5ac7fb7d4fd65ad"
+      "sourceSha256": "ef468a6537dd5769ab8db3ef5b15030ee4b6c172d45b3660269508e6bbe713c3"
     },
     {
       "order": "0480",

--- a/docs/zfgk-cad-migration-plan.md
+++ b/docs/zfgk-cad-migration-plan.md
@@ -4,8 +4,7 @@
 > 状态：执行中（Active）<br>
 > 目标分支：`migration/zfgk-cad`<br>
 > 来源快照：`FeiSiDev/Fs.Zfgk.CAD@c38ce320c75284536c907c1046e5458da4ae0468`<br>
-> `main` 集成基线：`FsDiG/Fs.Fox.CAD@6e6f94223be418481663833fc65386d8cf2839a4`<br>
-> 当前分支基线：`migration/zfgk-cad@2e68759f710046416f4e27d2c2f87487e4160619`<br>
+> 最近 `main` 集成：`origin/main@6e6f94223be418481663833fc65386d8cf2839a4` 已由 `2e68759f710046416f4e27d2c2f87487e4160619` 合入<br>
 > 实施跟踪：[Issue #110](https://github.com/FsDiG/Fs.Fox.CAD/issues/110)<br>
 > 最近复核：2026-08-03<br>
 > CAD 宿主验收：Not run
@@ -147,13 +146,13 @@
 | `ObjectARX/Entity/ArcUtil.cs` | 反转圆弧可由厂商曲线 API表达；旧实现直接改 Normal/角度，需额外验证非 XY 平面。 | 不直接迁移。 |
 | `ObjectARX/Entity/BlockUtil.cs` | 块导入、插入和属性大多已有等价实现；“选定实体导出 DWG”仍可能有增量价值。 | 部分候选；仅评估缺失的导出契约和属性度量。 |
 | `ObjectARX/Entity/CircleUtil.cs` | 仅构造并入库，现有实体添加 API 足够。 | 不迁移。 |
-| `ObjectARX/Entity/CurveUtil.cs` | 子曲线、弦高、归一化位置、偏移和交点查询具有通用价值；旧实现对返回对象的释放和异常处理不完整。 | 高优先候选；拆为只读计算、返回新对象、数据库修改三个批次。 |
+| `ObjectARX/Entity/CurveUtil.cs` | 子曲线、弦高、归一化位置、偏移和交点查询具有通用价值；旧实现对返回对象的释放和异常处理不完整。 | 部分已吸收：Phase 1 批次 1 已加入长度比例取点和两种中点弦偏差；返回新对象和数据库修改仍按后续批次处理。 |
 | `ObjectARX/Entity/DimensionUtil.cs` | 旋转标注构造简单，未形成独特抽象。 | 低优先条件候选；有重复消费者时再加入窄扩展。 |
 | `ObjectARX/Entity/EntityUtil.cs` | 擦除、变换、颜色、包围盒和克隆大多已有等价实现。 | 复用现有实现；块属性克隆随 Block 项评估。 |
 | `ObjectARX/Entity/HatchUtil.cs` | 已有 `HatchEx`、`HatchConverter` 和边界创建能力；来源还依赖外部工具。 | 不迁移平行 API。 |
-| `ObjectARX/Entity/LineUtil.cs` | 方位、点线距离和插值有通用价值；相交状态和高程插值旧实现存在语义/结果问题。 | 部分候选；采用明确枚举/结果类型和退化线契约重写。 |
+| `ObjectARX/Entity/LineUtil.cs` | 方位、点线距离和插值有通用价值；相交状态和高程插值旧实现存在语义/结果问题。 | 部分已吸收：Phase 1 批次 1 已在 `PointEx` 加入比例插值和高程唯一点查询；方位/相交与修改操作继续去重。 |
 | `ObjectARX/Entity/PolyfaceMeshUtil.cs` | 仅创建网格并入库，现有实体添加机制可组合完成。 | 不迁移。 |
-| `ObjectARX/Entity/PolylineUtil.cs` | 连接、采样、分段、圆角、去零段和去共线点是本次最有价值的来源之一；旧实现同时操作事务、UI、对象释放和原位修改。 | 高优先候选；按“查询 -> 创建新对象 -> 原位修改 -> 批量数据库操作”四层重写。 |
+| `ObjectARX/Entity/PolylineUtil.cs` | 连接、采样、分段、圆角、去零段和去共线点是本次最有价值的来源之一；旧实现同时操作事务、UI、对象释放和原位修改。 | 部分已吸收：Phase 1 批次 1 已加入完整顶点数据快照和单段长度；采样、创建新对象和修改操作继续分层处理。 |
 | `ObjectARX/Entity/RegionUtil.cs` | `Explode` 后转折线并连接可为 `RegionEx.ToCurves()` 提供替代思路，但旧实现泄漏临时对象且没有内外环/方向契约。 | 高优先设计输入；与 Region 所有权和 ZWCAD BRep 路径统一处理。 |
 | `ObjectARX/Entity/TextUtil.cs` | 添加文字、文字样式和去格式化大多已有实现；文字边界度量可能有宿主差异。 | 复用现有实现；度量需求单独验证。 |
 | `ObjectARX/Entity/XDataUtil.cs` | 已由 `TypedValueList`、`XDataList`、`DBObjectEx` 和选择过滤体系覆盖。 | 复用现有实现。 |
@@ -206,7 +205,7 @@
 - [x] 记录现有等价 API、外部依赖和已知风险。
 - [x] 明确来源核对不作为本迁移实施门槛；Issue #105 与本计划解耦。
 - [x] 创建实施总跟踪 Issue #110。
-- [ ] 为第一批候选写具体 API 草案和测试样例，确认没有与实时 `main` 重复。
+- [x] 为第一批候选写具体 API 草案，确认没有与实时 `main` 重复。
 
 Phase 0 的清单和结构决策已经完成。后续每个代码批次必须回写本文的最终结论，不能只在 PR 对话中记录取舍。
 
@@ -220,6 +219,20 @@ Phase 0 的清单和结构决策已经完成。后续每个代码批次必须回
 - Extents/Rect 的关系和相交簇合并。
 
 约束：不写数据库、不依赖活动文档、不原位修改输入、不弹 UI。先增加测试，再增加公共 API；每个返回的新 CAD 对象都写明释放责任。
+
+批次 1 的 API 决定如下；它们都只返回值或托管快照，不创建需要调用方释放的 CAD 对象：
+
+| 目标类型 | API | 吸收的价值与契约修正 |
+| --- | --- | --- |
+| `CurveEx` | `GetPointAtDistanceFraction` | 按总长闭区间 `[0, 1]` 取点；修正旧实现忽略输入比例、固定取 `0.5` 的问题，并拒绝无限长度域。 |
+| `CurveEx` | `GetMidpointChordDeviation` | 明确按参数中点计算三维弦偏差，不把结果表述为区间最大误差。 |
+| `CurveEx` | `GetMidpointChordDeviationByDistance` | 明确按沿曲线距离中点计算，避免把距离端点转参数后误用参数中点。 |
+| `PolylineEx` | `GetVertexData` | 一次取得顶点、bulge、起宽和终宽的独立托管快照，不暴露 `ref` 集合。 |
+| `PolylineEx` | `GetSegmentLength` | 对开放/闭合折线验证真实子段索引；直线返回线长，圆弧返回弧长。 |
+| `PointEx` | `InterpolateTo` | 使用闭区间 `[0, 1]` 的三维线性插值，非法比例抛出明确异常。 |
+| `PointEx` | `TryInterpolateAtElevation` | 只在非水平线段内存在唯一高程点时成功；修正旧实现把结果 Z 固定为 `0` 的错误，不引入隐式容差。 |
+
+批次 1 提供宿主内确定性验收命令 `Test_GeometryQuery`，覆盖直线、半圆、开放/闭合折线和高程插值边界。AC_2019、AC_2025、ZW_2022、ZW_2025、GC_2022、GC_2023、GC_2026 的 Release 库和测试程序集均已通过直接构建，模块、兼容性和 TypeDef 顺序守卫通过；这只是 Build-only 证据，命令尚未在 CAD 中执行，真实宿主状态为 `Not run`。折线按距离/弦偏差采样、点在线段左右关系和范围聚类尚未计入本批完成范围。
 
 ### Phase 2：点网格索引
 

--- a/src/CADShared/Cad/Database/Entities/Curves/CurveEx.cs
+++ b/src/CADShared/Cad/Database/Entities/Curves/CurveEx.cs
@@ -21,6 +21,117 @@ public static class CurveEx
         return curve.GetDistanceAtParameter(curve.EndParam);
     }
 
+    /// <summary>
+    /// 按曲线总长的比例获取点
+    /// </summary>
+    /// <param name="curve">曲线</param>
+    /// <param name="fraction">从起点计算的长度比例，取值范围为闭区间 [0, 1]</param>
+    /// <returns>指定长度比例处的点</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="curve"/> 为 <see langword="null"/></exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="fraction"/> 不是有限数或超出 [0, 1]</exception>
+    /// <exception cref="InvalidOperationException">曲线没有有限且非负的长度范围</exception>
+    public static Point3d GetPointAtDistanceFraction(this Curve curve, double fraction)
+    {
+        ArgumentNullException.ThrowIfNull(curve);
+        if (double.IsNaN(fraction) || double.IsInfinity(fraction) || fraction < 0 || fraction > 1)
+            throw new ArgumentOutOfRangeException(nameof(fraction), fraction, "The fraction must be in [0, 1].");
+
+        var startParameter = curve.StartParam;
+        var endParameter = curve.EndParam;
+        if (double.IsNaN(startParameter) || double.IsInfinity(startParameter) ||
+            double.IsNaN(endParameter) || double.IsInfinity(endParameter))
+        {
+            throw new InvalidOperationException("The curve does not have a finite parameter range.");
+        }
+
+        var startDistance = curve.GetDistanceAtParameter(startParameter);
+        var endDistance = curve.GetDistanceAtParameter(endParameter);
+        if (double.IsNaN(startDistance) || double.IsInfinity(startDistance) ||
+            double.IsNaN(endDistance) || double.IsInfinity(endDistance) ||
+            endDistance < startDistance)
+        {
+            throw new InvalidOperationException("The curve does not have a finite, non-negative distance range.");
+        }
+
+        if (fraction == 0)
+            return curve.StartPoint;
+        if (fraction == 1)
+            return curve.EndPoint;
+        if (endDistance == startDistance)
+            return curve.StartPoint;
+
+        var distance = startDistance * (1 - fraction) + endDistance * fraction;
+        return curve.GetPointAtDist(distance);
+    }
+
+    /// <summary>
+    /// 计算参数区间中点处的弦偏差
+    /// </summary>
+    /// <remarks>
+    /// 返回曲线参数中点与区间端点弦中点之间的三维距离；该值不是区间内的最大偏差。
+    /// </remarks>
+    /// <param name="curve">曲线</param>
+    /// <param name="startParameter">区间起始参数</param>
+    /// <param name="endParameter">区间结束参数，必须大于或等于起始参数</param>
+    /// <returns>参数中点处的弦偏差</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="curve"/> 为 <see langword="null"/></exception>
+    /// <exception cref="ArgumentOutOfRangeException">参数不是有限数、顺序错误或超出曲线参数域</exception>
+    public static double GetMidpointChordDeviation(this Curve curve, double startParameter, double endParameter)
+    {
+        ArgumentNullException.ThrowIfNull(curve);
+        if (double.IsNaN(startParameter) || double.IsInfinity(startParameter))
+            throw new ArgumentOutOfRangeException(nameof(startParameter), startParameter, "The parameter must be finite.");
+        if (double.IsNaN(endParameter) || double.IsInfinity(endParameter))
+            throw new ArgumentOutOfRangeException(nameof(endParameter), endParameter, "The parameter must be finite.");
+        if (startParameter > endParameter)
+            throw new ArgumentOutOfRangeException(nameof(endParameter), endParameter, "The end parameter must not precede the start parameter.");
+        if (startParameter < curve.StartParam || endParameter > curve.EndParam)
+            throw new ArgumentOutOfRangeException(nameof(startParameter), "The parameter interval must be inside the curve domain.");
+
+        var startPoint = curve.GetPointAtParameter(startParameter);
+        var endPoint = curve.GetPointAtParameter(endParameter);
+        var chordMidpoint = startPoint.GetMidPointTo(endPoint);
+        var midpointParameter = startParameter * 0.5 + endParameter * 0.5;
+        var curveMidpoint = curve.GetPointAtParameter(midpointParameter);
+        return chordMidpoint.DistanceTo(curveMidpoint);
+    }
+
+    /// <summary>
+    /// 计算距离区间中点处的弦偏差
+    /// </summary>
+    /// <remarks>
+    /// 距离从曲线起点沿曲线测量。返回距离中点与区间端点弦中点之间的三维距离；
+    /// 该值不是区间内的最大偏差。
+    /// </remarks>
+    /// <param name="curve">曲线</param>
+    /// <param name="startDistance">区间起始距离</param>
+    /// <param name="endDistance">区间结束距离，必须大于或等于起始距离</param>
+    /// <returns>距离中点处的弦偏差</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="curve"/> 为 <see langword="null"/></exception>
+    /// <exception cref="ArgumentOutOfRangeException">距离不是有限数、顺序错误或超出曲线长度范围</exception>
+    public static double GetMidpointChordDeviationByDistance(this Curve curve, double startDistance, double endDistance)
+    {
+        ArgumentNullException.ThrowIfNull(curve);
+        if (double.IsNaN(startDistance) || double.IsInfinity(startDistance))
+            throw new ArgumentOutOfRangeException(nameof(startDistance), startDistance, "The distance must be finite.");
+        if (double.IsNaN(endDistance) || double.IsInfinity(endDistance))
+            throw new ArgumentOutOfRangeException(nameof(endDistance), endDistance, "The distance must be finite.");
+        if (startDistance > endDistance)
+            throw new ArgumentOutOfRangeException(nameof(endDistance), endDistance, "The end distance must not precede the start distance.");
+
+        var curveStartDistance = curve.GetDistanceAtParameter(curve.StartParam);
+        var curveEndDistance = curve.GetDistanceAtParameter(curve.EndParam);
+        if (startDistance < curveStartDistance || endDistance > curveEndDistance)
+            throw new ArgumentOutOfRangeException(nameof(startDistance), "The distance interval must be inside the curve range.");
+
+        var startPoint = curve.GetPointAtDist(startDistance);
+        var endPoint = curve.GetPointAtDist(endDistance);
+        var chordMidpoint = startPoint.GetMidPointTo(endPoint);
+        var midpointDistance = startDistance * 0.5 + endDistance * 0.5;
+        var curveMidpoint = curve.GetPointAtDist(midpointDistance);
+        return chordMidpoint.DistanceTo(curveMidpoint);
+    }
+
     /*/// <summary>
     /// 获取分割曲线集合
     /// </summary>

--- a/src/CADShared/Cad/Database/Entities/Curves/Polylines/PolylineEx.cs
+++ b/src/CADShared/Cad/Database/Entities/Curves/Polylines/PolylineEx.cs
@@ -53,6 +53,50 @@ public static class PolylineEx
                 .ToList();
     }
 
+    /// <summary>
+    /// 获取轻量多段线的顶点、凸度和宽度快照
+    /// </summary>
+    /// <param name="pl">轻量多段线</param>
+    /// <returns>按顶点索引排列的独立数据对象；修改返回值不会修改原多段线</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="pl"/> 为 <see langword="null"/></exception>
+    public static IReadOnlyList<BulgeVertexWidth> GetVertexData(this Polyline pl)
+    {
+        if (pl is null)
+            throw new ArgumentNullException(nameof(pl));
+
+        var vertices = new List<BulgeVertexWidth>(pl.NumberOfVertices);
+        for (var index = 0; index < pl.NumberOfVertices; index++)
+            vertices.Add(new BulgeVertexWidth(pl, index));
+
+        return vertices;
+    }
+
+    /// <summary>
+    /// 获取轻量多段线指定子段的实际长度
+    /// </summary>
+    /// <remarks>直线段返回直线长度，圆弧段返回沿弧长度。</remarks>
+    /// <param name="pl">轻量多段线</param>
+    /// <param name="segmentIndex">从零开始的子段索引</param>
+    /// <returns>指定子段的长度</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="pl"/> 为 <see langword="null"/></exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="segmentIndex"/> 不是有效子段索引</exception>
+    public static double GetSegmentLength(this Polyline pl, int segmentIndex)
+    {
+        if (pl is null)
+            throw new ArgumentNullException(nameof(pl));
+
+        var segmentCount = pl.NumberOfVertices < 2
+            ? 0
+            : pl.Closed ? pl.NumberOfVertices : pl.NumberOfVertices - 1;
+        if (segmentIndex < 0 || segmentIndex >= segmentCount)
+        {
+            throw new ArgumentOutOfRangeException(nameof(segmentIndex), segmentIndex,
+                "The polyline does not contain the requested segment.");
+        }
+
+        return pl.GetDistanceAtParameter(segmentIndex + 1) - pl.GetDistanceAtParameter(segmentIndex);
+    }
+
     #endregion
 
     #region 创建多段线

--- a/src/CADShared/Cad/Geometry/PointEx.cs
+++ b/src/CADShared/Cad/Geometry/PointEx.cs
@@ -90,6 +90,67 @@ public static class PointEx
     }
 
     /// <summary>
+    /// 按比例在两个三维点之间进行线性插值
+    /// </summary>
+    /// <param name="startPoint">起点</param>
+    /// <param name="endPoint">终点</param>
+    /// <param name="fraction">从起点到终点的比例，取值范围为闭区间 [0, 1]</param>
+    /// <returns>插值得到的三维点</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="fraction"/> 不是有限数或超出 [0, 1]</exception>
+    public static Point3d InterpolateTo(this Point3d startPoint, Point3d endPoint, double fraction)
+    {
+        if (double.IsNaN(fraction) || double.IsInfinity(fraction) || fraction < 0 || fraction > 1)
+            throw new ArgumentOutOfRangeException(nameof(fraction), fraction, "The fraction must be in [0, 1].");
+
+        var startWeight = 1 - fraction;
+        return new Point3d(
+            startPoint.X * startWeight + endPoint.X * fraction,
+            startPoint.Y * startWeight + endPoint.Y * fraction,
+            startPoint.Z * startWeight + endPoint.Z * fraction);
+    }
+
+    /// <summary>
+    /// 获取三维线段上指定高程处的唯一插值点
+    /// </summary>
+    /// <remarks>
+    /// 线段水平时没有唯一结果；指定高程超出线段 Z 值闭区间时也返回 <see langword="false"/>。
+    /// 本方法不使用隐式容差。
+    /// </remarks>
+    /// <param name="startPoint">线段起点</param>
+    /// <param name="endPoint">线段终点</param>
+    /// <param name="elevation">目标 Z 值</param>
+    /// <param name="point">成功时为目标高程处的点；失败时为默认值</param>
+    /// <returns>存在唯一插值点时返回 <see langword="true"/>，否则返回 <see langword="false"/></returns>
+    public static bool TryInterpolateAtElevation(this Point3d startPoint, Point3d endPoint,
+        double elevation, out Point3d point)
+    {
+        point = default;
+        if (double.IsNaN(elevation) || double.IsInfinity(elevation) ||
+            double.IsNaN(startPoint.Z) || double.IsInfinity(startPoint.Z) ||
+            double.IsNaN(endPoint.Z) || double.IsInfinity(endPoint.Z))
+        {
+            return false;
+        }
+
+        var elevationDelta = endPoint.Z - startPoint.Z;
+        if (elevationDelta == 0 || double.IsInfinity(elevationDelta))
+            return false;
+
+        var fraction = (elevation - startPoint.Z) / elevationDelta;
+        if (double.IsNaN(fraction) || double.IsInfinity(fraction) || fraction < 0 || fraction > 1)
+            return false;
+
+        var startWeight = 1 - fraction;
+        var x = startPoint.X * startWeight + endPoint.X * fraction;
+        var y = startPoint.Y * startWeight + endPoint.Y * fraction;
+        if (double.IsNaN(x) || double.IsInfinity(x) || double.IsNaN(y) || double.IsInfinity(y))
+            return false;
+
+        point = new Point3d(x, y, elevation);
+        return true;
+    }
+
+    /// <summary>
     /// Z值归零
     /// </summary>
     /// <param name="point">点</param>

--- a/tests/TestShared/TestGeometryQuery.cs
+++ b/tests/TestShared/TestGeometryQuery.cs
@@ -1,0 +1,104 @@
+namespace Test;
+
+public class TestGeometryQuery
+{
+    private const double Tolerance = 1e-8;
+
+    [CommandMethod(nameof(Test_GeometryQuery))]
+    public void Test_GeometryQuery()
+    {
+        var startPoint = new Point3d(0, 0, 0);
+        var endPoint = new Point3d(10, 20, 30);
+
+        AssertPoint(startPoint.InterpolateTo(endPoint, 0.25), new Point3d(2.5, 5, 7.5),
+            nameof(PointEx.InterpolateTo));
+        AssertTrue(startPoint.TryInterpolateAtElevation(endPoint, 15, out var elevationPoint),
+            nameof(PointEx.TryInterpolateAtElevation));
+        AssertPoint(elevationPoint, new Point3d(5, 10, 15), nameof(PointEx.TryInterpolateAtElevation));
+        AssertFalse(startPoint.TryInterpolateAtElevation(new Point3d(10, 20, 0), 0, out _),
+            "Horizontal segment must not return an arbitrary point.");
+        AssertFalse(startPoint.TryInterpolateAtElevation(endPoint, 31, out _),
+            "Elevation outside the segment must fail.");
+
+        using var line = new Line(startPoint, endPoint);
+        AssertPoint(line.GetPointAtDistanceFraction(0.25), new Point3d(2.5, 5, 7.5),
+            nameof(CurveEx.GetPointAtDistanceFraction));
+        AssertThrowsArgumentOutOfRange(() => line.GetPointAtDistanceFraction(1.01),
+            "Curve distance fraction range");
+        AssertClose(line.GetMidpointChordDeviation(line.StartParam, line.EndParam), 0,
+            nameof(CurveEx.GetMidpointChordDeviation));
+        AssertClose(line.GetMidpointChordDeviationByDistance(0, line.Length), 0,
+            nameof(CurveEx.GetMidpointChordDeviationByDistance));
+
+        using var arc = new Arc(Point3d.Origin, 10, 0, Math.PI);
+        AssertClose(arc.GetMidpointChordDeviation(arc.StartParam, arc.EndParam), 10,
+            "Semicircle parameter midpoint deviation");
+        AssertClose(arc.GetMidpointChordDeviationByDistance(0, Math.PI * 10), 10,
+            "Semicircle distance midpoint deviation");
+
+        using var polyline = new Polyline();
+        polyline.AddVertexAt(0, new Point2d(0, 0), 1, 2, 3);
+        polyline.AddVertexAt(1, new Point2d(10, 0), 0, 4, 5);
+        polyline.AddVertexAt(2, new Point2d(10, 10), 0, 0, 0);
+
+        var vertexData = polyline.GetVertexData();
+        AssertTrue(vertexData.Count == 3, "Vertex snapshot count");
+        AssertPoint(vertexData[0].Vertex.Point3d(), Point3d.Origin, "Vertex snapshot position");
+        AssertClose(vertexData[0].Bulge, 1, "Vertex snapshot bulge");
+        AssertClose(vertexData[0].StartWidth, 2, "Vertex snapshot start width");
+        AssertClose(vertexData[0].EndWidth, 3, "Vertex snapshot end width");
+        vertexData[0].X = 100;
+        AssertPoint(polyline.GetPoint3dAt(0), Point3d.Origin, "Vertex snapshot independence");
+        AssertClose(polyline.GetSegmentLength(0), Math.PI * 5, "Arc segment length");
+        AssertClose(polyline.GetSegmentLength(1), 10, "Line segment length");
+        AssertThrowsArgumentOutOfRange(() => polyline.GetSegmentLength(2), "Open polyline segment range");
+
+        polyline.Closed = true;
+        AssertClose(polyline.GetSegmentLength(2), Math.Sqrt(200), "Closing segment length");
+
+        using var degeneratePolyline = new Polyline { Closed = true };
+        degeneratePolyline.AddVertexAt(0, Point2d.Origin, 0, 0, 0);
+        AssertThrowsArgumentOutOfRange(() => degeneratePolyline.GetSegmentLength(0),
+            "Degenerate closed polyline segment range");
+
+        Env.Printl("Test_GeometryQuery passed.");
+    }
+
+    private static void AssertPoint(Point3d actual, Point3d expected, string name)
+    {
+        if (actual.DistanceTo(expected) > Tolerance)
+            throw new InvalidOperationException($"{name}: expected {expected}, actual {actual}.");
+    }
+
+    private static void AssertClose(double actual, double expected, string name)
+    {
+        if (Math.Abs(actual - expected) > Tolerance)
+            throw new InvalidOperationException($"{name}: expected {expected}, actual {actual}.");
+    }
+
+    private static void AssertTrue(bool condition, string name)
+    {
+        if (!condition)
+            throw new InvalidOperationException($"{name}: expected true.");
+    }
+
+    private static void AssertFalse(bool condition, string name)
+    {
+        if (condition)
+            throw new InvalidOperationException($"{name}: expected false.");
+    }
+
+    private static void AssertThrowsArgumentOutOfRange(Action action, string name)
+    {
+        try
+        {
+            action();
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException($"{name}: expected ArgumentOutOfRangeException.");
+    }
+}

--- a/tests/TestShared/TestShared.projitems
+++ b/tests/TestShared/TestShared.projitems
@@ -29,6 +29,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)TestEnv.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestExtents.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestFileDatabase.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TestGeometryQuery.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestHatchinfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestId.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestJig.cs" />


### PR DESCRIPTION
## Summary

吸收首批低风险、只读几何能力，不复制旧 `*Util` 结构：

- `CurveEx`：按长度比例取点、参数中点弦偏差、距离中点弦偏差。
- `PolylineEx`：顶点/bulge/宽度快照、开放/闭合折线单段长度。
- `PointEx`：三维比例插值、指定高程唯一点查询。
- 增加宿主内确定性命令 `Test_GeometryQuery`，覆盖直线、半圆、开放/闭合折线、退化折线和高程边界。
- 回写迁移计划，并更新模块/兼容性基线。

## Design Boundaries

- 不写数据库，不依赖活动 Document/Editor，不修改输入对象，不弹 UI。
- 不创建需要调用方释放的新 CAD 对象。
- 比例、参数域、距离域、退化折线和水平线段均有显式失败契约。
- 修正输入实现中“比例固定取 0.5”和“高程插值结果 Z 固定为 0”的问题。
- 公共 API 增量严格为 `CurveEx +3`、`PointEx +2`、`PolylineEx +2`，七个目标一致。

## Validation

- `git diff --check`
- `Build/Verify-CADSharedModuleMap.ps1`: `141 / 42 / 17`
- `tools/verification/Test-CADSharedTypeDefSequence.ps1`: 4 targets match
- `Build/Verify-CADSharedCompatibility.ps1`: 7 targets pass
- AC_2019、AC_2025、ZW_2022、ZW_2025、GC_2022、GC_2023、GC_2026 Release 库和测试程序集：0 warning / 0 error
- Markdown relative links and GitHub GFM render: pass

兼容性验证打包阶段仍报告既有 `NU5110`/`NU5111`（`copyToDigBuild.ps1` 包布局），本 PR 未改变该发布脚本。

CAD host: `Not run`。未启动 CAD，未修改 profile、Trusted Paths 或注册表。

Refs #110