### PR TITLE
feat: add sparse point grid index

### DIFF
--- a/Build/CADSharedCompatibilityBaseline.json
+++ b/Build/CADSharedCompatibilityBaseline.json
@@ -103,7 +103,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2305,
+        "publicApiRecordCount": 2321,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -726,6 +726,11 @@
             "contractSha256": "dcc41ddcb6149ae4a3d4daff0b2007faee124c437633af1c6382862b85c3a4db"
           },
           {
+            "type": "Fs.Fox.Cad.PointGridIndex",
+            "recordCount": 16,
+            "contractSha256": "abdb670a86cc02dda5649762e6c49862a536c6d48fb98775f3593fe18274e75b"
+          },
+          {
             "type": "Fs.Fox.Cad.PointOnRegionType",
             "recordCount": 6,
             "contractSha256": "4e9c7e1e10993792aabb0446c0ed8db277a92b7235f93eec63c4a0f47c70598a"
@@ -1004,9 +1009,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.AutoCad.xml",
-            "length": 496065,
+            "length": 501914,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "9461882745dedbe7016b924690be883406f565c2a625e158b42be430d2899e4b",
+            "contentSha256": "a335b72d93b05079bd4f136bde6c64840dd31c281fe558b16a34496d3d51cb83",
             "binarySource": null
           },
           {
@@ -1212,7 +1217,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2303,
+        "publicApiRecordCount": 2319,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArrayEx",
@@ -1830,6 +1835,11 @@
             "contractSha256": "230d7251a6cd2ce982cf485d63d333e82adc382250d79ef96a72da19ae56f068"
           },
           {
+            "type": "Fs.Fox.Cad.PointGridIndex",
+            "recordCount": 16,
+            "contractSha256": "3e85db78ce222e86bf120744e3e1260cec6c9db313fafd6e344768062e41fd1a"
+          },
+          {
             "type": "Fs.Fox.Cad.PointOnRegionType",
             "recordCount": 6,
             "contractSha256": "4e9c7e1e10993792aabb0446c0ed8db277a92b7235f93eec63c4a0f47c70598a"
@@ -2122,9 +2132,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.AutoCad.xml",
-            "length": 460341,
+            "length": 466190,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "5bb03f051842bf76f8ff2c4de829ec3afd37892d88af374b9de1e07703634939",
+            "contentSha256": "be5071f83c016d92c981fc29873a4bec9dcde5230c32908cba2ec555ac88b6f8",
             "binarySource": null
           },
           {
@@ -2246,7 +2256,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2282,
+        "publicApiRecordCount": 2298,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -2859,6 +2869,11 @@
             "contractSha256": "09c2fc5cef4edc22b2c0a8697d360f57f24f5a0609b09d6276fe8ad92e1ad68c"
           },
           {
+            "type": "Fs.Fox.Cad.PointGridIndex",
+            "recordCount": 16,
+            "contractSha256": "da8ca6094bd23590682e7997d177f0c353a591c72171c9012d935e2a881f0e72"
+          },
+          {
             "type": "Fs.Fox.Cad.PointOnRegionType",
             "recordCount": 6,
             "contractSha256": "4e9c7e1e10993792aabb0446c0ed8db277a92b7235f93eec63c4a0f47c70598a"
@@ -3123,9 +3138,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 486947,
+            "length": 492772,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "0a8895a513d432ecd02f44b190b9af6cab32ae20e79b8c1b21255ec21a6c53b2",
+            "contentSha256": "4e6dfc9a363e13bbddf8eb55c22dece3796d5d2efaccb2e715ed8fed5e2f23d3",
             "binarySource": null
           },
           {
@@ -3247,7 +3262,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2285,
+        "publicApiRecordCount": 2301,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -3860,6 +3875,11 @@
             "contractSha256": "09c2fc5cef4edc22b2c0a8697d360f57f24f5a0609b09d6276fe8ad92e1ad68c"
           },
           {
+            "type": "Fs.Fox.Cad.PointGridIndex",
+            "recordCount": 16,
+            "contractSha256": "da8ca6094bd23590682e7997d177f0c353a591c72171c9012d935e2a881f0e72"
+          },
+          {
             "type": "Fs.Fox.Cad.PointOnRegionType",
             "recordCount": 6,
             "contractSha256": "4e9c7e1e10993792aabb0446c0ed8db277a92b7235f93eec63c4a0f47c70598a"
@@ -4124,9 +4144,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 488336,
+            "length": 494161,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "9f732de88936fbeb1bb2ab35a07d612a49b4eadd2d31f70856116798ca14b14a",
+            "contentSha256": "4fe434615e3c66f09be0a751d3855adeff456cc5835d0a5ec3b9dfb7d900167c",
             "binarySource": null
           },
           {
@@ -4248,7 +4268,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2269,
+        "publicApiRecordCount": 2285,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -4849,6 +4869,11 @@
             "type": "Fs.Fox.Cad.PointEx",
             "recordCount": 24,
             "contractSha256": "75646268c6496a2dd5a4967e254ea0a9da100d2ea297f0fe0a3e7685ed584f3c"
+          },
+          {
+            "type": "Fs.Fox.Cad.PointGridIndex",
+            "recordCount": 16,
+            "contractSha256": "3aee8a41291f7cefe8bc8f4ade30c5f14fe435aaae57beba5f30db11a8d4fabc"
           },
           {
             "type": "Fs.Fox.Cad.PointOnRegionType",
@@ -5115,9 +5140,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 480705,
+            "length": 486494,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "abe116c62e5b5f01291e209db42efc483580f1b8f1596d45e00274cc36f3d715",
+            "contentSha256": "31f4675bab74d7927080369bd5da30e01e798e0276fe764a4548e0952557e54f",
             "binarySource": null
           },
           {
@@ -5239,7 +5264,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2269,
+        "publicApiRecordCount": 2285,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -5842,6 +5867,11 @@
             "contractSha256": "75646268c6496a2dd5a4967e254ea0a9da100d2ea297f0fe0a3e7685ed584f3c"
           },
           {
+            "type": "Fs.Fox.Cad.PointGridIndex",
+            "recordCount": 16,
+            "contractSha256": "3aee8a41291f7cefe8bc8f4ade30c5f14fe435aaae57beba5f30db11a8d4fabc"
+          },
+          {
             "type": "Fs.Fox.Cad.PointOnRegionType",
             "recordCount": 6,
             "contractSha256": "4e9c7e1e10993792aabb0446c0ed8db277a92b7235f93eec63c4a0f47c70598a"
@@ -6106,9 +6136,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 480705,
+            "length": 486494,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "abe116c62e5b5f01291e209db42efc483580f1b8f1596d45e00274cc36f3d715",
+            "contentSha256": "31f4675bab74d7927080369bd5da30e01e798e0276fe764a4548e0952557e54f",
             "binarySource": null
           },
           {
@@ -6314,7 +6344,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2292,
+        "publicApiRecordCount": 2308,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArrayEx",
@@ -6922,6 +6952,11 @@
             "contractSha256": "42e375a21d084aa3234fe082a46821b8c0048244cc5a18137545c0da548b0f6c"
           },
           {
+            "type": "Fs.Fox.Cad.PointGridIndex",
+            "recordCount": 16,
+            "contractSha256": "93aef070ce5b16001c223c9fe81df881b4f87c84cef424d9bcc3a087ffaae4bf"
+          },
+          {
             "type": "Fs.Fox.Cad.PointOnRegionType",
             "recordCount": 6,
             "contractSha256": "4e9c7e1e10993792aabb0446c0ed8db277a92b7235f93eec63c4a0f47c70598a"
@@ -7200,9 +7235,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.Gcad.xml",
-            "length": 454035,
+            "length": 459860,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "3b89a540bf149aa9b5dddfb7b4fd46738154ea0857139bbffc212c5baa116910",
+            "contentSha256": "24356b6e5700db9f4ed57cb94ba54a43b30c48a37790c51893e39022f877c7d1",
             "binarySource": null
           },
           {

--- a/Build/CADSharedModuleBaseline.json
+++ b/Build/CADSharedModuleBaseline.json
@@ -1,12 +1,12 @@
 {
   "schemaVersion": 1,
   "normalizedSourceHash": "sha256-utf8-lf",
-  "expectedCompileCount": 141,
+  "expectedCompileCount": 142,
   "moduleCounts": {
     "Foundation": 11,
     "Platform.Windows": 15,
     "Cad.Interop": 3,
-    "Cad.Geometry": 16,
+    "Cad.Geometry": 17,
     "Cad.Database": 43,
     "Cad.Editor": 23,
     "Cad.Application": 8,
@@ -1308,6 +1308,14 @@
       "boundaryDebt": [],
       "boundaryFindings": [],
       "sourceSha256": "bedbc78b4b0b49654969ffc71c245c59a243beb2979ff3cf3c35f2968e785e93"
+    },
+    {
+      "order": "0970",
+      "fileName": "PointGridIndex.cs",
+      "module": "Cad.Geometry",
+      "boundaryDebt": [],
+      "boundaryFindings": [],
+      "sourceSha256": "57e7c25956d95be9201348287a362910d8fe3d2505a18e089bd56d8be52ff5a0"
     }
   ]
 }

--- a/Build/Verify-CADSharedModuleMap.ps1
+++ b/Build/Verify-CADSharedModuleMap.ps1
@@ -28,12 +28,12 @@ $BaselinePath = [IO.Path]::GetFullPath($BaselinePath)
 $sourceRoot = [IO.Path]::GetFullPath((Split-Path -Parent $ProjectItemsPath))
 $sourceRootPrefix = $sourceRoot.TrimEnd([IO.Path]::DirectorySeparatorChar) + [IO.Path]::DirectorySeparatorChar
 
-$expectedCompileCount = 141
+$expectedCompileCount = 142
 $expectedModuleCounts = [ordered]@{
     'Foundation'       = 11
     'Platform.Windows' = 15
     'Cad.Interop'      = 3
-    'Cad.Geometry'     = 16
+    'Cad.Geometry'     = 17
     'Cad.Database'     = 43
     'Cad.Editor'       = 23
     'Cad.Application'  = 8

--- a/docs/zfgk-cad-migration-plan.md
+++ b/docs/zfgk-cad-migration-plan.md
@@ -95,7 +95,7 @@
 | 能力 | 目标位置 | 建议承载类型 | 说明 |
 | --- | --- | --- | --- |
 | 点、向量、坐标和普通几何 | `Cad/Geometry` | 现有 `PointEx`、`VectorEx`、`GeometryEx` | 只补确实缺失且可测试的方法。 |
-| 点邻域/去重网格 | `Cad/Geometry/SpatialIndex/Grid` | `PointGridIndex` 或经评审后的同义名 | 有状态索引用名词类，不叫 `DynamicPointSpatialIndexUtil`。优先稀疏桶，避免旧实现的二维巨型数组。 |
+| 点邻域/去重网格 | `Cad/Geometry/SpatialIndex/Grid` | `PointGridIndex` | 有状态索引用名词类，不叫 `DynamicPointSpatialIndexUtil`。使用无固定 extent 的稀疏桶，避免旧实现的二维巨型数组。 |
 | 曲线查询与拆分 | `Cad/Database/Entities/Curves` | 现有 `CurveEx`，必要时按能力拆文件 | 返回新曲线时必须写明释放责任。 |
 | 折线查询、采样和编辑 | `Cad/Database/Entities/Curves/Polylines` | 现有 `PolylineEx` | 只读查询与原位修改分批，不在一个 PR 混合。 |
 | 面域边界 | `Cad/Database/Entities` | 现有 `RegionEx` | 与 Issue #103/#107 记录的 `ToCurves()` 所有权风险一并设计。 |
@@ -173,7 +173,7 @@
 | `ObjectARX/Others/FormatUtil.cs` | 点/向量文本序列化可能有价值，但旧实现缺少文化区、版本和失败契约。 | 低优先条件候选；先定义 invariant/显示格式和 `TryParse`。 |
 | `ObjectARX/Others/ListUtil.cs` | 唯一有效方法为交换元素，其余为大段历史注释。 | 不迁移。 |
 | `ObjectARX/Others/ViewUtil.cs` | 已由 `EditorEx.Zoom*` 覆盖。 | 复用现有实现。 |
-| `ObjectARX/SpacialIndex/DynamicPointSpatialIndex.cs` | 点去重、邻域、最近点和范围查询有明确通用价值。旧实现存在无效状态、密集二维数组、UI 弹窗和边界错误。 | 高优先候选；重写为稀疏网格索引并补确定性测试。 |
+| `ObjectARX/SpacialIndex/DynamicPointSpatialIndex.cs` | 点去重、邻域、最近点和范围查询有明确通用价值。旧实现存在无效状态、密集二维数组、UI 弹窗和边界错误。 | 已吸收为 `PointGridIndex`：保留稳定索引、近似去重、范围和最近点能力；不保留固定 extent、公开网格行列和两阶段初始化。 |
 | `ObjectARX/SpacialIndex/EntitySpatialIndex.cs` | 实体范围查询有价值，但目标已有 `QuadTree`；旧实现把事务和网格构建耦合。 | 不迁移该类型；仅把可证明的批量建索引需求补到现有空间索引体系。 |
 | `Other/NumberUtil.cs` | 只拆尾部数字；无数字时抛异常但始终声明返回 true。 | 不迁移；真实需求使用明确 `Try*` 契约。 |
 | `Others/ApplicationUtil.cs` | 支持路径读取与现有 `Env` 边界重合。 | 复用现有实现。 |
@@ -243,6 +243,23 @@ Phase 0 的清单和结构决策已经完成。后续每个代码批次必须回
 - XY 容差、Z 容差、格长和边界闭合规则显式；
 - 不依赖 WinForms，不在失败时弹窗；
 - 与 `QuadTree` 做职责对照和基准，不能建立两套等价实体索引。
+
+Phase 2 的目标 API 与边界如下：
+
+| API/成员 | 契约 |
+| --- | --- |
+| 构造函数、`CellSize` | 构造即有效；网格边长必须是有限正数，不设置固定 extent。 |
+| `Add`、索引器、`Points`、`Count` | 无条件添加并返回稳定整数索引；点视图只读，`Clear` 前索引不变化。 |
+| `TryAdd`、`TryFind` | XY 使用欧氏距离闭区间，Z 使用独立闭区间容差；多个候选按三维距离、再按添加顺序决定。 |
+| `QueryIndices` | 查询 XY 矩形闭区间，结果按添加顺序稳定返回，不隐含 Z 过滤。 |
+| `TryGetNearest` | 在有限最大三维距离内查询，并额外应用 Z 差闭区间过滤；失败结果为索引 -1、距离正无穷。 |
+| `Clear` | 同时释放点和稀疏桶引用；之后索引重新从零开始。 |
+
+旧实现的 `Create`、`GetBlockOfPoint`、`GetNeighborPoints`、`GetExtent` 和 `IsIn` 不成为公共 API：无界稀疏索引不需要固定范围，网格桶只是实现细节。`Test_PointGridIndex` 覆盖跨桶去重、Z 分层、负坐标、闭区间范围、最近点并列、退化参数和清空重用；当前仅参加测试程序集编译，CAD 宿主状态为 `Not run`。
+
+Phase 2 的七目标公共契约基线均只新增 `PointGridIndex` 的 16 条记录。以 `migration/zfgk-cad@587e77f` 为基线重新构建并比较 AC_2019、AC_2025、ZW_2022、ZW_2025 实际程序集后，每个目标都只新增一个 TypeDef，所有既有 TypeDef 的相对顺序保持不变；由于 Roslyn 先发射 `Fs.Fox.Cad` 根类型再发射 `Fs.Fox.Cad.Assoc`，新类型位于现有根类型末尾并使其后的 token 顺延一位，这是新增公共根类型的已审查结果，不是既有类型重排。
+
+AC_2019、AC_2025、ZW_2022、ZW_2025、GC_2022、GC_2023、GC_2026 的 Release 库和测试程序集均已通过直接构建，模块期望更新为 `142` 个编译项、`Cad.Geometry = 17`；真实 CAD 宿主状态仍为 `Not run`。
 
 ### Phase 3：曲线/折线修改与 Region
 

--- a/src/CADShared/CADShared.projitems
+++ b/src/CADShared/CADShared.projitems
@@ -615,6 +615,10 @@
       <FsFoxModule>Cad.Editor</FsFoxModule>
       <FsFoxOrder>0962</FsFoxOrder>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Cad\Geometry\SpatialIndex\Grid\PointGridIndex.cs">
+      <FsFoxModule>Cad.Geometry</FsFoxModule>
+      <FsFoxOrder>0970</FsFoxOrder>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="$(MSBuildThisFileDirectory)ExtensionMethod\Geometry\ToDo\" />

--- a/src/CADShared/Cad/Geometry/SpatialIndex/Grid/PointGridIndex.cs
+++ b/src/CADShared/Cad/Geometry/SpatialIndex/Grid/PointGridIndex.cs
@@ -1,0 +1,372 @@
+namespace Fs.Fox.Cad;
+
+/// <summary>
+/// 基于 XY 稀疏网格的三维点索引
+/// </summary>
+/// <remarks>
+/// 索引没有固定空间边界，点索引在调用 <see cref="Clear"/> 前保持稳定。
+/// 本类型不是线程安全的；同一实例的读取和写入应由调用方同步。
+/// </remarks>
+public sealed class PointGridIndex
+{
+    private readonly Dictionary<(long X, long Y), List<int>> _buckets = [];
+    private readonly List<Point3d> _points = [];
+    private readonly IReadOnlyList<Point3d> _readOnlyPoints;
+
+    /// <summary>
+    /// 初始化稀疏点网格索引
+    /// </summary>
+    /// <param name="cellSize">XY 网格边长，必须为有限正数</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="cellSize"/> 不是有限正数</exception>
+    public PointGridIndex(double cellSize)
+    {
+        if (!IsFinite(cellSize) || cellSize <= 0)
+            throw new ArgumentOutOfRangeException(nameof(cellSize), cellSize, "The cell size must be finite and positive.");
+
+        CellSize = cellSize;
+        _readOnlyPoints = _points.AsReadOnly();
+    }
+
+    /// <summary>
+    /// XY 网格边长
+    /// </summary>
+    public double CellSize { get; }
+
+    /// <summary>
+    /// 索引中的点数
+    /// </summary>
+    public int Count => _points.Count;
+
+    /// <summary>
+    /// 按稳定索引排列的只读点视图
+    /// </summary>
+    public IReadOnlyList<Point3d> Points => _readOnlyPoints;
+
+    /// <summary>
+    /// 按索引获取点
+    /// </summary>
+    /// <param name="index">点索引</param>
+    /// <returns>对应的三维点</returns>
+    public Point3d this[int index] => _points[index];
+
+    /// <summary>
+    /// 无条件添加一个点
+    /// </summary>
+    /// <param name="point">要添加的有限三维点</param>
+    /// <returns>新点的稳定索引</returns>
+    /// <exception cref="ArgumentOutOfRangeException">点包含 NaN、无穷值或无法映射到网格的坐标</exception>
+    public int Add(Point3d point)
+    {
+        ValidatePoint(point, nameof(point));
+        return AddValidated(point);
+    }
+
+    /// <summary>
+    /// 在不存在近似点时添加一个点
+    /// </summary>
+    /// <remarks>
+    /// 近似点必须同时满足：XY 欧氏距离小于或等于 <paramref name="xyTolerance"/>，
+    /// 且 Z 差绝对值小于或等于 <paramref name="zTolerance"/>。
+    /// </remarks>
+    /// <param name="point">要添加的有限三维点</param>
+    /// <param name="xyTolerance">XY 欧氏距离容差，必须为有限非负数</param>
+    /// <param name="zTolerance">Z 差容差，必须为非负数；允许正无穷</param>
+    /// <param name="pointIndex">添加成功时为新索引；存在近似点时为最接近的既有索引</param>
+    /// <returns>添加新点时返回 <see langword="true"/>；复用既有点时返回 <see langword="false"/></returns>
+    public bool TryAdd(Point3d point, double xyTolerance, double zTolerance, out int pointIndex)
+    {
+        ValidatePoint(point, nameof(point));
+        ValidateTolerance(xyTolerance, nameof(xyTolerance), false);
+        ValidateTolerance(zTolerance, nameof(zTolerance), true);
+
+        if (TryFindCore(point, xyTolerance, zTolerance, out pointIndex))
+            return false;
+
+        pointIndex = AddValidated(point);
+        return true;
+    }
+
+    /// <summary>
+    /// 查找与指定点近似的既有点
+    /// </summary>
+    /// <remarks>
+    /// 候选点必须同时满足 XY 欧氏距离和 Z 差的闭区间容差；有多个候选时返回三维距离最近者，
+    /// 距离相同时返回较早添加的点。
+    /// </remarks>
+    /// <param name="point">查询点</param>
+    /// <param name="xyTolerance">XY 欧氏距离容差，必须为有限非负数</param>
+    /// <param name="zTolerance">Z 差容差，必须为非负数；允许正无穷</param>
+    /// <param name="pointIndex">成功时为匹配点索引；失败时为 -1</param>
+    /// <returns>找到近似点时返回 <see langword="true"/></returns>
+    public bool TryFind(Point3d point, double xyTolerance, double zTolerance, out int pointIndex)
+    {
+        ValidatePoint(point, nameof(point));
+        ValidateTolerance(xyTolerance, nameof(xyTolerance), false);
+        ValidateTolerance(zTolerance, nameof(zTolerance), true);
+        return TryFindCore(point, xyTolerance, zTolerance, out pointIndex);
+    }
+
+    /// <summary>
+    /// 查询 XY 矩形闭区间内的点索引
+    /// </summary>
+    /// <param name="minPoint">矩形最小 XY 坐标</param>
+    /// <param name="maxPoint">矩形最大 XY 坐标</param>
+    /// <returns>按添加顺序排列的点索引</returns>
+    /// <exception cref="ArgumentOutOfRangeException">坐标不是有限数或最小坐标大于最大坐标</exception>
+    public IReadOnlyList<int> QueryIndices(Point2d minPoint, Point2d maxPoint)
+    {
+        ValidatePoint(minPoint, nameof(minPoint));
+        ValidatePoint(maxPoint, nameof(maxPoint));
+        if (minPoint.X > maxPoint.X || minPoint.Y > maxPoint.Y)
+            throw new ArgumentOutOfRangeException(nameof(maxPoint), "The maximum point must not precede the minimum point.");
+
+        var results = new List<int>();
+        foreach (var index in GetCandidateIndices(minPoint.X, minPoint.Y, maxPoint.X, maxPoint.Y))
+        {
+            var point = _points[index];
+            if (point.X >= minPoint.X && point.X <= maxPoint.X &&
+                point.Y >= minPoint.Y && point.Y <= maxPoint.Y)
+            {
+                results.Add(index);
+            }
+        }
+
+        results.Sort();
+        return results;
+    }
+
+    /// <summary>
+    /// 在最大三维距离内查找最近点
+    /// </summary>
+    /// <remarks>
+    /// 候选点还必须满足 Z 差绝对值小于或等于 <paramref name="zTolerance"/>。
+    /// 距离边界为闭区间；距离相同时返回较早添加的点。
+    /// </remarks>
+    /// <param name="point">查询点</param>
+    /// <param name="maxDistance">允许的最大三维距离，必须为有限非负数</param>
+    /// <param name="zTolerance">Z 差容差，必须为非负数；允许正无穷</param>
+    /// <param name="pointIndex">成功时为最近点索引；失败时为 -1</param>
+    /// <param name="distance">成功时为三维距离；失败时为正无穷</param>
+    /// <returns>在约束范围内找到点时返回 <see langword="true"/></returns>
+    public bool TryGetNearest(Point3d point, double maxDistance, double zTolerance,
+        out int pointIndex, out double distance)
+    {
+        ValidatePoint(point, nameof(point));
+        ValidateTolerance(maxDistance, nameof(maxDistance), false);
+        ValidateTolerance(zTolerance, nameof(zTolerance), true);
+
+        pointIndex = -1;
+        distance = double.PositiveInfinity;
+        var bestDistance = double.PositiveInfinity;
+
+        foreach (var index in GetCandidateIndices(
+                     point.X - maxDistance,
+                     point.Y - maxDistance,
+                     point.X + maxDistance,
+                     point.Y + maxDistance))
+        {
+            var candidate = _points[index];
+            var zDifference = Math.Abs(candidate.Z - point.Z);
+            if (zDifference > zTolerance)
+                continue;
+
+            var xDifference = candidate.X - point.X;
+            var yDifference = candidate.Y - point.Y;
+            var candidateDistance = GetLength(xDifference, yDifference, zDifference);
+            if (candidateDistance > maxDistance)
+                continue;
+
+            if (pointIndex < 0 || candidateDistance < bestDistance ||
+                candidateDistance == bestDistance && index < pointIndex)
+            {
+                pointIndex = index;
+                bestDistance = candidateDistance;
+            }
+        }
+
+        if (pointIndex < 0)
+            return false;
+
+        distance = bestDistance;
+        return true;
+    }
+
+    /// <summary>
+    /// 清空所有点和网格桶
+    /// </summary>
+    /// <remarks>清空后新点索引重新从零开始。</remarks>
+    public void Clear()
+    {
+        _points.Clear();
+        _buckets.Clear();
+    }
+
+    private int AddValidated(Point3d point)
+    {
+        var cell = GetCell(point.X, point.Y);
+        var pointIndex = _points.Count;
+        _points.Add(point);
+
+        if (!_buckets.TryGetValue(cell, out var bucket))
+        {
+            bucket = [];
+            _buckets.Add(cell, bucket);
+        }
+
+        bucket.Add(pointIndex);
+        return pointIndex;
+    }
+
+    private bool TryFindCore(Point3d point, double xyTolerance, double zTolerance, out int pointIndex)
+    {
+        pointIndex = -1;
+        var bestDistance = double.PositiveInfinity;
+
+        foreach (var index in GetCandidateIndices(
+                     point.X - xyTolerance,
+                     point.Y - xyTolerance,
+                     point.X + xyTolerance,
+                     point.Y + xyTolerance))
+        {
+            var candidate = _points[index];
+            var xDifference = candidate.X - point.X;
+            var yDifference = candidate.Y - point.Y;
+            var planarDistance = GetLength(xDifference, yDifference);
+            if (planarDistance > xyTolerance)
+                continue;
+
+            var zDifference = Math.Abs(candidate.Z - point.Z);
+            if (zDifference > zTolerance)
+                continue;
+
+            var distance = GetLength(xDifference, yDifference, zDifference);
+            if (pointIndex < 0 || distance < bestDistance ||
+                distance == bestDistance && index < pointIndex)
+            {
+                pointIndex = index;
+                bestDistance = distance;
+            }
+        }
+
+        return pointIndex >= 0;
+    }
+
+    private List<int> GetCandidateIndices(double minX, double minY, double maxX, double maxY)
+    {
+        var results = new List<int>();
+        if (_points.Count == 0)
+            return results;
+
+        if (double.IsNaN(minX) || double.IsNaN(minY) || double.IsNaN(maxX) || double.IsNaN(maxY))
+            throw new ArgumentOutOfRangeException(nameof(minX), "The query bounds must not contain NaN.");
+
+        if (double.IsInfinity(minX) || double.IsInfinity(minY) ||
+            double.IsInfinity(maxX) || double.IsInfinity(maxY))
+        {
+            for (var index = 0; index < _points.Count; index++)
+                results.Add(index);
+            return results;
+        }
+
+        var minCell = GetCell(minX, minY);
+        var maxCell = GetCell(maxX, maxY);
+        var columnCount = (double)maxCell.X - minCell.X + 1;
+        var rowCount = (double)maxCell.Y - minCell.Y + 1;
+        var gridCellCount = columnCount * rowCount;
+
+        if (gridCellCount <= _buckets.Count)
+        {
+            for (var row = minCell.Y;; row++)
+            {
+                for (var column = minCell.X;; column++)
+                {
+                    if (_buckets.TryGetValue((column, row), out var bucket))
+                        results.AddRange(bucket);
+
+                    if (column == maxCell.X)
+                        break;
+                }
+
+                if (row == maxCell.Y)
+                    break;
+            }
+
+            return results;
+        }
+
+        foreach (var entry in _buckets)
+        {
+            if (entry.Key.X < minCell.X || entry.Key.X > maxCell.X ||
+                entry.Key.Y < minCell.Y || entry.Key.Y > maxCell.Y)
+            {
+                continue;
+            }
+
+            results.AddRange(entry.Value);
+        }
+
+        return results;
+    }
+
+    private (long X, long Y) GetCell(double x, double y)
+    {
+        return (GetCellCoordinate(x), GetCellCoordinate(y));
+    }
+
+    private long GetCellCoordinate(double value)
+    {
+        var coordinate = Math.Floor(value / CellSize);
+        if (!IsFinite(coordinate) || coordinate <= long.MinValue || coordinate >= long.MaxValue)
+        {
+            throw new ArgumentOutOfRangeException(nameof(value), value,
+                "The coordinate cannot be represented by this grid cell size.");
+        }
+
+        return (long)coordinate;
+    }
+
+    private static void ValidatePoint(Point3d point, string parameterName)
+    {
+        if (!IsFinite(point.X) || !IsFinite(point.Y) || !IsFinite(point.Z))
+            throw new ArgumentOutOfRangeException(parameterName, "Point coordinates must be finite.");
+    }
+
+    private static void ValidatePoint(Point2d point, string parameterName)
+    {
+        if (!IsFinite(point.X) || !IsFinite(point.Y))
+            throw new ArgumentOutOfRangeException(parameterName, "Point coordinates must be finite.");
+    }
+
+    private static void ValidateTolerance(double value, string parameterName, bool allowPositiveInfinity)
+    {
+        if (double.IsNaN(value) || value < 0 || !allowPositiveInfinity && double.IsInfinity(value))
+        {
+            throw new ArgumentOutOfRangeException(parameterName, value,
+                allowPositiveInfinity
+                    ? "The tolerance must be non-negative and must not be NaN."
+                    : "The value must be finite and non-negative.");
+        }
+    }
+
+    private static bool IsFinite(double value)
+    {
+        return !double.IsNaN(value) && !double.IsInfinity(value);
+    }
+
+    private static double GetLength(double x, double y, double z = 0)
+    {
+        x = Math.Abs(x);
+        y = Math.Abs(y);
+        z = Math.Abs(z);
+        var scale = Math.Max(x, Math.Max(y, z));
+        if (double.IsInfinity(scale))
+            return double.PositiveInfinity;
+        if (scale == 0)
+            return 0;
+
+        x /= scale;
+        y /= scale;
+        z /= scale;
+        return scale * Math.Sqrt(x * x + y * y + z * z);
+    }
+}

--- a/tests/TestShared/TestPointGridIndex.cs
+++ b/tests/TestShared/TestPointGridIndex.cs
@@ -1,0 +1,113 @@
+namespace Test;
+
+public class TestPointGridIndex
+{
+    private const double Tolerance = 1e-8;
+
+    [CommandMethod(nameof(Test_PointGridIndex))]
+    public void Test_PointGridIndex()
+    {
+        AssertThrowsArgumentOutOfRange(() => _ = new PointGridIndex(0), "Zero cell size");
+        AssertThrowsArgumentOutOfRange(() => _ = new PointGridIndex(double.PositiveInfinity),
+            "Infinite cell size");
+
+        var index = new PointGridIndex(1);
+        var firstIndex = index.Add(new Point3d(0.95, 0, 0));
+        AssertTrue(firstIndex == 0, "First point index");
+
+        var added = index.TryAdd(new Point3d(1.05, 0, 0.05), 0.11, 0.1, out var nearIndex);
+        AssertFalse(added, "Cross-cell approximate duplicate");
+        AssertTrue(nearIndex == firstIndex, "Approximate duplicate index");
+
+        added = index.TryAdd(new Point3d(1.05, 0, 2), 0.11, 0.5, out var elevatedIndex);
+        AssertTrue(added, "Z-separated point addition");
+        AssertTrue(elevatedIndex == 1, "Z-separated point index");
+
+        var negativeIndex = index.Add(new Point3d(-1, -1, 0));
+        var farIndex = index.Add(new Point3d(3, 3, 0));
+        AssertTrue(index.Count == 4 && index.Points.Count == 4, "Point count and read-only view");
+        AssertPoint(index[firstIndex], new Point3d(0.95, 0, 0), "Point indexer");
+
+        AssertTrue(index.TryFind(new Point3d(1.04, 0, 2.1), 0.1, 0.2, out var foundIndex),
+            "Approximate find");
+        AssertTrue(foundIndex == elevatedIndex, "Approximate find index");
+        AssertFalse(index.TryFind(new Point3d(1.04, 0, 2.1), 0.1, 0.05, out _),
+            "Approximate find Z boundary");
+
+        var rangeIndices = index.QueryIndices(new Point2d(-1, -1), new Point2d(1, 1));
+        AssertTrue(rangeIndices.Count == 2, "Inclusive XY range count");
+        AssertTrue(rangeIndices[0] == firstIndex && rangeIndices[1] == negativeIndex,
+            "Range results use insertion order");
+        AssertFalse(rangeIndices.Contains(elevatedIndex) || rangeIndices.Contains(farIndex),
+            "Range excludes outside points");
+        var boundaryIndices = index.QueryIndices(new Point2d(-1, -1), new Point2d(-1, -1));
+        AssertTrue(boundaryIndices.Count == 1 && boundaryIndices[0] == negativeIndex,
+            "Range includes exact boundary point");
+        AssertThrowsArgumentOutOfRange(
+            () => index.QueryIndices(new Point2d(1, 0), new Point2d(0, 1)),
+            "Reversed range");
+
+        AssertTrue(index.TryGetNearest(new Point3d(1, 0, 0), 0.2, 0.1,
+                out var nearestIndex, out var distance),
+            "Nearest point query");
+        AssertTrue(nearestIndex == firstIndex, "Nearest point index");
+        AssertClose(distance, 0.05, "Nearest point distance");
+        AssertFalse(index.TryGetNearest(new Point3d(1, 0, 0), 0.01, double.PositiveInfinity,
+                out _, out _),
+            "Nearest point maximum distance");
+        AssertThrowsArgumentOutOfRange(
+            () => index.TryFind(Point3d.Origin, -1, 0, out _),
+            "Negative XY tolerance");
+
+        var tieIndex = new PointGridIndex(1);
+        tieIndex.Add(new Point3d(-1, 0, 0));
+        tieIndex.Add(new Point3d(1, 0, 0));
+        AssertTrue(tieIndex.TryGetNearest(Point3d.Origin, 1, 0, out var tieResult, out _),
+            "Nearest point tie query");
+        AssertTrue(tieResult == 0, "Nearest point tie uses insertion order");
+
+        index.Clear();
+        AssertTrue(index.Count == 0 && index.Points.Count == 0, "Clear");
+        AssertTrue(index.Add(Point3d.Origin) == 0, "Index restarts after clear");
+
+        Env.Printl("Test_PointGridIndex passed.");
+    }
+
+    private static void AssertPoint(Point3d actual, Point3d expected, string name)
+    {
+        if (actual.DistanceTo(expected) > Tolerance)
+            throw new InvalidOperationException($"{name}: expected {expected}, actual {actual}.");
+    }
+
+    private static void AssertClose(double actual, double expected, string name)
+    {
+        if (Math.Abs(actual - expected) > Tolerance)
+            throw new InvalidOperationException($"{name}: expected {expected}, actual {actual}.");
+    }
+
+    private static void AssertTrue(bool condition, string name)
+    {
+        if (!condition)
+            throw new InvalidOperationException($"{name}: expected true.");
+    }
+
+    private static void AssertFalse(bool condition, string name)
+    {
+        if (condition)
+            throw new InvalidOperationException($"{name}: expected false.");
+    }
+
+    private static void AssertThrowsArgumentOutOfRange(Action action, string name)
+    {
+        try
+        {
+            action();
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException($"{name}: expected ArgumentOutOfRangeException.");
+    }
+}

--- a/tests/TestShared/TestShared.projitems
+++ b/tests/TestShared/TestShared.projitems
@@ -41,6 +41,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)TestMarshal.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestMirrorFile.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestPoint.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TestPointGridIndex.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestPointOnRegion.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestProgressMeter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestQuadTree.cs" />


### PR DESCRIPTION
## Summary

- add `PointGridIndex`, an unbounded sparse XY grid for stable point indices
- support approximate deduplication, range queries, and deterministic nearest-point lookup with independent Z tolerance
- replace the source design's fixed extent, dense two-dimensional bucket array, two-stage initialization, and UI failure paths
- add `Test_PointGridIndex` and update module, compatibility, and migration-plan baselines

## Design boundary

- no database, transaction, document, editor, UI, or host-lifecycle dependency
- no mutation or ownership transfer of caller-provided CAD objects
- grid buckets remain an implementation detail; public results use stable insertion indices
- public behavior uses closed interval tolerances and deterministic insertion-order tie breaking

## Validation

- `git diff --check`
- `pwsh -NoProfile -File Build/Verify-CADSharedModuleMap.ps1`
  - 142 compile items
  - 42 debt-tagged files
  - 17 boundary findings
- `pwsh -NoProfile -File Build/Verify-CADSharedCompatibility.ps1`
  - passed for AC_2019, AC_2025, ZW_2022, ZW_2025, GC_2022, GC_2023, and GC_2026
  - each target adds only the 16-record `PointGridIndex` public contract
- Release library and test assemblies built for all seven targets with 0 errors and 0 warnings before baseline verification
- CAD host: Not run

Refs #110
Follow-up to #111