### PR TITLE
fix: close geometry migration review findings

### DIFF
--- a/Build/CADSharedCompatibilityBaseline.json
+++ b/Build/CADSharedCompatibilityBaseline.json
@@ -1009,9 +1009,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.AutoCad.xml",
-            "length": 501914,
+            "length": 502044,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "a335b72d93b05079bd4f136bde6c64840dd31c281fe558b16a34496d3d51cb83",
+            "contentSha256": "4c060325dc24372f10078fb718a45c34055559c40176d9e50fe0003f0c016297",
             "binarySource": null
           },
           {
@@ -2132,9 +2132,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.AutoCad.xml",
-            "length": 466190,
+            "length": 466320,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "be5071f83c016d92c981fc29873a4bec9dcde5230c32908cba2ec555ac88b6f8",
+            "contentSha256": "f2d4b789d22b30fa3382c1abdf5286a11ea474748195f0803d95be6d8004e35a",
             "binarySource": null
           },
           {
@@ -3138,9 +3138,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 492772,
+            "length": 492902,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "4e6dfc9a363e13bbddf8eb55c22dece3796d5d2efaccb2e715ed8fed5e2f23d3",
+            "contentSha256": "fb7f281efda77f31e22064e4f179a96a8f1be2215da65fe4226995d56f3443d8",
             "binarySource": null
           },
           {
@@ -4144,9 +4144,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 494161,
+            "length": 494291,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "4fe434615e3c66f09be0a751d3855adeff456cc5835d0a5ec3b9dfb7d900167c",
+            "contentSha256": "f53358e53cfc3de95eae9b7096102b88cb3b59f7d84ddf4159f41f3005ab955b",
             "binarySource": null
           },
           {
@@ -5140,9 +5140,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 486494,
+            "length": 486624,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "31f4675bab74d7927080369bd5da30e01e798e0276fe764a4548e0952557e54f",
+            "contentSha256": "5e8e67b90f86f7c112373d7c6a1fed5bfa28790b9afe8a91e74c330d29236809",
             "binarySource": null
           },
           {
@@ -6136,9 +6136,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 486494,
+            "length": 486624,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "31f4675bab74d7927080369bd5da30e01e798e0276fe764a4548e0952557e54f",
+            "contentSha256": "5e8e67b90f86f7c112373d7c6a1fed5bfa28790b9afe8a91e74c330d29236809",
             "binarySource": null
           },
           {
@@ -7235,9 +7235,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.Gcad.xml",
-            "length": 459860,
+            "length": 459990,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "24356b6e5700db9f4ed57cb94ba54a43b30c48a37790c51893e39022f877c7d1",
+            "contentSha256": "047e79b45bd2b491fb8b43bb614e66c92bfe03a27b9799d607895bdddb0298fe",
             "binarySource": null
           },
           {

--- a/Build/CADSharedCompatibilityBaseline.json
+++ b/Build/CADSharedCompatibilityBaseline.json
@@ -1009,9 +1009,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.AutoCad.xml",
-            "length": 502044,
+            "length": 502192,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "4c060325dc24372f10078fb718a45c34055559c40176d9e50fe0003f0c016297",
+            "contentSha256": "c10a3837a7ca7f726a95330bb0accf0bc7f5a957018ef95c5172b8b16928a160",
             "binarySource": null
           },
           {
@@ -2132,9 +2132,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.AutoCad.xml",
-            "length": 466320,
+            "length": 466468,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "f2d4b789d22b30fa3382c1abdf5286a11ea474748195f0803d95be6d8004e35a",
+            "contentSha256": "d2b9a2e0164b44031d9f877f48d221b8c1cd4cd2e0fab5592fb3cf5dab6ab922",
             "binarySource": null
           },
           {
@@ -3138,9 +3138,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 492902,
+            "length": 493042,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "fb7f281efda77f31e22064e4f179a96a8f1be2215da65fe4226995d56f3443d8",
+            "contentSha256": "b72ffff4d9e4a2a7dec6284777a43c333da9a37d2baefe9f5b0930c307998bfd",
             "binarySource": null
           },
           {
@@ -4144,9 +4144,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 494291,
+            "length": 494431,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "f53358e53cfc3de95eae9b7096102b88cb3b59f7d84ddf4159f41f3005ab955b",
+            "contentSha256": "0275723978fb4fe06743fd8640c0347fee13c0554e51aa4bce3162bbcee82598",
             "binarySource": null
           },
           {
@@ -5140,9 +5140,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 486624,
+            "length": 486752,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "5e8e67b90f86f7c112373d7c6a1fed5bfa28790b9afe8a91e74c330d29236809",
+            "contentSha256": "a0c005c68c80b1de2fca08564aa43da9cd1b9e63325efee9105571730193e017",
             "binarySource": null
           },
           {
@@ -6136,9 +6136,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 486624,
+            "length": 486752,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "5e8e67b90f86f7c112373d7c6a1fed5bfa28790b9afe8a91e74c330d29236809",
+            "contentSha256": "a0c005c68c80b1de2fca08564aa43da9cd1b9e63325efee9105571730193e017",
             "binarySource": null
           },
           {
@@ -7235,9 +7235,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.Gcad.xml",
-            "length": 459990,
+            "length": 460130,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "047e79b45bd2b491fb8b43bb614e66c92bfe03a27b9799d607895bdddb0298fe",
+            "contentSha256": "d8a2f25ef97b203abdf39e65770f4983411a94b09b7e7d28fa251924ec5180ac",
             "binarySource": null
           },
           {

--- a/Build/CADSharedModuleBaseline.json
+++ b/Build/CADSharedModuleBaseline.json
@@ -493,7 +493,7 @@
       "module": "Cad.Database",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "6d65af7c688c92312f4abe828511221ddbe0cf95dfa16110aa7f3694f36d20d2"
+      "sourceSha256": "f6a0762cbf405d2d3c1d92c5b7c8b444be112c54c41f77d5c312b7b841fbb352"
     },
     {
       "order": "0360",

--- a/Build/CADSharedModuleBaseline.json
+++ b/Build/CADSharedModuleBaseline.json
@@ -493,7 +493,7 @@
       "module": "Cad.Database",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "7ff0e743a6fbc8f7d7dd233e8fd8a49b586a681be34441c3d339aa03eaae5f07"
+      "sourceSha256": "6d65af7c688c92312f4abe828511221ddbe0cf95dfa16110aa7f3694f36d20d2"
     },
     {
       "order": "0360",
@@ -1315,7 +1315,7 @@
       "module": "Cad.Geometry",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "57e7c25956d95be9201348287a362910d8fe3d2505a18e089bd56d8be52ff5a0"
+      "sourceSha256": "4972a5290c1a2dc46c5fe34526b18d33591a9262232857d56afa31cf2f58cb0e"
     }
   ]
 }

--- a/docs/zfgk-cad-migration-plan.md
+++ b/docs/zfgk-cad-migration-plan.md
@@ -226,7 +226,7 @@ Phase 0 的清单和结构决策已经完成。后续每个代码批次必须回
 | --- | --- | --- |
 | `CurveEx` | `GetPointAtDistanceFraction` | 按总长闭区间 `[0, 1]` 取点；修正旧实现忽略输入比例、固定取 `0.5` 的问题，并拒绝无限长度域。 |
 | `CurveEx` | `GetMidpointChordDeviation` | 明确按参数中点计算三维弦偏差，不把结果表述为区间最大误差。 |
-| `CurveEx` | `GetMidpointChordDeviationByDistance` | 明确按沿曲线距离中点计算，避免把距离端点转参数后误用参数中点。 |
+| `CurveEx` | `GetMidpointChordDeviationByDistance` | 明确按沿曲线距离中点计算，避免把距离端点转参数后误用参数中点；曲线本身没有有限且有序的参数或距离范围时明确失败。 |
 | `PolylineEx` | `GetVertexData` | 一次取得顶点、bulge、起宽和终宽的独立托管快照，不暴露 `ref` 集合。 |
 | `PolylineEx` | `GetSegmentLength` | 对开放/闭合折线验证真实子段索引；直线返回线长，圆弧返回弧长。 |
 | `PointEx` | `InterpolateTo` | 使用闭区间 `[0, 1]` 的三维线性插值，非法比例抛出明确异常。 |
@@ -256,6 +256,8 @@ Phase 2 的目标 API 与边界如下：
 | `Clear` | 同时释放点和稀疏桶引用；之后索引重新从零开始。 |
 
 旧实现的 `Create`、`GetBlockOfPoint`、`GetNeighborPoints`、`GetExtent` 和 `IsIn` 不成为公共 API：无界稀疏索引不需要固定范围，网格桶只是实现细节。`Test_PointGridIndex` 覆盖跨桶去重、Z 分层、负坐标、闭区间范围、最近点并列、退化参数和清空重用；当前仅参加测试程序集编译，CAD 宿主状态为 `Not run`。
+
+PR #112 的评审收口规定：有限查询范围因坐标量级与 `CellSize` 组合而不能表示为 `long` 网格坐标时，索引退化为扫描全部已存点并继续执行精确过滤，不把实现范围限制暴露成查询异常；高频查询复用实例内候选缓冲区，仍遵守类型既有的非线程安全契约。查询结果是与索引内部状态分离的独立集合，因此不为阻止调用方修改其副本而增加只读包装分配。
 
 Phase 2 的七目标公共契约基线均只新增 `PointGridIndex` 的 16 条记录。以 `migration/zfgk-cad@587e77f` 为基线重新构建并比较 AC_2019、AC_2025、ZW_2022、ZW_2025 实际程序集后，每个目标都只新增一个 TypeDef，所有既有 TypeDef 的相对顺序保持不变；由于 Roslyn 先发射 `Fs.Fox.Cad` 根类型再发射 `Fs.Fox.Cad.Assoc`，新类型位于现有根类型末尾并使其后的 token 顺延一位，这是新增公共根类型的已审查结果，不是既有类型重排。
 

--- a/docs/zfgk-cad-migration-plan.md
+++ b/docs/zfgk-cad-migration-plan.md
@@ -226,7 +226,7 @@ Phase 0 的清单和结构决策已经完成。后续每个代码批次必须回
 | --- | --- | --- |
 | `CurveEx` | `GetPointAtDistanceFraction` | 按总长闭区间 `[0, 1]` 取点；修正旧实现忽略输入比例、固定取 `0.5` 的问题，并拒绝无限长度域。 |
 | `CurveEx` | `GetMidpointChordDeviation` | 明确按参数中点计算三维弦偏差，不把结果表述为区间最大误差。 |
-| `CurveEx` | `GetMidpointChordDeviationByDistance` | 明确按沿曲线距离中点计算，避免把距离端点转参数后误用参数中点；曲线本身没有有限且有序的参数或距离范围时明确失败。 |
+| `CurveEx` | `GetMidpointChordDeviationByDistance` | 明确按沿曲线距离中点计算，避免把距离端点转参数后误用参数中点；`Ray`、`Xline` 及其他没有有限且有序参数或距离范围的曲线明确失败。 |
 | `PolylineEx` | `GetVertexData` | 一次取得顶点、bulge、起宽和终宽的独立托管快照，不暴露 `ref` 集合。 |
 | `PolylineEx` | `GetSegmentLength` | 对开放/闭合折线验证真实子段索引；直线返回线长，圆弧返回弧长。 |
 | `PointEx` | `InterpolateTo` | 使用闭区间 `[0, 1]` 的三维线性插值，非法比例抛出明确异常。 |

--- a/src/CADShared/Cad/Database/Entities/Curves/CurveEx.cs
+++ b/src/CADShared/Cad/Database/Entities/Curves/CurveEx.cs
@@ -101,7 +101,7 @@ public static class CurveEx
     /// </summary>
     /// <remarks>
     /// 距离从曲线起点沿曲线测量。返回距离中点与区间端点弦中点之间的三维距离；
-    /// 该值不是区间内的最大偏差。
+    /// 该值不是区间内的最大偏差。无有限总长的 <see cref="Ray"/> 和 <see cref="Xline"/> 不受支持。
     /// </remarks>
     /// <param name="curve">曲线</param>
     /// <param name="startDistance">区间起始距离</param>
@@ -119,6 +119,8 @@ public static class CurveEx
             throw new ArgumentOutOfRangeException(nameof(endDistance), endDistance, "The distance must be finite.");
         if (startDistance > endDistance)
             throw new ArgumentOutOfRangeException(nameof(endDistance), endDistance, "The end distance must not precede the start distance.");
+        if (curve is Ray || curve is Xline)
+            throw new InvalidOperationException("The curve must have a finite parameter and distance range.");
 
         var curveStartParameter = curve.StartParam;
         var curveEndParameter = curve.EndParam;

--- a/src/CADShared/Cad/Database/Entities/Curves/CurveEx.cs
+++ b/src/CADShared/Cad/Database/Entities/Curves/CurveEx.cs
@@ -109,6 +109,7 @@ public static class CurveEx
     /// <returns>距离中点处的弦偏差</returns>
     /// <exception cref="ArgumentNullException"><paramref name="curve"/> 为 <see langword="null"/></exception>
     /// <exception cref="ArgumentOutOfRangeException">距离不是有限数、顺序错误或超出曲线长度范围</exception>
+    /// <exception cref="InvalidOperationException">曲线没有有限且有序的参数或距离范围</exception>
     public static double GetMidpointChordDeviationByDistance(this Curve curve, double startDistance, double endDistance)
     {
         ArgumentNullException.ThrowIfNull(curve);
@@ -119,8 +120,23 @@ public static class CurveEx
         if (startDistance > endDistance)
             throw new ArgumentOutOfRangeException(nameof(endDistance), endDistance, "The end distance must not precede the start distance.");
 
-        var curveStartDistance = curve.GetDistanceAtParameter(curve.StartParam);
-        var curveEndDistance = curve.GetDistanceAtParameter(curve.EndParam);
+        var curveStartParameter = curve.StartParam;
+        var curveEndParameter = curve.EndParam;
+        if (double.IsNaN(curveStartParameter) || double.IsInfinity(curveStartParameter) ||
+            double.IsNaN(curveEndParameter) || double.IsInfinity(curveEndParameter))
+        {
+            throw new InvalidOperationException("The curve does not have a finite parameter range.");
+        }
+
+        var curveStartDistance = curve.GetDistanceAtParameter(curveStartParameter);
+        var curveEndDistance = curve.GetDistanceAtParameter(curveEndParameter);
+        if (double.IsNaN(curveStartDistance) || double.IsInfinity(curveStartDistance) ||
+            double.IsNaN(curveEndDistance) || double.IsInfinity(curveEndDistance) ||
+            curveEndDistance < curveStartDistance)
+        {
+            throw new InvalidOperationException("The curve does not have a finite, non-negative distance range.");
+        }
+
         if (startDistance < curveStartDistance || endDistance > curveEndDistance)
             throw new ArgumentOutOfRangeException(nameof(startDistance), "The distance interval must be inside the curve range.");
 

--- a/src/CADShared/Cad/Geometry/SpatialIndex/Grid/PointGridIndex.cs
+++ b/src/CADShared/Cad/Geometry/SpatialIndex/Grid/PointGridIndex.cs
@@ -11,6 +11,7 @@ public sealed class PointGridIndex
 {
     private readonly Dictionary<(long X, long Y), List<int>> _buckets = [];
     private readonly List<Point3d> _points = [];
+    private readonly List<int> _candidateIndices = [];
     private readonly IReadOnlyList<Point3d> _readOnlyPoints;
 
     /// <summary>
@@ -199,6 +200,7 @@ public sealed class PointGridIndex
     {
         _points.Clear();
         _buckets.Clear();
+        _candidateIndices.Clear();
     }
 
     private int AddValidated(Point3d point)
@@ -253,7 +255,8 @@ public sealed class PointGridIndex
 
     private List<int> GetCandidateIndices(double minX, double minY, double maxX, double maxY)
     {
-        var results = new List<int>();
+        var results = _candidateIndices;
+        results.Clear();
         if (_points.Count == 0)
             return results;
 
@@ -263,13 +266,18 @@ public sealed class PointGridIndex
         if (double.IsInfinity(minX) || double.IsInfinity(minY) ||
             double.IsInfinity(maxX) || double.IsInfinity(maxY))
         {
-            for (var index = 0; index < _points.Count; index++)
-                results.Add(index);
+            AddAllPointIndices(results);
             return results;
         }
 
-        var minCell = GetCell(minX, minY);
-        var maxCell = GetCell(maxX, maxY);
+        var hasMinCell = TryGetCell(minX, minY, out var minCell);
+        var hasMaxCell = TryGetCell(maxX, maxY, out var maxCell);
+        if (!hasMinCell || !hasMaxCell)
+        {
+            AddAllPointIndices(results);
+            return results;
+        }
+
         var columnCount = (double)maxCell.X - minCell.X + 1;
         var rowCount = (double)maxCell.Y - minCell.Y + 1;
         var gridCellCount = columnCount * rowCount;
@@ -308,21 +316,53 @@ public sealed class PointGridIndex
         return results;
     }
 
+    private void AddAllPointIndices(List<int> results)
+    {
+        for (var index = 0; index < _points.Count; index++)
+            results.Add(index);
+    }
+
     private (long X, long Y) GetCell(double x, double y)
     {
         return (GetCellCoordinate(x), GetCellCoordinate(y));
     }
 
+    private bool TryGetCell(double x, double y, out (long X, long Y) cell)
+    {
+        var hasX = TryGetCellCoordinate(x, out var cellX);
+        var hasY = TryGetCellCoordinate(y, out var cellY);
+        if (!hasX || !hasY)
+        {
+            cell = default;
+            return false;
+        }
+
+        cell = (cellX, cellY);
+        return true;
+    }
+
     private long GetCellCoordinate(double value)
     {
-        var coordinate = Math.Floor(value / CellSize);
-        if (!IsFinite(coordinate) || coordinate <= long.MinValue || coordinate >= long.MaxValue)
+        if (!TryGetCellCoordinate(value, out var coordinate))
         {
             throw new ArgumentOutOfRangeException(nameof(value), value,
                 "The coordinate cannot be represented by this grid cell size.");
         }
 
-        return (long)coordinate;
+        return coordinate;
+    }
+
+    private bool TryGetCellCoordinate(double value, out long cellCoordinate)
+    {
+        var coordinate = Math.Floor(value / CellSize);
+        if (!IsFinite(coordinate) || coordinate <= long.MinValue || coordinate >= long.MaxValue)
+        {
+            cellCoordinate = default;
+            return false;
+        }
+
+        cellCoordinate = (long)coordinate;
+        return true;
     }
 
     private static void ValidatePoint(Point3d point, string parameterName)

--- a/tests/TestShared/TestGeometryQuery.cs
+++ b/tests/TestShared/TestGeometryQuery.cs
@@ -2,7 +2,7 @@ namespace Test;
 
 public class TestGeometryQuery
 {
-    private const double Tolerance = 1e-8;
+    private const double Tolerance = 1e-6;
 
     [CommandMethod(nameof(Test_GeometryQuery))]
     public void Test_GeometryQuery()

--- a/tests/TestShared/TestGeometryQuery.cs
+++ b/tests/TestShared/TestGeometryQuery.cs
@@ -36,6 +36,13 @@ public class TestGeometryQuery
         AssertClose(arc.GetMidpointChordDeviationByDistance(0, Math.PI * 10), 10,
             "Semicircle distance midpoint deviation");
 
+        using var ray = new Ray();
+        AssertThrowsInvalidOperation(() => ray.GetMidpointChordDeviationByDistance(0, 1),
+            "Ray distance domain");
+        using var xline = new Xline();
+        AssertThrowsInvalidOperation(() => xline.GetMidpointChordDeviationByDistance(0, 1),
+            "Xline distance domain");
+
         using var polyline = new Polyline();
         polyline.AddVertexAt(0, new Point2d(0, 0), 1, 2, 3);
         polyline.AddVertexAt(1, new Point2d(10, 0), 0, 4, 5);
@@ -100,5 +107,19 @@ public class TestGeometryQuery
         }
 
         throw new InvalidOperationException($"{name}: expected ArgumentOutOfRangeException.");
+    }
+
+    private static void AssertThrowsInvalidOperation(Action action, string name)
+    {
+        try
+        {
+            action();
+        }
+        catch (InvalidOperationException)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException($"{name}: expected InvalidOperationException.");
     }
 }

--- a/tests/TestShared/TestPointGridIndex.cs
+++ b/tests/TestShared/TestPointGridIndex.cs
@@ -2,7 +2,7 @@ namespace Test;
 
 public class TestPointGridIndex
 {
-    private const double Tolerance = 1e-8;
+    private const double Tolerance = 1e-6;
 
     [CommandMethod(nameof(Test_PointGridIndex))]
     public void Test_PointGridIndex()
@@ -43,6 +43,13 @@ public class TestPointGridIndex
         var boundaryIndices = index.QueryIndices(new Point2d(-1, -1), new Point2d(-1, -1));
         AssertTrue(boundaryIndices.Count == 1 && boundaryIndices[0] == negativeIndex,
             "Range includes exact boundary point");
+        var extremeRangeIndices = index.QueryIndices(
+            new Point2d(-double.MaxValue, -double.MaxValue),
+            new Point2d(double.MaxValue, double.MaxValue));
+        AssertTrue(extremeRangeIndices.Count == index.Count &&
+                   extremeRangeIndices[0] == firstIndex &&
+                   extremeRangeIndices[extremeRangeIndices.Count - 1] == farIndex,
+            "Unmappable finite range falls back to exact point filtering");
         AssertThrowsArgumentOutOfRange(
             () => index.QueryIndices(new Point2d(1, 0), new Point2d(0, 1)),
             "Reversed range");


### PR DESCRIPTION
## Summary

- validate finite, ordered curve parameter and distance domains before distance-based chord-deviation queries
- make `PointGridIndex` fall back to exact full-point filtering when finite query bounds cannot map to `long` grid cells
- reuse the instance candidate buffer for high-frequency dedupe and nearest queries
- reduce the two new host-command comparison tolerances from `1e-8` to `1e-6`
- update the migration decision record and generated module/package baselines

## Review decisions

Accepted from PR #111:

- explicit failure for curves without a finite ordered distance domain
- less brittle cross-host numeric acceptance tolerance

Accepted from PR #112:

- preserve correct extreme-coordinate queries by scanning all stored points when cell mapping is impossible
- remove per-query candidate-list allocation; this remains inside the type's documented non-thread-safe contract

Not accepted from PR #112:

- wrapping `QueryIndices` results in another read-only object: the returned list is a detached result, so caller mutation cannot affect index state and an extra wrapper would add allocation without strengthening encapsulation

The separate Test DLL package-layout concern is tracked by #113 and does not block this migration batch or require a NuGet release.

## Validation

- seven Release library and test targets built: AC_2019, AC_2025, ZW_2022, ZW_2025, GC_2022, GC_2023, GC_2026
- `pwsh -NoProfile -File Build/Verify-CADSharedModuleMap.ps1`
  - 142 compile items
  - 42 debt-tagged files
  - 17 boundary findings
- `pwsh -NoProfile -File Build/Verify-CADSharedCompatibility.ps1`
  - passed for all seven targets
  - public API record and type counts unchanged
  - only XML documentation artifact hashes changed
- `pwsh -NoProfile -File tools/HostAcceptance/Test-Runner.ps1`
  - runner smoke checks passed
- changed-document relative links and GitHub GFM rendering passed
- `git diff --check`
- CAD host: Not run

Refs #110 #111 #112 #113