### PR TITLE
fix: distinguish unbounded curve query domains

### DIFF
--- a/Build/CADSharedCompatibilityBaseline.json
+++ b/Build/CADSharedCompatibilityBaseline.json
@@ -1009,9 +1009,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.AutoCad.xml",
-            "length": 502192,
+            "length": 502609,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "c10a3837a7ca7f726a95330bb0accf0bc7f5a957018ef95c5172b8b16928a160",
+            "contentSha256": "d9a7315df6896c88f65a05303140933208d6c07660d7e653c9cf5eeeb2ae03c1",
             "binarySource": null
           },
           {
@@ -2132,9 +2132,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.AutoCad.xml",
-            "length": 466468,
+            "length": 466885,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "d2b9a2e0164b44031d9f877f48d221b8c1cd4cd2e0fab5592fb3cf5dab6ab922",
+            "contentSha256": "67c2ae5c7ee10ea3469f0bc775cfe61cf13c65948583772a565f5f5373ec8607",
             "binarySource": null
           },
           {
@@ -3138,9 +3138,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 493042,
+            "length": 493451,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "b72ffff4d9e4a2a7dec6284777a43c333da9a37d2baefe9f5b0930c307998bfd",
+            "contentSha256": "f1f735f1e74a954b2c760f685cef89c207085960c8ae07ac65a6b0a6a8302b5f",
             "binarySource": null
           },
           {
@@ -4144,9 +4144,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 494431,
+            "length": 494840,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "0275723978fb4fe06743fd8640c0347fee13c0554e51aa4bce3162bbcee82598",
+            "contentSha256": "2c6c4655d4917f77530da3627b7829de71ddac38e0dd6b3d1ca2812effd68c03",
             "binarySource": null
           },
           {
@@ -5140,9 +5140,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 486752,
+            "length": 487149,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "a0c005c68c80b1de2fca08564aa43da9cd1b9e63325efee9105571730193e017",
+            "contentSha256": "77b40bc5e1aeb4635e2644eeaf2028eb008e35daea2d59abc79ba1d484204b2f",
             "binarySource": null
           },
           {
@@ -6136,9 +6136,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 486752,
+            "length": 487149,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "a0c005c68c80b1de2fca08564aa43da9cd1b9e63325efee9105571730193e017",
+            "contentSha256": "77b40bc5e1aeb4635e2644eeaf2028eb008e35daea2d59abc79ba1d484204b2f",
             "binarySource": null
           },
           {
@@ -7235,9 +7235,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.Gcad.xml",
-            "length": 460130,
+            "length": 460539,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "d8a2f25ef97b203abdf39e65770f4983411a94b09b7e7d28fa251924ec5180ac",
+            "contentSha256": "27e35492ae86fb0df38226753be9b6d6ff1a058a35b3f842ff78fb89a58fd768",
             "binarySource": null
           },
           {

--- a/Build/CADSharedCompatibilityBaseline.json
+++ b/Build/CADSharedCompatibilityBaseline.json
@@ -1009,9 +1009,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.AutoCad.xml",
-            "length": 502609,
+            "length": 502862,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "d9a7315df6896c88f65a05303140933208d6c07660d7e653c9cf5eeeb2ae03c1",
+            "contentSha256": "9e83a347a3614cf07f110e165a131b0150788e3f26c40d894d45b2c1efbacf7b",
             "binarySource": null
           },
           {
@@ -2132,9 +2132,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.AutoCad.xml",
-            "length": 466885,
+            "length": 467138,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "67c2ae5c7ee10ea3469f0bc775cfe61cf13c65948583772a565f5f5373ec8607",
+            "contentSha256": "925fedc695e2cccaf775e60e4cf24b9519b5b8b6149aa7e52400d69bb8f60e40",
             "binarySource": null
           },
           {
@@ -3138,9 +3138,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 493451,
+            "length": 493696,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "f1f735f1e74a954b2c760f685cef89c207085960c8ae07ac65a6b0a6a8302b5f",
+            "contentSha256": "c60b65dc5a0cebb01ac68a752aaf4207574ff30d9a923ad8c84ecc718a33ca22",
             "binarySource": null
           },
           {
@@ -4144,9 +4144,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 494840,
+            "length": 495085,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "2c6c4655d4917f77530da3627b7829de71ddac38e0dd6b3d1ca2812effd68c03",
+            "contentSha256": "61648d02b254124bb3a47cef2179880a5b4fe110f430f8ab94d5e67a73f68f7e",
             "binarySource": null
           },
           {
@@ -5140,9 +5140,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 487149,
+            "length": 487382,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "77b40bc5e1aeb4635e2644eeaf2028eb008e35daea2d59abc79ba1d484204b2f",
+            "contentSha256": "35b2eb2aa0087d6ac70ff6e860d78436918dcadd9c3e2cb49af59c37f3d61b1b",
             "binarySource": null
           },
           {
@@ -6136,9 +6136,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 487149,
+            "length": 487382,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "77b40bc5e1aeb4635e2644eeaf2028eb008e35daea2d59abc79ba1d484204b2f",
+            "contentSha256": "35b2eb2aa0087d6ac70ff6e860d78436918dcadd9c3e2cb49af59c37f3d61b1b",
             "binarySource": null
           },
           {
@@ -7235,9 +7235,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.Gcad.xml",
-            "length": 460539,
+            "length": 460784,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "27e35492ae86fb0df38226753be9b6d6ff1a058a35b3f842ff78fb89a58fd768",
+            "contentSha256": "96f98c2791934509aef48dd4ee1fcf367812b26507172ff4a5067606d41b78c7",
             "binarySource": null
           },
           {

--- a/Build/CADSharedModuleBaseline.json
+++ b/Build/CADSharedModuleBaseline.json
@@ -493,7 +493,7 @@
       "module": "Cad.Database",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "f6a0762cbf405d2d3c1d92c5b7c8b444be112c54c41f77d5c312b7b841fbb352"
+      "sourceSha256": "29b5d5fd5339d2396f8cbec32b6f58d25532c0bc89562ae11dbe895a3a789329"
     },
     {
       "order": "0360",

--- a/Build/CADSharedModuleBaseline.json
+++ b/Build/CADSharedModuleBaseline.json
@@ -493,7 +493,7 @@
       "module": "Cad.Database",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "29b5d5fd5339d2396f8cbec32b6f58d25532c0bc89562ae11dbe895a3a789329"
+      "sourceSha256": "c94db1ad0694fb400e1086aa66c377c8a1a7c0de0ab733f93f0e58d4000d7c64"
     },
     {
       "order": "0360",

--- a/docs/zfgk-cad-migration-plan.md
+++ b/docs/zfgk-cad-migration-plan.md
@@ -226,13 +226,15 @@ Phase 0 的清单和结构决策已经完成。后续每个代码批次必须回
 | --- | --- | --- |
 | `CurveEx` | `GetPointAtDistanceFraction` | 按总长闭区间 `[0, 1]` 取点；修正旧实现忽略输入比例、固定取 `0.5` 的问题，并拒绝无限长度域。 |
 | `CurveEx` | `GetMidpointChordDeviation` | 明确按参数中点计算三维弦偏差，不把结果表述为区间最大误差。 |
-| `CurveEx` | `GetMidpointChordDeviationByDistance` | 明确按沿曲线距离中点计算，避免把距离端点转参数后误用参数中点；`Ray`、`Xline` 及其他没有有限且有序参数或距离范围的曲线明确失败。 |
+| `CurveEx` | `GetMidpointChordDeviationByDistance` | 明确按沿曲线距离中点计算，避免把距离端点转参数后误用参数中点；`Ray` 以基点为距离原点并支持有限非负区间，`Xline` 因没有曲线起点而明确失败。 |
 | `PolylineEx` | `GetVertexData` | 一次取得顶点、bulge、起宽和终宽的独立托管快照，不暴露 `ref` 集合。 |
 | `PolylineEx` | `GetSegmentLength` | 对开放/闭合折线验证真实子段索引；直线返回线长，圆弧返回弧长。 |
 | `PointEx` | `InterpolateTo` | 使用闭区间 `[0, 1]` 的三维线性插值，非法比例抛出明确异常。 |
 | `PointEx` | `TryInterpolateAtElevation` | 只在非水平线段内存在唯一高程点时成功；修正旧实现把结果 Z 固定为 `0` 的错误，不引入隐式容差。 |
 
-批次 1 提供宿主内确定性验收命令 `Test_GeometryQuery`，覆盖直线、半圆、开放/闭合折线和高程插值边界。AC_2019、AC_2025、ZW_2022、ZW_2025、GC_2022、GC_2023、GC_2026 的 Release 库和测试程序集均已通过直接构建，模块、兼容性和 TypeDef 顺序守卫通过；这只是 Build-only 证据，命令尚未在 CAD 中执行，真实宿主状态为 `Not run`。折线按距离/弦偏差采样、点在线段左右关系和范围聚类尚未计入本批完成范围。
+ObjectARX、ZRX 和 GRX 的曲线契约均把 `Ray` 定义为起始参数 `0` 且没有终止参数，把 `Xline` 定义为没有起止参数或起止点。因此三种查询不能共用“必须具有有限总长”这一前置条件：长度比例取点明确拒绝两者；参数中点弦偏差接受有限的 `Ray`/`Xline` 参数区间，其中 `Ray` 参数不得小于 `0`；距离中点弦偏差接受从基点开始的有限非负 `Ray` 距离区间，但拒绝没有距离原点的 `Xline`。这一区分以 SDK 曲线契约为准。
+
+批次 1 提供宿主内确定性验收命令 `Test_GeometryQuery`，覆盖直线、半圆、`Ray`/`Xline` 边界、开放/闭合折线和高程插值边界。AC_2019、AC_2025、ZW_2022、ZW_2025、GC_2022、GC_2023、GC_2026 的 Release 库和测试程序集均已通过直接构建，模块、兼容性和 TypeDef 顺序守卫通过；这只是 Build-only 证据，命令尚未在 CAD 中执行，真实宿主状态为 `Not run`。折线按距离/弦偏差采样、点在线段左右关系和范围聚类尚未计入本批完成范围。
 
 ### Phase 2：点网格索引
 

--- a/src/CADShared/Cad/Database/Entities/Curves/CurveEx.cs
+++ b/src/CADShared/Cad/Database/Entities/Curves/CurveEx.cs
@@ -35,18 +35,21 @@ public static class CurveEx
         ArgumentNullException.ThrowIfNull(curve);
         if (double.IsNaN(fraction) || double.IsInfinity(fraction) || fraction < 0 || fraction > 1)
             throw new ArgumentOutOfRangeException(nameof(fraction), fraction, "The fraction must be in [0, 1].");
+        if (curve is Ray || curve is Xline)
+            throw new InvalidOperationException("The curve does not have a finite total length.");
 
         var startParameter = curve.StartParam;
         var endParameter = curve.EndParam;
         if (double.IsNaN(startParameter) || double.IsInfinity(startParameter) ||
-            double.IsNaN(endParameter) || double.IsInfinity(endParameter))
+            double.IsNaN(endParameter) || double.IsInfinity(endParameter) ||
+            endParameter < startParameter)
         {
-            throw new InvalidOperationException("The curve does not have a finite parameter range.");
+            throw new InvalidOperationException("The curve does not have a finite, ordered parameter range.");
         }
 
         var startDistance = curve.GetDistanceAtParameter(startParameter);
         var endDistance = curve.GetDistanceAtParameter(endParameter);
-        if (double.IsNaN(startDistance) || double.IsInfinity(startDistance) ||
+        if (double.IsNaN(startDistance) || double.IsInfinity(startDistance) || startDistance < 0 ||
             double.IsNaN(endDistance) || double.IsInfinity(endDistance) ||
             endDistance < startDistance)
         {
@@ -69,6 +72,7 @@ public static class CurveEx
     /// </summary>
     /// <remarks>
     /// 返回曲线参数中点与区间端点弦中点之间的三维距离；该值不是区间内的最大偏差。
+    /// <see cref="Ray"/> 的参数区间必须位于 [0, +∞)，<see cref="Xline"/> 支持任意有限参数区间。
     /// </remarks>
     /// <param name="curve">曲线</param>
     /// <param name="startParameter">区间起始参数</param>
@@ -76,6 +80,7 @@ public static class CurveEx
     /// <returns>参数中点处的弦偏差</returns>
     /// <exception cref="ArgumentNullException"><paramref name="curve"/> 为 <see langword="null"/></exception>
     /// <exception cref="ArgumentOutOfRangeException">参数不是有限数、顺序错误或超出曲线参数域</exception>
+    /// <exception cref="InvalidOperationException">有界曲线没有有限且有序的参数域</exception>
     public static double GetMidpointChordDeviation(this Curve curve, double startParameter, double endParameter)
     {
         ArgumentNullException.ThrowIfNull(curve);
@@ -85,8 +90,30 @@ public static class CurveEx
             throw new ArgumentOutOfRangeException(nameof(endParameter), endParameter, "The parameter must be finite.");
         if (startParameter > endParameter)
             throw new ArgumentOutOfRangeException(nameof(endParameter), endParameter, "The end parameter must not precede the start parameter.");
-        if (startParameter < curve.StartParam || endParameter > curve.EndParam)
-            throw new ArgumentOutOfRangeException(nameof(startParameter), "The parameter interval must be inside the curve domain.");
+        if (curve is Ray)
+        {
+            if (startParameter < 0)
+                throw new ArgumentOutOfRangeException(nameof(startParameter), startParameter,
+                    "The ray parameter interval must start at or after zero.");
+        }
+        else if (!(curve is Xline))
+        {
+            var curveStartParameter = curve.StartParam;
+            var curveEndParameter = curve.EndParam;
+            if (double.IsNaN(curveStartParameter) || double.IsInfinity(curveStartParameter) ||
+                double.IsNaN(curveEndParameter) || double.IsInfinity(curveEndParameter) ||
+                curveEndParameter < curveStartParameter)
+            {
+                throw new InvalidOperationException("The curve does not have a finite, ordered parameter range.");
+            }
+
+            if (startParameter < curveStartParameter)
+                throw new ArgumentOutOfRangeException(nameof(startParameter), startParameter,
+                    "The start parameter must be inside the curve domain.");
+            if (endParameter > curveEndParameter)
+                throw new ArgumentOutOfRangeException(nameof(endParameter), endParameter,
+                    "The end parameter must be inside the curve domain.");
+        }
 
         var startPoint = curve.GetPointAtParameter(startParameter);
         var endPoint = curve.GetPointAtParameter(endParameter);
@@ -101,7 +128,8 @@ public static class CurveEx
     /// </summary>
     /// <remarks>
     /// 距离从曲线起点沿曲线测量。返回距离中点与区间端点弦中点之间的三维距离；
-    /// 该值不是区间内的最大偏差。无有限总长的 <see cref="Ray"/> 和 <see cref="Xline"/> 不受支持。
+    /// 该值不是区间内的最大偏差。<see cref="Ray"/> 以基点为距离起点并支持有限非负区间；
+    /// <see cref="Xline"/> 没有曲线起点，因此不受支持。
     /// </remarks>
     /// <param name="curve">曲线</param>
     /// <param name="startDistance">区间起始距离</param>
@@ -109,7 +137,7 @@ public static class CurveEx
     /// <returns>距离中点处的弦偏差</returns>
     /// <exception cref="ArgumentNullException"><paramref name="curve"/> 为 <see langword="null"/></exception>
     /// <exception cref="ArgumentOutOfRangeException">距离不是有限数、顺序错误或超出曲线长度范围</exception>
-    /// <exception cref="InvalidOperationException">曲线没有有限且有序的参数或距离范围</exception>
+    /// <exception cref="InvalidOperationException">曲线没有距离起点，或没有有限且有序的参数或距离范围</exception>
     public static double GetMidpointChordDeviationByDistance(this Curve curve, double startDistance, double endDistance)
     {
         ArgumentNullException.ThrowIfNull(curve);
@@ -119,28 +147,43 @@ public static class CurveEx
             throw new ArgumentOutOfRangeException(nameof(endDistance), endDistance, "The distance must be finite.");
         if (startDistance > endDistance)
             throw new ArgumentOutOfRangeException(nameof(endDistance), endDistance, "The end distance must not precede the start distance.");
-        if (curve is Ray || curve is Xline)
-            throw new InvalidOperationException("The curve must have a finite parameter and distance range.");
+        if (curve is Xline)
+            throw new InvalidOperationException("An Xline has no curve start from which to measure distance.");
 
-        var curveStartParameter = curve.StartParam;
-        var curveEndParameter = curve.EndParam;
-        if (double.IsNaN(curveStartParameter) || double.IsInfinity(curveStartParameter) ||
-            double.IsNaN(curveEndParameter) || double.IsInfinity(curveEndParameter))
+        if (curve is Ray)
         {
-            throw new InvalidOperationException("The curve does not have a finite parameter range.");
+            if (startDistance < 0)
+                throw new ArgumentOutOfRangeException(nameof(startDistance), startDistance,
+                    "The ray distance interval must start at or after zero.");
         }
-
-        var curveStartDistance = curve.GetDistanceAtParameter(curveStartParameter);
-        var curveEndDistance = curve.GetDistanceAtParameter(curveEndParameter);
-        if (double.IsNaN(curveStartDistance) || double.IsInfinity(curveStartDistance) ||
-            double.IsNaN(curveEndDistance) || double.IsInfinity(curveEndDistance) ||
-            curveEndDistance < curveStartDistance)
+        else
         {
-            throw new InvalidOperationException("The curve does not have a finite, non-negative distance range.");
-        }
+            var curveStartParameter = curve.StartParam;
+            var curveEndParameter = curve.EndParam;
+            if (double.IsNaN(curveStartParameter) || double.IsInfinity(curveStartParameter) ||
+                double.IsNaN(curveEndParameter) || double.IsInfinity(curveEndParameter) ||
+                curveEndParameter < curveStartParameter)
+            {
+                throw new InvalidOperationException("The curve does not have a finite, ordered parameter range.");
+            }
 
-        if (startDistance < curveStartDistance || endDistance > curveEndDistance)
-            throw new ArgumentOutOfRangeException(nameof(startDistance), "The distance interval must be inside the curve range.");
+            var curveStartDistance = curve.GetDistanceAtParameter(curveStartParameter);
+            var curveEndDistance = curve.GetDistanceAtParameter(curveEndParameter);
+            if (double.IsNaN(curveStartDistance) || double.IsInfinity(curveStartDistance) ||
+                curveStartDistance < 0 ||
+                double.IsNaN(curveEndDistance) || double.IsInfinity(curveEndDistance) ||
+                curveEndDistance < curveStartDistance)
+            {
+                throw new InvalidOperationException("The curve does not have a finite, non-negative distance range.");
+            }
+
+            if (startDistance < curveStartDistance)
+                throw new ArgumentOutOfRangeException(nameof(startDistance), startDistance,
+                    "The start distance must be inside the curve range.");
+            if (endDistance > curveEndDistance)
+                throw new ArgumentOutOfRangeException(nameof(endDistance), endDistance,
+                    "The end distance must be inside the curve range.");
+        }
 
         var startPoint = curve.GetPointAtDist(startDistance);
         var endPoint = curve.GetPointAtDist(endDistance);

--- a/src/CADShared/Cad/Database/Entities/Curves/CurveEx.cs
+++ b/src/CADShared/Cad/Database/Entities/Curves/CurveEx.cs
@@ -24,12 +24,13 @@ public static class CurveEx
     /// <summary>
     /// 按曲线总长的比例获取点
     /// </summary>
+    /// <remarks>没有有限总长的 <see cref="Ray"/> 和 <see cref="Xline"/> 不受支持。</remarks>
     /// <param name="curve">曲线</param>
     /// <param name="fraction">从起点计算的长度比例，取值范围为闭区间 [0, 1]</param>
     /// <returns>指定长度比例处的点</returns>
     /// <exception cref="ArgumentNullException"><paramref name="curve"/> 为 <see langword="null"/></exception>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="fraction"/> 不是有限数或超出 [0, 1]</exception>
-    /// <exception cref="InvalidOperationException">曲线没有有限且非负的长度范围</exception>
+    /// <exception cref="InvalidOperationException">曲线没有有限总长，参数域不是有限且有序的，或距离范围不是有限、非负且有序的</exception>
     public static Point3d GetPointAtDistanceFraction(this Curve curve, double fraction)
     {
         ArgumentNullException.ThrowIfNull(curve);

--- a/tests/TestShared/TestGeometryQuery.cs
+++ b/tests/TestShared/TestGeometryQuery.cs
@@ -37,11 +37,28 @@ public class TestGeometryQuery
             "Semicircle distance midpoint deviation");
 
         using var ray = new Ray();
-        AssertThrowsInvalidOperation(() => ray.GetMidpointChordDeviationByDistance(0, 1),
-            "Ray distance domain");
+        ray.BasePoint = Point3d.Origin;
+        ray.UnitDir = Vector3d.XAxis;
+        AssertThrowsInvalidOperation(() => ray.GetPointAtDistanceFraction(0.5),
+            "Ray has no finite total length");
+        AssertClose(ray.GetMidpointChordDeviation(0, 1), 0,
+            "Ray parameter midpoint deviation");
+        AssertClose(ray.GetMidpointChordDeviationByDistance(0, 1), 0,
+            "Ray distance midpoint deviation");
+        AssertThrowsArgumentOutOfRange(() => ray.GetMidpointChordDeviation(-1, 1),
+            "Ray parameter range");
+        AssertThrowsArgumentOutOfRange(() => ray.GetMidpointChordDeviationByDistance(-1, 1),
+            "Ray distance range");
+
         using var xline = new Xline();
+        xline.BasePoint = Point3d.Origin;
+        xline.UnitDir = Vector3d.XAxis;
+        AssertThrowsInvalidOperation(() => xline.GetPointAtDistanceFraction(0.5),
+            "Xline has no finite total length");
+        AssertClose(xline.GetMidpointChordDeviation(-1, 1), 0,
+            "Xline parameter midpoint deviation");
         AssertThrowsInvalidOperation(() => xline.GetMidpointChordDeviationByDistance(0, 1),
-            "Xline distance domain");
+            "Xline has no distance origin");
 
         using var polyline = new Polyline();
         polyline.AddVertexAt(0, new Point2d(0, 0), 1, 2, 3);


### PR DESCRIPTION
## Summary

- distinguish APIs that require a finite total curve length from APIs that only consume a finite interval
- reject `Ray` / `Xline` deterministically in `GetPointAtDistanceFraction` before querying unavailable end properties
- support finite `Ray` / `Xline` parameter intervals; require non-negative `Ray` parameters
- support finite non-negative `Ray` distance intervals from its base point, while rejecting `Xline` because it has no curve start
- validate bounded parameter/distance domains as finite, ordered and non-negative, with the correct offending parameter name
- update host-command coverage, migration decisions and generated baselines

## Independent review of Qodo findings

The PR #111 finding correctly identified that reading `StartParam` / `EndParam` without considering unbounded curves could leak host-specific failures. Its optional suggestion to reject both `Ray` and `Xline`, however, was broader than the evidence.

The SDK contracts separate the two cases:

- ObjectARX 2019/2025, ZRX 2022/2025 and GRX 2026 headers define `Ray` with start parameter `0` and no end parameter.
- The same SDK families define `Xline` with neither a start nor an end parameter/point.
- Therefore a whole-length fraction is undefined for both, a finite parameter interval remains meaningful for both, and a distance interval from a curve start is meaningful for `Ray` but not `Xline`.

The PR #112 PointGrid findings were also re-audited. The exact full-scan fallback and reusable candidate buffer remain justified; wrapping a detached query-result list remains unnecessary.

## Validation

- Release library and test builds passed for AC_2019, AC_2025, ZW_2022, ZW_2025, GC_2022, GC_2023 and GC_2026
- `Build/Verify-CADSharedModuleMap.ps1`: 142 compile items, 42 debt-tagged files, 17 boundary findings
- `Build/Verify-CADSharedCompatibility.ps1`: passed for all seven targets; only XML documentation artifact hashes/lengths changed
- `tools/verification/Test-CADSharedTypeDefSequence.ps1`: passed for all four comparison targets and fixtures
- `tools/HostAcceptance/Test-Runner.ps1`: runner smoke checks passed
- changed-document relative links and GitHub GFM rendering passed
- `git diff --check`
- known existing warnings: GC_2022 `MSB3270`; AutoCAD package `NU5110` / `NU5111`
- CAD host: Not run

Follow-up to #114. Refs #110 #111 #112.