### PR TITLE
feat: 完成通用折线采样迁移

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 - `main` 承载正常功能、修复、发布和文档治理，相关工作使用从最新 `main` 建立的短期分支和 PR。
 - Issue #25 的 `CADShared` 单程序集逻辑模块化已由 PR #100 合入 `main`；`refactor/cad-modules` 仅作为历史实施分支，不再作为新 PR 的 base。
 - 后续模块边界调整从最新 `main` 建立短期分支，并通过独立 Issue/PR 说明收益、兼容性边界和验收证据。
+- Issue #110 的 `Fs.Zfgk.CAD` 能力迁移已在 `migration/zfgk-cad` 收口；不再从来源仓库建立新迁移批次。该长期分支与 `main` 保持隔离，最终集成必须另行同步、审查并取得明确批准。
 - 不在逻辑模块化的机械移动中夹带行为修改、公共 API 修改、全文件格式化或无关文档重写。
 - 文档治理与发布能力由 Issue #48 跟踪；`Fs.Fox.CAD` 保持唯一产品内容源，已创建的展示/部署仓库及其边界见 [EdgeOne 站点仓库评估](docs/edgeone-site-repository-evaluation.md)和 [Fs.Fox.CAD.Site](https://github.com/FeiSiPub/Fs.Fox.CAD.Site)。站点框架尚未确定，不要在本仓库提前引入框架专用目录或生成产物。
 

--- a/Build/CADSharedCompatibilityBaseline.json
+++ b/Build/CADSharedCompatibilityBaseline.json
@@ -738,7 +738,7 @@
           {
             "type": "Fs.Fox.Cad.PolylineEx",
             "recordCount": 13,
-            "contractSha256": "e0329848ab3f94781385fc4dec91a343192d588703266f93dccffd2fb21bdc89"
+            "contractSha256": "00cc5345442f1b0866de9f7edab924a818779c172d112fb98eba3c43905e0cd3"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -1009,9 +1009,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.AutoCad.xml",
-            "length": 505379,
+            "length": 505449,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "604d1c7a8fcb0bad463f15648cd5aba1daf19d52e9ba1a2209430db0f81fca5c",
+            "contentSha256": "03e529ecc750de7d4994232abba6a65d3ccc1344b8db13f037994188a7e00347",
             "binarySource": null
           },
           {
@@ -1847,7 +1847,7 @@
           {
             "type": "Fs.Fox.Cad.PolylineEx",
             "recordCount": 13,
-            "contractSha256": "1f0c4f5bdbc0fa747133e0361401e63d2b662a63bb111203aa2523a01bc69267"
+            "contractSha256": "bf54a8410636de6e55adf3ca3c8b57f509944c5a5c12e01a89985245f993691e"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -2132,9 +2132,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.AutoCad.xml",
-            "length": 469655,
+            "length": 469725,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "ba253c6ee787b2c0edb37e58b951f19dc8450b23cc51918d3b284746a7e9beb0",
+            "contentSha256": "2f2e782c159e36bfa06ace8123edff8a3f5f01322d0173a6cbca84417768d6ca",
             "binarySource": null
           },
           {
@@ -2881,7 +2881,7 @@
           {
             "type": "Fs.Fox.Cad.PolylineEx",
             "recordCount": 13,
-            "contractSha256": "c907e675711a9e7c4eec4658a941b09d9ca277176ebe0e9f605a2f7feb52b371"
+            "contractSha256": "6e7d6fd1ee52127f1eefc42174a9aec957f169829fc5dec97e6a11827f721bfe"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -3138,9 +3138,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 496205,
+            "length": 496275,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "b9907b0ca0feb1c1111c171a455684749980893f466d2ed485bc38bd97610e37",
+            "contentSha256": "40a58ae432991e82cad82fa40edc043c17169a5426fe9c639fa364d1b4b32189",
             "binarySource": null
           },
           {
@@ -3887,7 +3887,7 @@
           {
             "type": "Fs.Fox.Cad.PolylineEx",
             "recordCount": 13,
-            "contractSha256": "c907e675711a9e7c4eec4658a941b09d9ca277176ebe0e9f605a2f7feb52b371"
+            "contractSha256": "6e7d6fd1ee52127f1eefc42174a9aec957f169829fc5dec97e6a11827f721bfe"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -4144,9 +4144,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 497594,
+            "length": 497664,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "fa963fdeb5c4578cd7e709cb4e0f7630ecc3cd4c103ef96b306325134ea21d8c",
+            "contentSha256": "27e4ad03c07e32bde7448b7fb2f8343d5336ee437f111651f92e96c7f49339ae",
             "binarySource": null
           },
           {
@@ -4883,7 +4883,7 @@
           {
             "type": "Fs.Fox.Cad.PolylineEx",
             "recordCount": 13,
-            "contractSha256": "55413872ca4ac7a31113aff56a81dc2bf5cd876f586fc36e62c2b58eeebdca9e"
+            "contractSha256": "eeaeb70247b5e87bcc56c0d3d839bdd8771091e4d65242b7d4c9548378404d35"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -5140,9 +5140,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 489879,
+            "length": 489949,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "bddfbac30dff5878604e7798f25e52a13f2199cacf17b95b3b054cdbc6e3ef19",
+            "contentSha256": "74840fab8fb8405d0c28eefc64a96f2295531c726b24326d179bcbf6ee040cf2",
             "binarySource": null
           },
           {
@@ -5879,7 +5879,7 @@
           {
             "type": "Fs.Fox.Cad.PolylineEx",
             "recordCount": 13,
-            "contractSha256": "55413872ca4ac7a31113aff56a81dc2bf5cd876f586fc36e62c2b58eeebdca9e"
+            "contractSha256": "eeaeb70247b5e87bcc56c0d3d839bdd8771091e4d65242b7d4c9548378404d35"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -6136,9 +6136,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 489879,
+            "length": 489949,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "bddfbac30dff5878604e7798f25e52a13f2199cacf17b95b3b054cdbc6e3ef19",
+            "contentSha256": "74840fab8fb8405d0c28eefc64a96f2295531c726b24326d179bcbf6ee040cf2",
             "binarySource": null
           },
           {
@@ -6964,7 +6964,7 @@
           {
             "type": "Fs.Fox.Cad.PolylineEx",
             "recordCount": 13,
-            "contractSha256": "786279bbdc6fe761d9f7e6e56a18c489a64f6909fceb6e37f3cb0a5c12b07daf"
+            "contractSha256": "3fec2b6a65add9eec32c2c7551b50f8099da710eef0fe1dab1bce22a13374a5e"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -7235,9 +7235,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.Gcad.xml",
-            "length": 463293,
+            "length": 463363,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "9d7b01b5cbb4524d9a15df8bc694f709a3c08f833d71857d9ecd01abe70303ce",
+            "contentSha256": "677fd4b7326d9c144c7f12cf56e1bd2c5712f60f32b06bdf1c338420fc7c9581",
             "binarySource": null
           },
           {

--- a/Build/CADSharedCompatibilityBaseline.json
+++ b/Build/CADSharedCompatibilityBaseline.json
@@ -103,7 +103,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2321,
+        "publicApiRecordCount": 2323,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -737,8 +737,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PolylineEx",
-            "recordCount": 11,
-            "contractSha256": "3aff3a32a0fd63e63a3fedd7d857e29b00c7c002681f994ca296401080f746e4"
+            "recordCount": 13,
+            "contractSha256": "e0329848ab3f94781385fc4dec91a343192d588703266f93dccffd2fb21bdc89"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -1009,9 +1009,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.AutoCad.xml",
-            "length": 502862,
+            "length": 505379,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "9e83a347a3614cf07f110e165a131b0150788e3f26c40d894d45b2c1efbacf7b",
+            "contentSha256": "604d1c7a8fcb0bad463f15648cd5aba1daf19d52e9ba1a2209430db0f81fca5c",
             "binarySource": null
           },
           {
@@ -1217,7 +1217,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2319,
+        "publicApiRecordCount": 2321,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArrayEx",
@@ -1846,8 +1846,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PolylineEx",
-            "recordCount": 11,
-            "contractSha256": "0b848fbd8d8de9e5afab4011e48ebbff5f3c40fef73397309099b21c71e9b22c"
+            "recordCount": 13,
+            "contractSha256": "1f0c4f5bdbc0fa747133e0361401e63d2b662a63bb111203aa2523a01bc69267"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -2132,9 +2132,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.AutoCad.xml",
-            "length": 467138,
+            "length": 469655,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "925fedc695e2cccaf775e60e4cf24b9519b5b8b6149aa7e52400d69bb8f60e40",
+            "contentSha256": "ba253c6ee787b2c0edb37e58b951f19dc8450b23cc51918d3b284746a7e9beb0",
             "binarySource": null
           },
           {
@@ -2256,7 +2256,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2298,
+        "publicApiRecordCount": 2300,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -2880,8 +2880,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PolylineEx",
-            "recordCount": 11,
-            "contractSha256": "921aa6b2e802236c7d86808c13aac916d7ff87d1ea8d559f04dc62157179af0b"
+            "recordCount": 13,
+            "contractSha256": "c907e675711a9e7c4eec4658a941b09d9ca277176ebe0e9f605a2f7feb52b371"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -3138,9 +3138,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 493696,
+            "length": 496205,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "c60b65dc5a0cebb01ac68a752aaf4207574ff30d9a923ad8c84ecc718a33ca22",
+            "contentSha256": "b9907b0ca0feb1c1111c171a455684749980893f466d2ed485bc38bd97610e37",
             "binarySource": null
           },
           {
@@ -3262,7 +3262,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2301,
+        "publicApiRecordCount": 2303,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -3886,8 +3886,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PolylineEx",
-            "recordCount": 11,
-            "contractSha256": "921aa6b2e802236c7d86808c13aac916d7ff87d1ea8d559f04dc62157179af0b"
+            "recordCount": 13,
+            "contractSha256": "c907e675711a9e7c4eec4658a941b09d9ca277176ebe0e9f605a2f7feb52b371"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -4144,9 +4144,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 495085,
+            "length": 497594,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "61648d02b254124bb3a47cef2179880a5b4fe110f430f8ab94d5e67a73f68f7e",
+            "contentSha256": "fa963fdeb5c4578cd7e709cb4e0f7630ecc3cd4c103ef96b306325134ea21d8c",
             "binarySource": null
           },
           {
@@ -4268,7 +4268,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2285,
+        "publicApiRecordCount": 2287,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -4882,8 +4882,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PolylineEx",
-            "recordCount": 11,
-            "contractSha256": "962fade718ca34104f38ae77c680c953f048a511ad15a53e8b48f4a187ae6e53"
+            "recordCount": 13,
+            "contractSha256": "55413872ca4ac7a31113aff56a81dc2bf5cd876f586fc36e62c2b58eeebdca9e"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -5140,9 +5140,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 487382,
+            "length": 489879,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "35b2eb2aa0087d6ac70ff6e860d78436918dcadd9c3e2cb49af59c37f3d61b1b",
+            "contentSha256": "bddfbac30dff5878604e7798f25e52a13f2199cacf17b95b3b054cdbc6e3ef19",
             "binarySource": null
           },
           {
@@ -5264,7 +5264,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2285,
+        "publicApiRecordCount": 2287,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -5878,8 +5878,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PolylineEx",
-            "recordCount": 11,
-            "contractSha256": "962fade718ca34104f38ae77c680c953f048a511ad15a53e8b48f4a187ae6e53"
+            "recordCount": 13,
+            "contractSha256": "55413872ca4ac7a31113aff56a81dc2bf5cd876f586fc36e62c2b58eeebdca9e"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -6136,9 +6136,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 487382,
+            "length": 489879,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "35b2eb2aa0087d6ac70ff6e860d78436918dcadd9c3e2cb49af59c37f3d61b1b",
+            "contentSha256": "bddfbac30dff5878604e7798f25e52a13f2199cacf17b95b3b054cdbc6e3ef19",
             "binarySource": null
           },
           {
@@ -6344,7 +6344,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2308,
+        "publicApiRecordCount": 2310,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArrayEx",
@@ -6963,8 +6963,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PolylineEx",
-            "recordCount": 11,
-            "contractSha256": "adf152ac3d02026f80509b72cc38f36c780d9347e6e363a049a9cb3714ae19b6"
+            "recordCount": 13,
+            "contractSha256": "786279bbdc6fe761d9f7e6e56a18c489a64f6909fceb6e37f3cb0a5c12b07daf"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -7235,9 +7235,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.Gcad.xml",
-            "length": 460784,
+            "length": 463293,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "96f98c2791934509aef48dd4ee1fcf367812b26507172ff4a5067606d41b78c7",
+            "contentSha256": "9d7b01b5cbb4524d9a15df8bc694f709a3c08f833d71857d9ecd01abe70303ce",
             "binarySource": null
           },
           {

--- a/Build/CADSharedModuleBaseline.json
+++ b/Build/CADSharedModuleBaseline.json
@@ -540,7 +540,7 @@
       "module": "Cad.Database",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "5d0273c6f7644cf3d89088fc96d9ae7cd02dc91ef0f21037afe6937d9b453884"
+      "sourceSha256": "21323df72cb263ebb2179e9262510547ca20ed529c7eb943ee4d03d59f654202"
     },
     {
       "order": "0410",

--- a/Build/CADSharedModuleBaseline.json
+++ b/Build/CADSharedModuleBaseline.json
@@ -540,7 +540,7 @@
       "module": "Cad.Database",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "4b4bb2512f86772953b7ae590d9276bfe0bf2a27de7b3eb11e400920b5e27a49"
+      "sourceSha256": "5d0273c6f7644cf3d89088fc96d9ae7cd02dc91ef0f21037afe6937d9b453884"
     },
     {
       "order": "0410",

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,7 +71,6 @@ front matter schema 和自动校验尚未落地。在迁移完成前，本页状
 
 | 状态 | 稳定 ID | 文档 | 使用边界 |
 | --- | --- | --- | --- |
-| `active` | `plan.zfgk-cad-migration` | [Fs.Zfgk.CAD 有价值能力迁移计划](zfgk-cad-migration-plan.md) | Issue #110 的长期集成计划；逐项吸收有增量价值的能力，不以来源或当前调用情况作为价值门槛，仍须满足多宿主、对象所有权和现有 API 去重要求。 |
 | `proposal` | `contract.dbtrans-lifecycle` | [DBTrans 生命周期与释放契约](dbtrans-lifecycle-contract.md) | 同时记录 Confirmed、Decision 与 Not run；不能把后续决定表述为已实施。 |
 | `proposal` | `proposal.edgeone-site-repository` | [EdgeOne Makers 站点仓库架构评估](edgeone-site-repository-evaluation.md) | Issue #48 的实施提案；展示仓库与精确来源链路已创建，最终框架、GitHub App、EdgeOne 和云资源仍未完成。 |
 
@@ -79,6 +78,7 @@ front matter schema 和自动校验尚未落地。在迁移完成前，本页状
 
 | 状态 | 稳定 ID | 文档 | 当前入口 |
 | --- | --- | --- | --- |
+| `historical` | `plan.zfgk-cad-migration` | [Fs.Zfgk.CAD 有价值能力迁移计划](zfgk-cad-migration-plan.md) | Issue #110 / PR #116 已结束来源迁移；现行行为以 `CurveEx`、`PointEx`、`PolylineEx`、`PointGridIndex` 的源码和 XML 注释为准。长期分支是否进入 `main` 另行评估。 |
 | `historical` | `plan.cad-modules` | [单程序集逻辑模块化执行计划](logical-modularization-plan.md) | 现行入口为[架构说明](关于IFoxCAD的架构说明.md)、根 [`AGENTS.md`](../AGENTS.md)、项目清单和模块基线；本文只追溯 Phase A 快照和实施过程。 |
 | `historical` | `history.upstream-v0.9` | [IFoxCAD v0.9 上游重要变更评估](ifoxcad-v0.9-upstream-merge-analysis.md) | Issue #26 已完成；后续需求重新核对实时上游和当前源码。 |
 

--- a/docs/zfgk-cad-migration-plan.md
+++ b/docs/zfgk-cad-migration-plan.md
@@ -244,7 +244,7 @@ ObjectARX、ZRX 和 GRX 的曲线契约均把 `Ray` 定义为起始参数 `0` �
 | `PolylineEx` | `GetSamplePointsByDistance` | 每个原始子段按沿折线的最大间距独立等距细分，保留所有原始顶点；闭合折线在结果末尾重复首顶点。 |
 | `PolylineEx` | `GetSamplePointsByChordDeviation` | 直线段只保留端点；圆弧段按弓高公式细分，使每个采样子弧的弦偏差不超过给定有限正数；同样保留原始顶点和闭合点。 |
 
-两个方法均返回独立的 `Point3d` 快照，不修改输入、不访问数据库、不创建需要释放的 CAD 对象。`Test_GeometryQuery` 同步覆盖直线/圆弧混合、开放/闭合、退化折线、非零 `Normal`/`Elevation`、非法阈值和不可表示的细分数量。点在线段左右关系由现有 `GeometryEx.GetArea`/`IsClockWise` 表达，范围关系和碰撞扫描由 `Rect`/`Rect.XCollision` 表达，不再新增平行 API。
+两个方法均返回独立的 `Point3d` 快照，不修改输入、不访问数据库、不创建需要释放的 CAD 对象。为避免极小但有限的阈值同步生成海量点并阻塞 CAD，方法先计算全部子段的总点数，超过 1,000,000 时在生成任何采样点前失败。`Test_GeometryQuery` 同步覆盖直线/圆弧混合、开放/闭合、退化折线、非零 `Normal`/`Elevation`、非法阈值、不可表示的细分数量和总点数上限。点在线段左右关系由现有 `GeometryEx.GetArea`/`IsClockWise` 表达，范围关系和碰撞扫描由 `Rect`/`Rect.XCollision` 表达，不再新增平行 API。
 
 最终批次的 AC_2019、AC_2025、ZW_2022、ZW_2025、GC_2022、GC_2023、GC_2026 Release 库和测试程序集均已通过直接构建。模块守卫保持 `142 / 42 / 17`，七目标兼容性基线仅增加 `PolylineEx` 的两个公开方法及对应 XML 文档，四目标 TypeDef 顺序未变化；HostAcceptance runner 自测通过。以上仍是 Build-only 和基础设施证据，`Test_GeometryQuery` 未在 CAD 中执行，真实宿主状态为 `Not run`。
 

--- a/docs/zfgk-cad-migration-plan.md
+++ b/docs/zfgk-cad-migration-plan.md
@@ -1,7 +1,7 @@
 # Fs.Zfgk.CAD 有价值能力迁移计划
 
 > 稳定 ID：`plan.zfgk-cad-migration`<br>
-> 状态：执行中（Active）<br>
+> 状态：最终收口中（Active）<br>
 > 目标分支：`migration/zfgk-cad`<br>
 > 来源快照：`FeiSiDev/Fs.Zfgk.CAD@c38ce320c75284536c907c1046e5458da4ae0468`<br>
 > 最近 `main` 集成：`origin/main@6e6f94223be418481663833fc65386d8cf2839a4` 已由 `2e68759f710046416f4e27d2c2f87487e4160619` 合入<br>
@@ -21,13 +21,13 @@
 - 大量能力已被 `DBTrans`、`SymbolTable`、`PointEx`、`GeometryEx`、`CurveEx`、`EditorEx`、`DBDictionaryEx`、`HatchEx`、`QuadTree` 等现行实现覆盖。
 - 若干未覆盖算法仍有通用价值，但旧实现存在资源所有权、容差、异常、事务和边界条件问题，必须按目标库契约重写并验证。
 
-迁移的合理目标是“吸收能力”，不是“搬运代码”。优先级如下：
+迁移的合理目标是“吸收能力”，不是“搬运代码”。最终只吸收三组可证明的通用增量：
 
-1. 曲线、折线和面域的只读几何算法，以及明确的对象所有权契约。
-2. 面向点去重、邻域和范围查询的稀疏网格索引；它与现有四叉树互补，而不是替换四叉树。
-3. 现有块导入/属性 API 没有覆盖的 DWG 导出工作流。
-4. SHX 搜索与几何文本序列化等有明确跨产品需求的辅助能力。
-5. 图形系统预览、DWG 表格和桌面 UI 只在出现真实通用消费者并能完成宿主验证后评估。
+1. 曲线、点和折线的只读几何查询，包括距离比例取点、弦偏差、顶点数据、子段长度、插值和确定性采样；
+2. 面向点去重、邻域和范围查询的稀疏 `PointGridIndex`，与现有四叉树形成明确分工；
+3. 为以上能力配套的跨宿主编译、公共契约守卫和宿主内确定性测试命令。
+
+其余来源能力最终决定为“复用现有”或“不迁移”，不再保留后续候选。以后出现相似需求时，应从 `Fs.Fox.CAD` 的实时契约重新设计，不继续以 `Fs.Zfgk.CAD` 为迁移输入。
 
 ## 2. 不可突破的边界
 
@@ -114,9 +114,9 @@
 | `Properties/AssemblyInfo.cs` | 旧项目程序集元数据。 | 不迁移；目标项目自行生成/维护。 |
 | `Geometry/AcadPlaneUtil.cs` | 仅返回 XY 平面；厂商 API 和现有 `PlaneEx` 足以表达。 | 不迁移。 |
 | `Geometry/CoordinateUtil.cs` | UCS/WCS 转换已由 `GeometryEx`、`EditorEx` 提供；旧实现隐式取活动文档。 | 复用现有实现。 |
-| `Geometry/GePointUtil.cs` | 极坐标、中点、二维距离和方向已有等价实现；点去重、排序和折线圆角概念仍可复核。 | 部分候选；只迁移经独立测试证明的缺失算法。 |
+| `Geometry/GePointUtil.cs` | 极坐标、中点、二维距离和方向已有等价实现；其点排序和折线圆角没有形成比现有几何 API 更可靠的契约。 | 复用现有 `PointEx`、`GeometryEx` 和 `PointGridIndex`；其余不迁移。 |
 | `Geometry/GeRectangleUtil.cs` | 轴向矩形相交已由 `Rect.IntersectsWith` 覆盖。 | 复用现有实现。 |
-| `Geometry/GeTriangle.cs` | 坡度/坡向和重心有领域价值，但旧实现存在退化三角形、法向方向和重心 Z 值问题。 | 条件候选；作为新的明确几何契约重写，不复制该类型。 |
+| `Geometry/GeTriangle.cs` | 坡度/坡向偏向地形业务，旧实现还存在退化三角形、法向方向和重心 Z 值问题。 | 不迁移。 |
 | `Geometry/MathUtil.cs` | 多数函数已有 `System.Math` 等价项；采样、反函数和容差方法的边界契约不完整。 | 不迁移整类；真实需求单独设计。 |
 
 ### 6.2 ObjectARX 基础能力
@@ -124,10 +124,10 @@
 | 来源文件 | 价值与现状 | 决定 |
 | --- | --- | --- |
 | `ObjectARX/AcadDocumentUtil.cs` | 文档枚举可直接使用 `DocumentManager`；`GetOpenedDocument` 忽略文件名并返回第一个文档。 | 不迁移。 |
-| `ObjectARX/ArxOthers/DwgScaleUtil.cs` | 使用特定字典键保存“标注/信息比例”，更像产品数据协议。 | 默认不迁移；若多个产品依赖同一持久化格式，先建立独立契约。 |
-| `ObjectARX/ArxOthers/ExtentUtil.cs` | 宽高、中心、扩展已被 `Rect`、`BoundingBox9`、`PointEx` 覆盖；范围关系和相交簇合并仍有价值。 | 部分候选；基于现有范围类型重写关系/聚类，不复制事务辅助。 |
+| `ObjectARX/ArxOthers/DwgScaleUtil.cs` | 使用特定字典键保存“标注/信息比例”，属于产品持久化协议。 | 不迁移。 |
+| `ObjectARX/ArxOthers/ExtentUtil.cs` | 宽高、中心、扩展、范围关系和碰撞扫描已被 `Rect`、`BoundingBox9`、`PointEx`、`Rect.XCollision` 覆盖。 | 复用现有实现，不迁移事务辅助。 |
 | `ObjectARX/ArxOthers/GroupUtil.cs` | 已由 `DBDictionaryEx.AddGroup`/`GetGroups` 覆盖。 | 复用现有实现。 |
-| `ObjectARX/ArxOthers/GsPreviewUtil.cs` | DWG 到位图预览有价值，但直接使用 AutoCAD GraphicsSystem、设备和视图生命周期。 | 高风险条件候选；独立平台设计和真实宿主测试前不迁移。 |
+| `ObjectARX/ArxOthers/GsPreviewUtil.cs` | DWG 到位图预览直接使用 AutoCAD GraphicsSystem、设备和视图生命周期，没有可验证的共享宿主契约。 | 不迁移。 |
 | `ObjectARX/ArxOthers/SectionUtil.cs` | 道路/断面面积算法带明显业务语义和 WinForms 提示。 | 不进入通用基础库。 |
 | `ObjectARX/DictionaryUtil.cs` | XDictionary/Xrecord 能力已由 `DBDictionaryEx`、`XRecordDataList` 和对象扩展覆盖。 | 复用现有实现。 |
 | `ObjectARX/DwgDatabaseUtil.cs` | 入库、空间枚举、Handle 转 ObjectId 已由 `DBTrans`、`SymbolTableRecordEx`、`ObjectIdEx`、`EntityEx` 覆盖。 | 复用现有实现。 |
@@ -136,25 +136,25 @@
 
 | 来源文件 | 价值与现状 | 决定 |
 | --- | --- | --- |
-| `ObjectARX/DwgTable/AcadDwgTable.cs` | 自绘表格、合并单元格和布局可能有业务价值，但依赖缺失的 `ZFGK.DwgTableBase`/`ZFGK.Utility`，实现约 1,500 行。 | 暂缓；先确认基础模型源码、真实消费者和与原生 `Table` 的差异。 |
-| `ObjectARX/DwgTable/AcadSubDrawTable.cs` | 只是缺失表格基础模型的 CAD 适配。 | 随上项处理，不单独迁移。 |
+| `ObjectARX/DwgTable/AcadDwgTable.cs` | 自绘表格、合并单元格和布局依赖缺失的 `ZFGK.DwgTableBase`/`ZFGK.Utility`，且与原生 `Table` 的职责边界不清。 | 不迁移。 |
+| `ObjectARX/DwgTable/AcadSubDrawTable.cs` | 只是缺失表格基础模型的 CAD 适配。 | 不迁移。 |
 
 ### 6.4 实体、曲线和面域
 
 | 来源文件 | 价值与现状 | 决定 |
 | --- | --- | --- |
-| `ObjectARX/Entity/ArcUtil.cs` | 反转圆弧可由厂商曲线 API表达；旧实现直接改 Normal/角度，需额外验证非 XY 平面。 | 不直接迁移。 |
-| `ObjectARX/Entity/BlockUtil.cs` | 块导入、插入和属性大多已有等价实现；“选定实体导出 DWG”仍可能有增量价值。 | 部分候选；仅评估缺失的导出契约和属性度量。 |
+| `ObjectARX/Entity/ArcUtil.cs` | 反转圆弧可由厂商曲线 API 表达；旧实现直接改 Normal/角度，不能可靠处理非 XY 平面。 | 复用厂商 API，不迁移。 |
+| `ObjectARX/Entity/BlockUtil.cs` | 块导入、插入和属性已有等价实现；导出 DWG 可由厂商 Wblock API 与现有数据库能力组合，旧实现存在失败后提交和固定版本问题。 | 复用现有实现，不迁移。 |
 | `ObjectARX/Entity/CircleUtil.cs` | 仅构造并入库，现有实体添加 API 足够。 | 不迁移。 |
-| `ObjectARX/Entity/CurveUtil.cs` | 子曲线、弦高、归一化位置、偏移和交点查询具有通用价值；旧实现对返回对象的释放和异常处理不完整。 | 部分已吸收：Phase 1 批次 1 已加入长度比例取点和两种中点弦偏差；返回新对象和数据库修改仍按后续批次处理。 |
-| `ObjectARX/Entity/DimensionUtil.cs` | 旋转标注构造简单，未形成独特抽象。 | 低优先条件候选；有重复消费者时再加入窄扩展。 |
-| `ObjectARX/Entity/EntityUtil.cs` | 擦除、变换、颜色、包围盒和克隆大多已有等价实现。 | 复用现有实现；块属性克隆随 Block 项评估。 |
+| `ObjectARX/Entity/CurveUtil.cs` | 子曲线、归一化位置和弦偏差具有通用价值；目标库已有拆分、偏移和交点相关能力，旧实现对返回对象的释放和异常处理不完整。 | 已吸收长度比例取点和两种中点弦偏差；其余复用现有实现，不再迁移。 |
+| `ObjectARX/Entity/DimensionUtil.cs` | 旋转标注构造简单，未形成独特抽象。 | 不迁移。 |
+| `ObjectARX/Entity/EntityUtil.cs` | 擦除、变换、颜色、包围盒和克隆已有等价实现。 | 复用现有实现。 |
 | `ObjectARX/Entity/HatchUtil.cs` | 已有 `HatchEx`、`HatchConverter` 和边界创建能力；来源还依赖外部工具。 | 不迁移平行 API。 |
-| `ObjectARX/Entity/LineUtil.cs` | 方位、点线距离和插值有通用价值；相交状态和高程插值旧实现存在语义/结果问题。 | 部分已吸收：Phase 1 批次 1 已在 `PointEx` 加入比例插值和高程唯一点查询；方位/相交与修改操作继续去重。 |
+| `ObjectARX/Entity/LineUtil.cs` | 方位、点线距离和插值有通用价值；目标库已有面积/方向和厂商相交能力，旧实现的相交状态与高程插值存在语义问题。 | 已吸收比例插值和高程唯一点查询；其余复用现有实现，不再迁移。 |
 | `ObjectARX/Entity/PolyfaceMeshUtil.cs` | 仅创建网格并入库，现有实体添加机制可组合完成。 | 不迁移。 |
-| `ObjectARX/Entity/PolylineUtil.cs` | 连接、采样、分段、圆角、去零段和去共线点是本次最有价值的来源之一；旧实现同时操作事务、UI、对象释放和原位修改。 | 部分已吸收：Phase 1 批次 1 已加入完整顶点数据快照和单段长度；采样、创建新对象和修改操作继续分层处理。 |
-| `ObjectARX/Entity/RegionUtil.cs` | `Explode` 后转折线并连接可为 `RegionEx.ToCurves()` 提供替代思路，但旧实现泄漏临时对象且没有内外环/方向契约。 | 高优先设计输入；与 Region 所有权和 ZWCAD BRep 路径统一处理。 |
-| `ObjectARX/Entity/TextUtil.cs` | 添加文字、文字样式和去格式化大多已有实现；文字边界度量可能有宿主差异。 | 复用现有实现；度量需求单独验证。 |
+| `ObjectARX/Entity/PolylineUtil.cs` | 顶点数据、子段长度和只读采样具有明确通用价值；连接、圆角、去零段和去共线点的旧实现会混合事务、UI、对象释放和原位修改。 | 已吸收顶点快照、子段长度、按距离采样和按弦偏差采样；修改操作不迁移。 |
+| `ObjectARX/Entity/RegionUtil.cs` | `Explode` 后转折线并连接的旧实现泄漏临时对象，且没有内外环、方向、顺序和部分失败契约；当前也缺少 ZWCAD 2022 真实宿主证据。 | 不迁移；`RegionEx.ToCurves()` 的条件编译历史实现保持禁用。 |
+| `ObjectARX/Entity/TextUtil.cs` | 添加文字、文字样式和去格式化已有实现；文字边界度量存在宿主差异。 | 复用现有实现，不迁移度量包装。 |
 | `ObjectARX/Entity/XDataUtil.cs` | 已由 `TypedValueList`、`XDataList`、`DBObjectEx` 和选择过滤体系覆盖。 | 复用现有实现。 |
 
 ### 6.5 Editor、符号表和辅助能力
@@ -167,14 +167,14 @@
 | `ObjectARX/Interaction/SelectionSetUtil.cs` | implied selection 是原生 Editor API，目标代码已有使用。 | 不新增平行包装。 |
 | `ObjectARX/Interaction/ResultLocateUtil.cs` | 与专用 WinForms 结果定位窗口强耦合。 | 不进入基础库。 |
 | `ObjectARX/LayerUtil.cs` | 已由 `SymbolTable<LayerTable,...>`、`SymbolTableEx` 和 Editor 选择能力覆盖。 | 复用现有实现。 |
-| `ObjectARX/LinetypeUtil.cs` | 线型表访问已有统一符号表入口；系统线型文件加载需要单独的宿主路径契约。 | 默认复用现有实现；加载真实需求另立项。 |
-| `ObjectARX/TextStyleUtil.cs` | 文字样式写入已有实现；支持路径中的 SHX 枚举/存在性检查仍可能有增量价值。 | 条件候选；分离“路径发现”和“样式写入”，禁止弹窗和静默替换。 |
+| `ObjectARX/LinetypeUtil.cs` | 线型表访问已有统一符号表入口；系统线型文件加载属于宿主路径策略。 | 复用现有实现，不迁移。 |
+| `ObjectARX/TextStyleUtil.cs` | 文字样式写入已有实现；SHX 枚举混合宿主路径、程序集目录、外部工具和 UI 回退。 | 复用现有文字样式与 `Env` 能力，不迁移。 |
 | `ObjectARX/Others/ConvertUtil.cs` | 点/向量/集合和 UCS/WCS 转换已由 `PointEx`、`VectorEx`、`GeometryEx`、LINQ 覆盖；外部向量类型不属于目标库。 | 复用现有实现。 |
-| `ObjectARX/Others/FormatUtil.cs` | 点/向量文本序列化可能有价值，但旧实现缺少文化区、版本和失败契约。 | 低优先条件候选；先定义 invariant/显示格式和 `TryParse`。 |
+| `ObjectARX/Others/FormatUtil.cs` | 点/向量文本序列化缺少文化区、版本和失败契约，也不属于 CAD 对象核心能力。 | 不迁移。 |
 | `ObjectARX/Others/ListUtil.cs` | 唯一有效方法为交换元素，其余为大段历史注释。 | 不迁移。 |
 | `ObjectARX/Others/ViewUtil.cs` | 已由 `EditorEx.Zoom*` 覆盖。 | 复用现有实现。 |
 | `ObjectARX/SpacialIndex/DynamicPointSpatialIndex.cs` | 点去重、邻域、最近点和范围查询有明确通用价值。旧实现存在无效状态、密集二维数组、UI 弹窗和边界错误。 | 已吸收为 `PointGridIndex`：保留稳定索引、近似去重、范围和最近点能力；不保留固定 extent、公开网格行列和两阶段初始化。 |
-| `ObjectARX/SpacialIndex/EntitySpatialIndex.cs` | 实体范围查询有价值，但目标已有 `QuadTree`；旧实现把事务和网格构建耦合。 | 不迁移该类型；仅把可证明的批量建索引需求补到现有空间索引体系。 |
+| `ObjectARX/SpacialIndex/EntitySpatialIndex.cs` | 实体范围查询已由 `QuadTree` 承担；旧实现把事务和网格构建耦合。 | 复用现有 `QuadTree`，不迁移。 |
 | `Other/NumberUtil.cs` | 只拆尾部数字；无数字时抛异常但始终声明返回 true。 | 不迁移；真实需求使用明确 `Try*` 契约。 |
 | `Others/ApplicationUtil.cs` | 支持路径读取与现有 `Env` 边界重合。 | 复用现有实现。 |
 | `UI/ResultLocateForm.cs`、`UI/ResultLocateForm.Designer.cs` | 专用结果定位窗口，包含删除/定位业务流程。 | 不进入通用基础库。 |
@@ -211,7 +211,7 @@ Phase 0 的清单和结构决策已经完成。后续每个代码批次必须回
 
 ### Phase 1：只读几何查询
 
-候选范围：
+最终范围：
 
 - 曲线按归一化距离取点、弦高/逼近误差计算；
 - 折线顶点、bulge、段长和确定性采样；
@@ -234,7 +234,18 @@ Phase 0 的清单和结构决策已经完成。后续每个代码批次必须回
 
 ObjectARX、ZRX 和 GRX 的曲线契约均把 `Ray` 定义为起始参数 `0` 且没有终止参数，把 `Xline` 定义为没有起止参数或起止点。因此三种查询不能共用“必须具有有限总长”这一前置条件：长度比例取点明确拒绝两者；参数中点弦偏差接受有限的 `Ray`/`Xline` 参数区间，其中 `Ray` 参数不得小于 `0`；距离中点弦偏差接受从基点开始的有限非负 `Ray` 距离区间，但拒绝没有距离原点的 `Xline`。这一区分以 SDK 曲线契约为准。
 
-批次 1 提供宿主内确定性验收命令 `Test_GeometryQuery`，覆盖直线、半圆、`Ray`/`Xline` 边界、开放/闭合折线和高程插值边界。AC_2019、AC_2025、ZW_2022、ZW_2025、GC_2022、GC_2023、GC_2026 的 Release 库和测试程序集均已通过直接构建，模块、兼容性和 TypeDef 顺序守卫通过；这只是 Build-only 证据，命令尚未在 CAD 中执行，真实宿主状态为 `Not run`。折线按距离/弦偏差采样、点在线段左右关系和范围聚类尚未计入本批完成范围。
+批次 1 提供宿主内确定性验收命令 `Test_GeometryQuery`，覆盖直线、半圆、`Ray`/`Xline` 边界、开放/闭合折线和高程插值边界。AC_2019、AC_2025、ZW_2022、ZW_2025、GC_2022、GC_2023、GC_2026 的 Release 库和测试程序集均已通过直接构建，模块、兼容性和 TypeDef 顺序守卫通过；这只是 Build-only 证据，命令尚未在 CAD 中执行，真实宿主状态为 `Not run`。
+
+最终批次只补充折线确定性采样，不混入折线修改或数据库行为：
+
+| 目标类型 | API | 最终契约 |
+| --- | --- | --- |
+| `PolylineEx` | `GetSamplePointsByDistance` | 每个原始子段按沿折线的最大间距独立等距细分，保留所有原始顶点；闭合折线在结果末尾重复首顶点。 |
+| `PolylineEx` | `GetSamplePointsByChordDeviation` | 直线段只保留端点；圆弧段按弓高公式细分，使每个采样子弧的弦偏差不超过给定有限正数；同样保留原始顶点和闭合点。 |
+
+两个方法均返回独立的 `Point3d` 快照，不修改输入、不访问数据库、不创建需要释放的 CAD 对象。`Test_GeometryQuery` 同步覆盖直线/圆弧混合、开放/闭合、退化折线、非零 `Normal`/`Elevation`、非法阈值和不可表示的细分数量。点在线段左右关系由现有 `GeometryEx.GetArea`/`IsClockWise` 表达，范围关系和碰撞扫描由 `Rect`/`Rect.XCollision` 表达，不再新增平行 API。
+
+最终批次的 AC_2019、AC_2025、ZW_2022、ZW_2025、GC_2022、GC_2023、GC_2026 Release 库和测试程序集均已通过直接构建。模块守卫保持 `142 / 42 / 17`，七目标兼容性基线仅增加 `PolylineEx` 的两个公开方法及对应 XML 文档，四目标 TypeDef 顺序未变化；HostAcceptance runner 自测通过。以上仍是 Build-only 和基础设施证据，`Test_GeometryQuery` 未在 CAD 中执行，真实宿主状态为 `Not run`。
 
 ### Phase 2：点网格索引
 
@@ -265,42 +276,34 @@ Phase 2 的七目标公共契约基线均只新增 `PointGridIndex` 的 16 条�
 
 AC_2019、AC_2025、ZW_2022、ZW_2025、GC_2022、GC_2023、GC_2026 的 Release 库和测试程序集均已通过直接构建，模块期望更新为 `142` 个编译项、`Cad.Geometry = 17`；真实 CAD 宿主状态仍为 `Not run`。
 
-### Phase 3：曲线/折线修改与 Region
+### Phase 3：曲线/折线修改与 Region（已关闭，不迁移）
 
-- 在只读算法稳定后，再实现返回新对象的拆分、连接和简化。
-- 原位修改折线作为独立批次，保留宽度、bulge、闭合状态、Normal、Elevation 和属性。
-- Region 边界提取同时评估 `Explode` 路径、AutoCAD BRep 路径和 ZWCAD 2022 能力；定义外环/内环、方向、顺序、部分失败和对象所有权。
-- Issue #103/#107 中条件编译保留的 `RegionEx.ToCurves()` 只作为历史实现和风险清单，不因本迁移直接启用。
+- 目标库已有曲线拆分等基础能力，不从来源复制连接、圆角、去零段或去共线点实现。
+- 来源的原位修改不能完整保留宽度、bulge、闭合状态、`Normal`、`Elevation` 和实体属性，最终不迁移。
+- Region 边界提取缺少内外环、方向、顺序、部分失败、对象所有权和 ZWCAD 2022 宿主证据，最终不迁移。
+- Issue #103/#107 中条件编译保留的 `RegionEx.ToCurves()` 继续只作为历史实现和风险清单，不启用、不扩展。
 
-### Phase 4：数据库工作流
+### Phase 4：数据库工作流（已关闭，不迁移）
 
-- 先证明现有 `GetBlockFrom`、`InsertBlock`、`ChangeBlockAttribute` 等 API 的缺口。
-- 如仍有增量，再设计“选定实体导出 DWG”：目标版本、基点、重复记录、覆盖、临时文件、原子替换和失败回滚均为必填契约。
-- SHX 搜索仅在调用方确有跨宿主需求时实现；路径枚举、去重、访问异常和文件名比较需可测试。
-- 数据库写入与 UI 提示分离，不把当前 Document/Editor 隐式嵌入底层方法。
+- 块导入、插入、属性和数据库保存复用现有 `GetBlockFrom`、`InsertBlock`、`ChangeBlockAttribute`、`DatabaseEx` 及厂商 Wblock API。
+- 来源的实体导出 DWG 实现固定旧版本、隐式依赖活动文档，并在失败路径提交事务，不作为公共契约迁移。
+- SHX 搜索混合宿主支持路径、程序集目录和 UI 回退；本次不建立新的文件发现 API。
 
-### Phase 5：宿主专属和暂缓能力
+### Phase 5：宿主专属能力（已关闭，不迁移）
 
-DWG 图像预览、复杂自绘表格、结果定位窗体等不能搭便车进入共享程序集。每项需具备：
-
-1. 至少一个真实通用消费者；
-2. 完整依赖源码或可接受的独立替代设计；
-3. AutoCAD/ZWCAD 支持决策；
-4. 可执行的真实宿主验收场景。
-
-不满足时维持“暂缓/不迁移”，不使用大段 `#if false` 保存旧仓库副本。
+DWG 图像预览、复杂自绘表格、结果定位窗体和其他 WinForms/GraphicsSystem 能力均不进入共享程序集。它们缺少可重复依赖、共享宿主契约或通用基础库边界；最终清单不再保留候选状态，也不使用条件编译复制来源实现。
 
 ## 9. 分支和 PR 组织
 
-`migration/zfgk-cad` 是本次迁移的长期集成分支。具体代码使用从该分支建立的短分支，并将 PR base 指向该分支；建议批次名称保持窄小，例如：
+`migration/zfgk-cad` 是本次迁移的长期集成分支。已经完成的代码批次均从该分支建立短分支，并将 PR base 指向该分支：
 
 - `zfgk/geometry-query`
 - `zfgk/point-grid`
-- `zfgk/polyline-edit`
-- `zfgk/region-boundary`
-- `zfgk/block-export`
+- `zfgk/review-fixes`
+- `zfgk/curve-domain`
+- `zfgk/final-sampling`
 
-每个批次只处理一个所有权边界。长期分支阶段性合入最新 `main`，但冲突解决后必须重新执行模块守卫、兼容性检查和受影响构建。最终进入 `main` 前重新审查整个差异，不能把“各子 PR 已通过”替代集成验证。
+最终采样 PR 合入后不再建立新的 `Fs.Zfgk.CAD` 迁移批次。`migration/zfgk-cad` 继续与 `main` 隔离；是否以及何时进入 `main` 属于独立集成决策，必须重新同步最新 `main`、审查完整差异并获得维护者明确批准，不能用各子 PR 已通过替代最终集成验证。
 
 ## 10. 每批验收
 
@@ -336,24 +339,24 @@ DWG 图像预览、复杂自绘表格、结果定位窗体等不能搭便车进�
 | 3 | AutoCAD 2026（AC_2025 二进制基线） | .NET 8/新宿主行为和兼容性。 |
 | Not required | ZWCAD 2025 | 当前无真实宿主，不阻塞，但保持编译目标。 |
 
-当前本文只完成静态盘点，没有运行 CAD，宿主状态统一为 `Not run`。
+当前所有迁移批次均未运行 CAD，宿主状态统一为 `Not run`。七目标构建和静态守卫不代表真实宿主通过。
 
 ## 11. 完成定义
 
 本迁移不是以“来源文件全部处理”或“公共方法数量接近 451”为完成标准。满足以下条件才可收口：
 
-1. 每个来源文件都已有 `复用现有`、`已重写`、`暂缓` 或 `不迁移` 的明确结论；
+1. 每个来源文件都已有 `复用现有`、`已吸收` 或 `不迁移` 的最终结论，不再保留候选；
 2. 所有迁移能力符合当前目录、命名、事务和对象所有权契约；
 3. 没有引入来源二进制、AutoCAD-only using 泄漏或第二套平行 API；
 4. 自动构建/守卫与要求的真实宿主场景分别记录，未执行项不被包装为通过；
-5. 最终有效的公共行为写入 XML 注释和 current 文档，本文随后转为 `historical`；
-6. 长期分支相对最新 `main` 完成最终集成审查后，才建立合入 `main` 的 PR。
+5. 最终有效的公共行为写入 XML 注释，实施结果和未运行的宿主项写入本文；
+6. 最终采样 PR 合入 `migration/zfgk-cad` 后关闭 Issue #110，并将本文转为 `historical`。
 
-## 12. 下一步
+进入 `main` 不属于上述迁移完成定义。长期分支的完整集成审查和维护者批准仍是未来独立门槛。
 
-当前最合理的下一批不是整体搬运 `PolylineUtil.cs`，而是：
+## 12. 收口后状态
 
-1. 从 `CurveUtil`、`PolylineUtil`、`LineUtil` 提炼 5 至 8 个只读几何用例；
-2. 对照实时 `CurveEx`、`PolylineEx`、`PointEx` 去重，形成 Phase 1 API 草案；
-3. 先补可确定验证的算法测试，再提交第一批代码；
-4. 将每项实际结果回写第 6 节并关联 Issue #110。
+- 不再从 `Fs.Zfgk.CAD` 开展后续迁移，也不复用已删除的短期分支。
+- 新的通用 CAD 需求从 `Fs.Fox.CAD` 实时结构、厂商 SDK 和独立 Issue 出发设计，不以来源方法为规格。
+- `migration/zfgk-cad` 保留为尚未进入 `main` 的长期集成结果；在明确批准前不创建以 `main` 为 base 的迁移 PR。
+- 真实 CAD 宿主状态保持 `Not run`；未来若决定集成到 `main`，再按当时差异确定宿主验收范围。

--- a/docs/zfgk-cad-migration-plan.md
+++ b/docs/zfgk-cad-migration-plan.md
@@ -1,11 +1,12 @@
 # Fs.Zfgk.CAD 有价值能力迁移计划
 
 > 稳定 ID：`plan.zfgk-cad-migration`<br>
-> 状态：最终收口中（Active）<br>
+> 状态：已完成（Historical）<br>
 > 目标分支：`migration/zfgk-cad`<br>
 > 来源快照：`FeiSiDev/Fs.Zfgk.CAD@c38ce320c75284536c907c1046e5458da4ae0468`<br>
 > 最近 `main` 集成：`origin/main@6e6f94223be418481663833fc65386d8cf2839a4` 已由 `2e68759f710046416f4e27d2c2f87487e4160619` 合入<br>
 > 实施跟踪：[Issue #110](https://github.com/FsDiG/Fs.Fox.CAD/issues/110)<br>
+> 最终批次：[PR #116](https://github.com/FsDiG/Fs.Fox.CAD/pull/116)<br>
 > 最近复核：2026-08-03<br>
 > CAD 宿主验收：Not run
 
@@ -303,7 +304,7 @@ DWG 图像预览、复杂自绘表格、结果定位窗体和其他 WinForms/Gra
 - `zfgk/curve-domain`
 - `zfgk/final-sampling`
 
-最终采样 PR 合入后不再建立新的 `Fs.Zfgk.CAD` 迁移批次。`migration/zfgk-cad` 继续与 `main` 隔离；是否以及何时进入 `main` 属于独立集成决策，必须重新同步最新 `main`、审查完整差异并获得维护者明确批准，不能用各子 PR 已通过替代最终集成验证。
+PR #116 合入后不再建立新的 `Fs.Zfgk.CAD` 迁移批次。`migration/zfgk-cad` 继续与 `main` 隔离；是否以及何时进入 `main` 属于独立集成决策，必须重新同步最新 `main`、审查完整差异并获得维护者明确批准，不能用各子 PR 已通过替代最终集成验证。
 
 ## 10. 每批验收
 

--- a/src/CADShared/Cad/Database/Entities/Curves/Polylines/PolylineEx.cs
+++ b/src/CADShared/Cad/Database/Entities/Curves/Polylines/PolylineEx.cs
@@ -5,6 +5,8 @@ namespace Fs.Fox.Cad;
 /// </summary>
 public static class PolylineEx
 {
+    private const int MaximumSamplePointCount = 1_000_000;
+
     #region 获取多段线端点
 
     /// <summary>
@@ -107,7 +109,7 @@ public static class PolylineEx
     /// <returns>按折线行进方向排列的采样点快照</returns>
     /// <exception cref="ArgumentNullException"><paramref name="pl"/> 为 <see langword="null"/></exception>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="maximumSpacing"/> 不是有限正数</exception>
-    /// <exception cref="InvalidOperationException">折线距离域无效，或阈值要求的细分数量无法表示</exception>
+    /// <exception cref="InvalidOperationException">折线距离域无效、阈值要求的细分数量无法表示，或结果将超过 1,000,000 个点</exception>
     public static IReadOnlyList<Point3d> GetSamplePointsByDistance(this Polyline pl, double maximumSpacing)
     {
         if (pl is null)
@@ -130,7 +132,7 @@ public static class PolylineEx
     /// <returns>按折线行进方向排列的采样点快照</returns>
     /// <exception cref="ArgumentNullException"><paramref name="pl"/> 为 <see langword="null"/></exception>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="maximumChordDeviation"/> 不是有限正数</exception>
-    /// <exception cref="InvalidOperationException">圆弧或折线距离域无效，或阈值要求的细分数量无法表示</exception>
+    /// <exception cref="InvalidOperationException">圆弧或折线距离域无效、阈值要求的细分数量无法表示，或结果将超过 1,000,000 个点</exception>
     public static IReadOnlyList<Point3d> GetSamplePointsByChordDeviation(this Polyline pl,
         double maximumChordDeviation)
     {
@@ -170,8 +172,17 @@ public static class PolylineEx
         if (vertexCount == 0)
             return Array.Empty<Point3d>();
 
-        var points = new List<Point3d> { pl.GetPoint3dAt(0) };
         var segmentCount = GetSegmentCount(pl);
+        if (segmentCount > MaximumSamplePointCount - 1)
+        {
+            throw new InvalidOperationException(
+                $"The requested sampling would contain more than {MaximumSamplePointCount} points.");
+        }
+
+        var startDistances = new double[segmentCount];
+        var endDistances = new double[segmentCount];
+        var subdivisionCounts = new int[segmentCount];
+        var totalPointCount = 1;
         for (var segmentIndex = 0; segmentIndex < segmentCount; segmentIndex++)
         {
             var startDistance = pl.GetDistanceAtParameter(segmentIndex);
@@ -187,6 +198,24 @@ public static class PolylineEx
             var subdivisionCount = getSubdivisionCount(segmentIndex, segmentLength);
             if (subdivisionCount < 1)
                 throw new InvalidOperationException("The subdivision count must be positive.");
+            if (subdivisionCount > MaximumSamplePointCount - totalPointCount)
+            {
+                throw new InvalidOperationException(
+                    $"The requested sampling would contain more than {MaximumSamplePointCount} points.");
+            }
+
+            startDistances[segmentIndex] = startDistance;
+            endDistances[segmentIndex] = endDistance;
+            subdivisionCounts[segmentIndex] = subdivisionCount;
+            totalPointCount += subdivisionCount;
+        }
+
+        var points = new List<Point3d>(totalPointCount) { pl.GetPoint3dAt(0) };
+        for (var segmentIndex = 0; segmentIndex < segmentCount; segmentIndex++)
+        {
+            var startDistance = startDistances[segmentIndex];
+            var endDistance = endDistances[segmentIndex];
+            var subdivisionCount = subdivisionCounts[segmentIndex];
 
             for (var sampleIndex = 1; sampleIndex < subdivisionCount; sampleIndex++)
             {

--- a/src/CADShared/Cad/Database/Entities/Curves/Polylines/PolylineEx.cs
+++ b/src/CADShared/Cad/Database/Entities/Curves/Polylines/PolylineEx.cs
@@ -85,9 +85,7 @@ public static class PolylineEx
         if (pl is null)
             throw new ArgumentNullException(nameof(pl));
 
-        var segmentCount = pl.NumberOfVertices < 2
-            ? 0
-            : pl.Closed ? pl.NumberOfVertices : pl.NumberOfVertices - 1;
+        var segmentCount = GetSegmentCount(pl);
         if (segmentIndex < 0 || segmentIndex >= segmentCount)
         {
             throw new ArgumentOutOfRangeException(nameof(segmentIndex), segmentIndex,
@@ -95,6 +93,138 @@ public static class PolylineEx
         }
 
         return pl.GetDistanceAtParameter(segmentIndex + 1) - pl.GetDistanceAtParameter(segmentIndex);
+    }
+
+    /// <summary>
+    /// 按沿折线的最大间距获取采样点
+    /// </summary>
+    /// <remarks>
+    /// 每个原始子段独立等距细分，因此所有原始顶点都会保留。开放折线的结果从首顶点到末顶点；
+    /// 闭合折线会在结果末尾再次包含首顶点，以完整表示闭合路径。返回值是独立的点快照，不修改原折线。
+    /// </remarks>
+    /// <param name="pl">轻量多段线</param>
+    /// <param name="maximumSpacing">相邻采样点沿折线的最大距离，必须是有限正数</param>
+    /// <returns>按折线行进方向排列的采样点快照</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="pl"/> 为 <see langword="null"/></exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="maximumSpacing"/> 不是有限正数</exception>
+    /// <exception cref="InvalidOperationException">折线距离域无效，或阈值要求的细分数量无法表示</exception>
+    public static IReadOnlyList<Point3d> GetSamplePointsByDistance(this Polyline pl, double maximumSpacing)
+    {
+        if (pl is null)
+            throw new ArgumentNullException(nameof(pl));
+        ValidatePositiveFinite(maximumSpacing, nameof(maximumSpacing));
+
+        return GetSegmentSamplePoints(pl, (_, segmentLength) =>
+            GetSubdivisionCount(segmentLength / maximumSpacing));
+    }
+
+    /// <summary>
+    /// 按圆弧段的最大弦偏差获取采样点
+    /// </summary>
+    /// <remarks>
+    /// 直线段只保留端点；圆弧段按弓高公式等弧长细分，使每个采样子弧的弦偏差不超过指定值。
+    /// 所有原始顶点都会保留。闭合折线会在结果末尾再次包含首顶点。返回值是独立的点快照，不修改原折线。
+    /// </remarks>
+    /// <param name="pl">轻量多段线</param>
+    /// <param name="maximumChordDeviation">圆弧采样子段允许的最大弦偏差，必须是有限正数</param>
+    /// <returns>按折线行进方向排列的采样点快照</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="pl"/> 为 <see langword="null"/></exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="maximumChordDeviation"/> 不是有限正数</exception>
+    /// <exception cref="InvalidOperationException">圆弧或折线距离域无效，或阈值要求的细分数量无法表示</exception>
+    public static IReadOnlyList<Point3d> GetSamplePointsByChordDeviation(this Polyline pl,
+        double maximumChordDeviation)
+    {
+        if (pl is null)
+            throw new ArgumentNullException(nameof(pl));
+        ValidatePositiveFinite(maximumChordDeviation, nameof(maximumChordDeviation));
+
+        return GetSegmentSamplePoints(pl, (segmentIndex, segmentLength) =>
+        {
+            if (segmentLength == 0 || pl.GetSegmentType(segmentIndex) != SegmentType.Arc)
+                return 1;
+
+            using var arc = pl.GetArcSegment2dAt(segmentIndex);
+            var radius = arc.Radius;
+            if (double.IsNaN(radius) || double.IsInfinity(radius) || radius <= 0)
+                throw new InvalidOperationException("The polyline contains an arc with an invalid radius.");
+
+            var deviationRatio = maximumChordDeviation / radius * 0.5;
+            var maximumAngle = deviationRatio >= 1
+                ? Math.PI * 2
+                : 4 * Math.Asin(Math.Sqrt(deviationRatio));
+            if (double.IsNaN(maximumAngle) || double.IsInfinity(maximumAngle) || maximumAngle <= 0)
+            {
+                throw new InvalidOperationException(
+                    "The chord deviation requires a subdivision count that cannot be represented.");
+            }
+
+            var includedAngle = segmentLength / radius;
+            return GetSubdivisionCount(includedAngle / maximumAngle);
+        });
+    }
+
+    private static IReadOnlyList<Point3d> GetSegmentSamplePoints(Polyline pl,
+        Func<int, double, int> getSubdivisionCount)
+    {
+        var vertexCount = pl.NumberOfVertices;
+        if (vertexCount == 0)
+            return Array.Empty<Point3d>();
+
+        var points = new List<Point3d> { pl.GetPoint3dAt(0) };
+        var segmentCount = GetSegmentCount(pl);
+        for (var segmentIndex = 0; segmentIndex < segmentCount; segmentIndex++)
+        {
+            var startDistance = pl.GetDistanceAtParameter(segmentIndex);
+            var endDistance = pl.GetDistanceAtParameter(segmentIndex + 1);
+            if (double.IsNaN(startDistance) || double.IsInfinity(startDistance) || startDistance < 0 ||
+                double.IsNaN(endDistance) || double.IsInfinity(endDistance) || endDistance < startDistance)
+            {
+                throw new InvalidOperationException(
+                    "The polyline does not have a finite, non-negative, ordered distance range.");
+            }
+
+            var segmentLength = endDistance - startDistance;
+            var subdivisionCount = getSubdivisionCount(segmentIndex, segmentLength);
+            if (subdivisionCount < 1)
+                throw new InvalidOperationException("The subdivision count must be positive.");
+
+            for (var sampleIndex = 1; sampleIndex < subdivisionCount; sampleIndex++)
+            {
+                var fraction = (double)sampleIndex / subdivisionCount;
+                var distance = startDistance * (1 - fraction) + endDistance * fraction;
+                points.Add(pl.GetPointAtDist(distance));
+            }
+
+            points.Add(pl.GetPoint3dAt((segmentIndex + 1) % vertexCount));
+        }
+
+        return points;
+    }
+
+    private static int GetSegmentCount(Polyline pl)
+    {
+        return pl.NumberOfVertices < 2
+            ? 0
+            : pl.Closed ? pl.NumberOfVertices : pl.NumberOfVertices - 1;
+    }
+
+    private static int GetSubdivisionCount(double requiredCount)
+    {
+        var subdivisionCount = Math.Ceiling(requiredCount);
+        if (double.IsNaN(subdivisionCount) || double.IsInfinity(subdivisionCount) ||
+            subdivisionCount > int.MaxValue)
+        {
+            throw new InvalidOperationException(
+                "The sampling threshold requires a subdivision count that cannot be represented.");
+        }
+
+        return Math.Max(1, (int)subdivisionCount);
+    }
+
+    private static void ValidatePositiveFinite(double value, string parameterName)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value) || value <= 0)
+            throw new ArgumentOutOfRangeException(parameterName, value, "The value must be finite and greater than zero.");
     }
 
     #endregion

--- a/tests/TestShared/TestGeometryQuery.cs
+++ b/tests/TestShared/TestGeometryQuery.cs
@@ -109,6 +109,10 @@ public class TestGeometryQuery
             "Distance sampling representable count");
         AssertThrowsInvalidOperation(() => polyline.GetSamplePointsByChordDeviation(double.Epsilon),
             "Chord sampling representable count");
+        AssertThrowsInvalidOperation(() => polyline.GetSamplePointsByDistance(1e-6),
+            "Distance sampling total point limit");
+        AssertThrowsInvalidOperation(() => polyline.GetSamplePointsByChordDeviation(1e-12),
+            "Chord sampling total point limit");
 
         polyline.Closed = true;
         AssertClose(polyline.GetSegmentLength(2), Math.Sqrt(200), "Closing segment length");

--- a/tests/TestShared/TestGeometryQuery.cs
+++ b/tests/TestShared/TestGeometryQuery.cs
@@ -77,13 +77,71 @@ public class TestGeometryQuery
         AssertClose(polyline.GetSegmentLength(1), 10, "Line segment length");
         AssertThrowsArgumentOutOfRange(() => polyline.GetSegmentLength(2), "Open polyline segment range");
 
+        var distanceSamples = polyline.GetSamplePointsByDistance(6);
+        AssertTrue(distanceSamples.Count == 6, "Distance sampling count");
+        AssertPoint(distanceSamples[0], polyline.GetPoint3dAt(0), "Distance sampling start vertex");
+        AssertPoint(distanceSamples[3], polyline.GetPoint3dAt(1), "Distance sampling preserved arc vertex");
+        AssertPoint(distanceSamples[5], polyline.GetPoint3dAt(2), "Distance sampling end vertex");
+        for (var index = 1; index < distanceSamples.Count; index++)
+        {
+            AssertTrue(distanceSamples[index - 1].DistanceTo(distanceSamples[index]) <= 6 + Tolerance,
+                "Distance sampling maximum spacing");
+        }
+
+        var chordSamples = polyline.GetSamplePointsByChordDeviation(1.5);
+        AssertTrue(chordSamples.Count == 4, "Chord deviation sampling count");
+        AssertPoint(chordSamples[0], polyline.GetPoint3dAt(0), "Chord sampling start vertex");
+        AssertPoint(chordSamples[2], polyline.GetPoint3dAt(1), "Chord sampling preserved arc vertex");
+        AssertPoint(chordSamples[3], polyline.GetPoint3dAt(2), "Chord sampling end vertex");
+        AssertClose(chordSamples[1].DistanceTo(new Point3d(5, 0, 0)), 5,
+            "Semicircle chord sampling midpoint deviation");
+        AssertClose(polyline.GetBulgeAt(0), 1, "Sampling leaves bulge unchanged");
+        AssertClose(polyline.GetStartWidthAt(0), 2, "Sampling leaves start width unchanged");
+        AssertClose(polyline.GetEndWidthAt(0), 3, "Sampling leaves end width unchanged");
+
+        AssertThrowsArgumentOutOfRange(() => polyline.GetSamplePointsByDistance(0),
+            "Distance sampling positive threshold");
+        AssertThrowsArgumentOutOfRange(() => polyline.GetSamplePointsByDistance(double.NaN),
+            "Distance sampling finite threshold");
+        AssertThrowsArgumentOutOfRange(() => polyline.GetSamplePointsByChordDeviation(double.PositiveInfinity),
+            "Chord sampling finite threshold");
+        AssertThrowsInvalidOperation(() => polyline.GetSamplePointsByDistance(double.Epsilon),
+            "Distance sampling representable count");
+        AssertThrowsInvalidOperation(() => polyline.GetSamplePointsByChordDeviation(double.Epsilon),
+            "Chord sampling representable count");
+
         polyline.Closed = true;
         AssertClose(polyline.GetSegmentLength(2), Math.Sqrt(200), "Closing segment length");
+        var closedSamples = polyline.GetSamplePointsByDistance(100);
+        AssertTrue(closedSamples.Count == 4, "Closed sampling count");
+        AssertPoint(closedSamples[0], closedSamples[closedSamples.Count - 1],
+            "Closed sampling repeats first vertex");
+
+        using var orientedPolyline = new Polyline
+        {
+            Elevation = 7,
+            Normal = Vector3d.YAxis
+        };
+        orientedPolyline.AddVertexAt(0, Point2d.Origin, 0, 0, 0);
+        orientedPolyline.AddVertexAt(1, new Point2d(10, 0), 0, 0, 0);
+        var orientedSamples = orientedPolyline.GetSamplePointsByDistance(4);
+        AssertPoint(orientedSamples[0], orientedPolyline.GetPoint3dAt(0),
+            "Oriented sampling preserves start point");
+        AssertPoint(orientedSamples[orientedSamples.Count - 1], orientedPolyline.GetPoint3dAt(1),
+            "Oriented sampling preserves end point");
 
         using var degeneratePolyline = new Polyline { Closed = true };
         degeneratePolyline.AddVertexAt(0, Point2d.Origin, 0, 0, 0);
         AssertThrowsArgumentOutOfRange(() => degeneratePolyline.GetSegmentLength(0),
             "Degenerate closed polyline segment range");
+        AssertTrue(degeneratePolyline.GetSamplePointsByDistance(1).Count == 1,
+            "Degenerate distance sampling");
+        AssertTrue(degeneratePolyline.GetSamplePointsByChordDeviation(1).Count == 1,
+            "Degenerate chord sampling");
+
+        using var emptyPolyline = new Polyline();
+        AssertTrue(emptyPolyline.GetSamplePointsByDistance(1).Count == 0, "Empty distance sampling");
+        AssertTrue(emptyPolyline.GetSamplePointsByChordDeviation(1).Count == 0, "Empty chord sampling");
 
         Env.Printl("Test_GeometryQuery passed.");
     }


### PR DESCRIPTION
## 目的

完成 `Fs.Zfgk.CAD` 的最后一次能力迁移，只吸收仍具明确通用增量且可验证的折线只读采样能力。PR base 为 `migration/zfgk-cad`，不进入 `main`。

Refs #110

## 变更

- 在 `PolylineEx` 增加按沿折线最大间距采样。
- 在 `PolylineEx` 增加按圆弧最大弦偏差采样。
- 保留全部原始顶点，明确开放/闭合、退化折线、阈值和对象所有权契约；预计算并限制结果最多 1,000,000 点。
- 扩展 `Test_GeometryQuery`，并更新模块/兼容性基线。
- 将 49 个来源文件全部收敛为“复用现有、已吸收或不迁移”；本 PR 后不再建立新的来源迁移批次。

## 非目标

- 不启用 `RegionEx.ToCurves()`。
- 不迁移折线原位修改、DWG 导出、SHX 搜索、GraphicsSystem、DWG 表格或 WinForms 能力。
- 不修改程序集、NuGet 产品边界或运行时宿主配置。
- 不创建进入 `main` 的 PR。

## 验证

- 七个 Release 库与测试项目构建通过：AC_2019、AC_2025、ZW_2022、ZW_2025、GC_2022、GC_2023、GC_2026。
- 模块守卫：`142 / 42 / 17`。
- 七目标兼容性守卫通过；仅 `PolylineEx` 新增两个公开方法及对应 XML 文档。
- 四目标 TypeDef 顺序比较通过。
- HostAcceptance runner smoke 通过。
- `git diff --check` 和迁移计划 GFM 渲染通过。
- 真实 CAD 宿主：`Not run`。

## 生命周期

本 PR 合入 `migration/zfgk-cad` 后手工关闭 Issue #110；非默认分支 PR 不依赖 GitHub closing keyword。长期分支是否进入 `main` 留待以后单独批准和集成审查。