### PR TITLE
feat: 集成通用几何查询与点空间索引

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,7 @@
 - `main` 承载正常功能、修复、发布和文档治理，相关工作使用从最新 `main` 建立的短期分支和 PR。
 - Issue #25 的 `CADShared` 单程序集逻辑模块化已由 PR #100 合入 `main`；`refactor/cad-modules` 仅作为历史实施分支，不再作为新 PR 的 base。
 - 后续模块边界调整从最新 `main` 建立短期分支，并通过独立 Issue/PR 说明收益、兼容性边界和验收证据。
+- Issue #110 的 `Fs.Zfgk.CAD` 能力迁移已在 `migration/zfgk-cad` 收口；不再从来源仓库建立新迁移批次。该长期分支与 `main` 保持隔离，最终集成必须另行同步、审查并取得明确批准。
 - 不在逻辑模块化的机械移动中夹带行为修改、公共 API 修改、全文件格式化或无关文档重写。
 - 文档治理与发布能力由 Issue #48 跟踪；`Fs.Fox.CAD` 保持唯一产品内容源，已创建的展示/部署仓库及其边界见 [EdgeOne 站点仓库评估](docs/edgeone-site-repository-evaluation.md)和 [Fs.Fox.CAD.Site](https://github.com/FeiSiPub/Fs.Fox.CAD.Site)。站点框架尚未确定，不要在本仓库提前引入框架专用目录或生成产物。
 

--- a/Build/CADSharedCompatibilityBaseline.json
+++ b/Build/CADSharedCompatibilityBaseline.json
@@ -738,7 +738,7 @@
           {
             "type": "Fs.Fox.Cad.PolylineEx",
             "recordCount": 13,
-            "contractSha256": "e0329848ab3f94781385fc4dec91a343192d588703266f93dccffd2fb21bdc89"
+            "contractSha256": "00cc5345442f1b0866de9f7edab924a818779c172d112fb98eba3c43905e0cd3"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -1009,9 +1009,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.AutoCad.xml",
-            "length": 505379,
+            "length": 505449,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "604d1c7a8fcb0bad463f15648cd5aba1daf19d52e9ba1a2209430db0f81fca5c",
+            "contentSha256": "03e529ecc750de7d4994232abba6a65d3ccc1344b8db13f037994188a7e00347",
             "binarySource": null
           },
           {
@@ -1847,7 +1847,7 @@
           {
             "type": "Fs.Fox.Cad.PolylineEx",
             "recordCount": 13,
-            "contractSha256": "1f0c4f5bdbc0fa747133e0361401e63d2b662a63bb111203aa2523a01bc69267"
+            "contractSha256": "bf54a8410636de6e55adf3ca3c8b57f509944c5a5c12e01a89985245f993691e"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -2132,9 +2132,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.AutoCad.xml",
-            "length": 469655,
+            "length": 469725,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "ba253c6ee787b2c0edb37e58b951f19dc8450b23cc51918d3b284746a7e9beb0",
+            "contentSha256": "2f2e782c159e36bfa06ace8123edff8a3f5f01322d0173a6cbca84417768d6ca",
             "binarySource": null
           },
           {
@@ -2881,7 +2881,7 @@
           {
             "type": "Fs.Fox.Cad.PolylineEx",
             "recordCount": 13,
-            "contractSha256": "c907e675711a9e7c4eec4658a941b09d9ca277176ebe0e9f605a2f7feb52b371"
+            "contractSha256": "6e7d6fd1ee52127f1eefc42174a9aec957f169829fc5dec97e6a11827f721bfe"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -3138,9 +3138,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 496205,
+            "length": 496275,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "b9907b0ca0feb1c1111c171a455684749980893f466d2ed485bc38bd97610e37",
+            "contentSha256": "40a58ae432991e82cad82fa40edc043c17169a5426fe9c639fa364d1b4b32189",
             "binarySource": null
           },
           {
@@ -3887,7 +3887,7 @@
           {
             "type": "Fs.Fox.Cad.PolylineEx",
             "recordCount": 13,
-            "contractSha256": "c907e675711a9e7c4eec4658a941b09d9ca277176ebe0e9f605a2f7feb52b371"
+            "contractSha256": "6e7d6fd1ee52127f1eefc42174a9aec957f169829fc5dec97e6a11827f721bfe"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -4144,9 +4144,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 497594,
+            "length": 497664,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "fa963fdeb5c4578cd7e709cb4e0f7630ecc3cd4c103ef96b306325134ea21d8c",
+            "contentSha256": "27e4ad03c07e32bde7448b7fb2f8343d5336ee437f111651f92e96c7f49339ae",
             "binarySource": null
           },
           {
@@ -4883,7 +4883,7 @@
           {
             "type": "Fs.Fox.Cad.PolylineEx",
             "recordCount": 13,
-            "contractSha256": "55413872ca4ac7a31113aff56a81dc2bf5cd876f586fc36e62c2b58eeebdca9e"
+            "contractSha256": "eeaeb70247b5e87bcc56c0d3d839bdd8771091e4d65242b7d4c9548378404d35"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -5140,9 +5140,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 489879,
+            "length": 489949,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "bddfbac30dff5878604e7798f25e52a13f2199cacf17b95b3b054cdbc6e3ef19",
+            "contentSha256": "74840fab8fb8405d0c28eefc64a96f2295531c726b24326d179bcbf6ee040cf2",
             "binarySource": null
           },
           {
@@ -5879,7 +5879,7 @@
           {
             "type": "Fs.Fox.Cad.PolylineEx",
             "recordCount": 13,
-            "contractSha256": "55413872ca4ac7a31113aff56a81dc2bf5cd876f586fc36e62c2b58eeebdca9e"
+            "contractSha256": "eeaeb70247b5e87bcc56c0d3d839bdd8771091e4d65242b7d4c9548378404d35"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -6136,9 +6136,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 489879,
+            "length": 489949,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "bddfbac30dff5878604e7798f25e52a13f2199cacf17b95b3b054cdbc6e3ef19",
+            "contentSha256": "74840fab8fb8405d0c28eefc64a96f2295531c726b24326d179bcbf6ee040cf2",
             "binarySource": null
           },
           {
@@ -6964,7 +6964,7 @@
           {
             "type": "Fs.Fox.Cad.PolylineEx",
             "recordCount": 13,
-            "contractSha256": "786279bbdc6fe761d9f7e6e56a18c489a64f6909fceb6e37f3cb0a5c12b07daf"
+            "contractSha256": "3fec2b6a65add9eec32c2c7551b50f8099da710eef0fe1dab1bce22a13374a5e"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -7235,9 +7235,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.Gcad.xml",
-            "length": 463293,
+            "length": 463363,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "9d7b01b5cbb4524d9a15df8bc694f709a3c08f833d71857d9ecd01abe70303ce",
+            "contentSha256": "677fd4b7326d9c144c7f12cf56e1bd2c5712f60f32b06bdf1c338420fc7c9581",
             "binarySource": null
           },
           {

--- a/Build/CADSharedCompatibilityBaseline.json
+++ b/Build/CADSharedCompatibilityBaseline.json
@@ -103,7 +103,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2321,
+        "publicApiRecordCount": 2323,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -737,8 +737,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PolylineEx",
-            "recordCount": 11,
-            "contractSha256": "3aff3a32a0fd63e63a3fedd7d857e29b00c7c002681f994ca296401080f746e4"
+            "recordCount": 13,
+            "contractSha256": "e0329848ab3f94781385fc4dec91a343192d588703266f93dccffd2fb21bdc89"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -1009,9 +1009,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.AutoCad.xml",
-            "length": 502862,
+            "length": 505379,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "9e83a347a3614cf07f110e165a131b0150788e3f26c40d894d45b2c1efbacf7b",
+            "contentSha256": "604d1c7a8fcb0bad463f15648cd5aba1daf19d52e9ba1a2209430db0f81fca5c",
             "binarySource": null
           },
           {
@@ -1217,7 +1217,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2319,
+        "publicApiRecordCount": 2321,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArrayEx",
@@ -1846,8 +1846,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PolylineEx",
-            "recordCount": 11,
-            "contractSha256": "0b848fbd8d8de9e5afab4011e48ebbff5f3c40fef73397309099b21c71e9b22c"
+            "recordCount": 13,
+            "contractSha256": "1f0c4f5bdbc0fa747133e0361401e63d2b662a63bb111203aa2523a01bc69267"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -2132,9 +2132,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.AutoCad.xml",
-            "length": 467138,
+            "length": 469655,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "925fedc695e2cccaf775e60e4cf24b9519b5b8b6149aa7e52400d69bb8f60e40",
+            "contentSha256": "ba253c6ee787b2c0edb37e58b951f19dc8450b23cc51918d3b284746a7e9beb0",
             "binarySource": null
           },
           {
@@ -2256,7 +2256,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2298,
+        "publicApiRecordCount": 2300,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -2880,8 +2880,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PolylineEx",
-            "recordCount": 11,
-            "contractSha256": "921aa6b2e802236c7d86808c13aac916d7ff87d1ea8d559f04dc62157179af0b"
+            "recordCount": 13,
+            "contractSha256": "c907e675711a9e7c4eec4658a941b09d9ca277176ebe0e9f605a2f7feb52b371"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -3138,9 +3138,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 493696,
+            "length": 496205,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "c60b65dc5a0cebb01ac68a752aaf4207574ff30d9a923ad8c84ecc718a33ca22",
+            "contentSha256": "b9907b0ca0feb1c1111c171a455684749980893f466d2ed485bc38bd97610e37",
             "binarySource": null
           },
           {
@@ -3262,7 +3262,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2301,
+        "publicApiRecordCount": 2303,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -3886,8 +3886,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PolylineEx",
-            "recordCount": 11,
-            "contractSha256": "921aa6b2e802236c7d86808c13aac916d7ff87d1ea8d559f04dc62157179af0b"
+            "recordCount": 13,
+            "contractSha256": "c907e675711a9e7c4eec4658a941b09d9ca277176ebe0e9f605a2f7feb52b371"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -4144,9 +4144,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 495085,
+            "length": 497594,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "61648d02b254124bb3a47cef2179880a5b4fe110f430f8ab94d5e67a73f68f7e",
+            "contentSha256": "fa963fdeb5c4578cd7e709cb4e0f7630ecc3cd4c103ef96b306325134ea21d8c",
             "binarySource": null
           },
           {
@@ -4268,7 +4268,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2285,
+        "publicApiRecordCount": 2287,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -4882,8 +4882,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PolylineEx",
-            "recordCount": 11,
-            "contractSha256": "962fade718ca34104f38ae77c680c953f048a511ad15a53e8b48f4a187ae6e53"
+            "recordCount": 13,
+            "contractSha256": "55413872ca4ac7a31113aff56a81dc2bf5cd876f586fc36e62c2b58eeebdca9e"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -5140,9 +5140,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 487382,
+            "length": 489879,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "35b2eb2aa0087d6ac70ff6e860d78436918dcadd9c3e2cb49af59c37f3d61b1b",
+            "contentSha256": "bddfbac30dff5878604e7798f25e52a13f2199cacf17b95b3b054cdbc6e3ef19",
             "binarySource": null
           },
           {
@@ -5264,7 +5264,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2285,
+        "publicApiRecordCount": 2287,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -5878,8 +5878,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PolylineEx",
-            "recordCount": 11,
-            "contractSha256": "962fade718ca34104f38ae77c680c953f048a511ad15a53e8b48f4a187ae6e53"
+            "recordCount": 13,
+            "contractSha256": "55413872ca4ac7a31113aff56a81dc2bf5cd876f586fc36e62c2b58eeebdca9e"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -6136,9 +6136,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 487382,
+            "length": 489879,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "35b2eb2aa0087d6ac70ff6e860d78436918dcadd9c3e2cb49af59c37f3d61b1b",
+            "contentSha256": "bddfbac30dff5878604e7798f25e52a13f2199cacf17b95b3b054cdbc6e3ef19",
             "binarySource": null
           },
           {
@@ -6344,7 +6344,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2308,
+        "publicApiRecordCount": 2310,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArrayEx",
@@ -6963,8 +6963,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PolylineEx",
-            "recordCount": 11,
-            "contractSha256": "adf152ac3d02026f80509b72cc38f36c780d9347e6e363a049a9cb3714ae19b6"
+            "recordCount": 13,
+            "contractSha256": "786279bbdc6fe761d9f7e6e56a18c489a64f6909fceb6e37f3cb0a5c12b07daf"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -7235,9 +7235,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.Gcad.xml",
-            "length": 460784,
+            "length": 463293,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "96f98c2791934509aef48dd4ee1fcf367812b26507172ff4a5067606d41b78c7",
+            "contentSha256": "9d7b01b5cbb4524d9a15df8bc694f709a3c08f833d71857d9ecd01abe70303ce",
             "binarySource": null
           },
           {

--- a/Build/CADSharedCompatibilityBaseline.json
+++ b/Build/CADSharedCompatibilityBaseline.json
@@ -103,7 +103,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2298,
+        "publicApiRecordCount": 2305,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -382,8 +382,8 @@
           },
           {
             "type": "Fs.Fox.Cad.CurveEx",
-            "recordCount": 31,
-            "contractSha256": "808602652496dd6369b0c200c9d01e262c7d43834bdeffdbb4898ff8b1d20afa"
+            "recordCount": 34,
+            "contractSha256": "a71a48987dc50e58ad55a5da3d91dde0803a539e3bea679e29071ee35f3d40df"
           },
           {
             "type": "Fs.Fox.Cad.DatabaseEx",
@@ -722,8 +722,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PointEx",
-            "recordCount": 22,
-            "contractSha256": "0474742d333a6ba048ac2ac6ee688f00197be90d5e7576ce2eae3ece75de1bfe"
+            "recordCount": 24,
+            "contractSha256": "dcc41ddcb6149ae4a3d4daff0b2007faee124c437633af1c6382862b85c3a4db"
           },
           {
             "type": "Fs.Fox.Cad.PointOnRegionType",
@@ -732,8 +732,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PolylineEx",
-            "recordCount": 9,
-            "contractSha256": "e129eeb7832d061e4ea1eda94b82884ca132d52723279d975c9d81a113fbd2d7"
+            "recordCount": 11,
+            "contractSha256": "3aff3a32a0fd63e63a3fedd7d857e29b00c7c002681f994ca296401080f746e4"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -1004,9 +1004,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.AutoCad.xml",
-            "length": 490259,
+            "length": 496065,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "36e5b2e9e09b7e16204a1f14bcfe49d90702e427e16cd6302d6418e86531c518",
+            "contentSha256": "9461882745dedbe7016b924690be883406f565c2a625e158b42be430d2899e4b",
             "binarySource": null
           },
           {
@@ -1212,7 +1212,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2296,
+        "publicApiRecordCount": 2303,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArrayEx",
@@ -1486,8 +1486,8 @@
           },
           {
             "type": "Fs.Fox.Cad.CurveEx",
-            "recordCount": 31,
-            "contractSha256": "c519ffa156d4728f44a97369e058a68b40e0ba552997df87cd9d446fc9b97c2c"
+            "recordCount": 34,
+            "contractSha256": "0994521d70817ce2572d33ad54c70c54fa0f9426dee34f3c034d0cc1a3e2f198"
           },
           {
             "type": "Fs.Fox.Cad.DatabaseEx",
@@ -1826,8 +1826,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PointEx",
-            "recordCount": 22,
-            "contractSha256": "8a19c2ca319e98a3d074d2e83dbcbc944a6f291744f008fbeb5f306b6294ecaa"
+            "recordCount": 24,
+            "contractSha256": "230d7251a6cd2ce982cf485d63d333e82adc382250d79ef96a72da19ae56f068"
           },
           {
             "type": "Fs.Fox.Cad.PointOnRegionType",
@@ -1836,8 +1836,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PolylineEx",
-            "recordCount": 9,
-            "contractSha256": "4430d7ea55289925fc1b82f97752ae3f864cde94ca85f25068e6b682777d5585"
+            "recordCount": 11,
+            "contractSha256": "0b848fbd8d8de9e5afab4011e48ebbff5f3c40fef73397309099b21c71e9b22c"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -2122,9 +2122,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.AutoCad.xml",
-            "length": 454532,
+            "length": 460341,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "aa68fd8bb0daf214b90c22a556f2a13cbd863f15975938ae9f7005e1c605520c",
+            "contentSha256": "5bb03f051842bf76f8ff2c4de829ec3afd37892d88af374b9de1e07703634939",
             "binarySource": null
           },
           {
@@ -2246,7 +2246,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2275,
+        "publicApiRecordCount": 2282,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -2520,8 +2520,8 @@
           },
           {
             "type": "Fs.Fox.Cad.CurveEx",
-            "recordCount": 31,
-            "contractSha256": "fea592d09e7b86c7dea633fbe6a44bfbf71eec0630f82206fb707cb03743e838"
+            "recordCount": 34,
+            "contractSha256": "25c1f8cc9aa458138ad9573f3b35d5e37ebad8478681d741946da05fd0d0c7a0"
           },
           {
             "type": "Fs.Fox.Cad.DatabaseEx",
@@ -2855,8 +2855,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PointEx",
-            "recordCount": 22,
-            "contractSha256": "8f7b20d4748f03a49aec486fde1d33e86c4619de841ea5e8284627f3d6769f93"
+            "recordCount": 24,
+            "contractSha256": "09c2fc5cef4edc22b2c0a8697d360f57f24f5a0609b09d6276fe8ad92e1ad68c"
           },
           {
             "type": "Fs.Fox.Cad.PointOnRegionType",
@@ -2865,8 +2865,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PolylineEx",
-            "recordCount": 9,
-            "contractSha256": "c1be91bbcb040a8bf88c570793631cf1c2eff04866472a4f89a882715a6a1b82"
+            "recordCount": 11,
+            "contractSha256": "921aa6b2e802236c7d86808c13aac916d7ff87d1ea8d559f04dc62157179af0b"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -3123,9 +3123,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 481181,
+            "length": 486947,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "227da6292324b41e087ff2ecba86c571afe92480aa755994322874a9c675cfc4",
+            "contentSha256": "0a8895a513d432ecd02f44b190b9af6cab32ae20e79b8c1b21255ec21a6c53b2",
             "binarySource": null
           },
           {
@@ -3247,7 +3247,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2278,
+        "publicApiRecordCount": 2285,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -3521,8 +3521,8 @@
           },
           {
             "type": "Fs.Fox.Cad.CurveEx",
-            "recordCount": 31,
-            "contractSha256": "fea592d09e7b86c7dea633fbe6a44bfbf71eec0630f82206fb707cb03743e838"
+            "recordCount": 34,
+            "contractSha256": "25c1f8cc9aa458138ad9573f3b35d5e37ebad8478681d741946da05fd0d0c7a0"
           },
           {
             "type": "Fs.Fox.Cad.DatabaseEx",
@@ -3856,8 +3856,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PointEx",
-            "recordCount": 22,
-            "contractSha256": "8f7b20d4748f03a49aec486fde1d33e86c4619de841ea5e8284627f3d6769f93"
+            "recordCount": 24,
+            "contractSha256": "09c2fc5cef4edc22b2c0a8697d360f57f24f5a0609b09d6276fe8ad92e1ad68c"
           },
           {
             "type": "Fs.Fox.Cad.PointOnRegionType",
@@ -3866,8 +3866,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PolylineEx",
-            "recordCount": 9,
-            "contractSha256": "c1be91bbcb040a8bf88c570793631cf1c2eff04866472a4f89a882715a6a1b82"
+            "recordCount": 11,
+            "contractSha256": "921aa6b2e802236c7d86808c13aac916d7ff87d1ea8d559f04dc62157179af0b"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -4124,9 +4124,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 482570,
+            "length": 488336,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "526f11c0944505de2c5b5380e27ba7c2b9334303d04cc990d78c86ec60da54f0",
+            "contentSha256": "9f732de88936fbeb1bb2ab35a07d612a49b4eadd2d31f70856116798ca14b14a",
             "binarySource": null
           },
           {
@@ -4248,7 +4248,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2262,
+        "publicApiRecordCount": 2269,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -4517,8 +4517,8 @@
           },
           {
             "type": "Fs.Fox.Cad.CurveEx",
-            "recordCount": 30,
-            "contractSha256": "6d5c160bf0bfcd354bb13e5e5383a20d0f1b4fb96cff140009762fc0ded14777"
+            "recordCount": 33,
+            "contractSha256": "9d63ec03e1ef6dabc845d8a8342427598c4b8de648cbcf44c68b0685c46e73d8"
           },
           {
             "type": "Fs.Fox.Cad.DatabaseEx",
@@ -4847,8 +4847,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PointEx",
-            "recordCount": 22,
-            "contractSha256": "28ef136750a626537da612c66624190927725e1d6b1d78c2223b5389e9da7fdb"
+            "recordCount": 24,
+            "contractSha256": "75646268c6496a2dd5a4967e254ea0a9da100d2ea297f0fe0a3e7685ed584f3c"
           },
           {
             "type": "Fs.Fox.Cad.PointOnRegionType",
@@ -4857,8 +4857,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PolylineEx",
-            "recordCount": 9,
-            "contractSha256": "c48bfdefb465abe0538f6a47fcb2c38a6d1dabfd08471dae9cf0b586d93790a5"
+            "recordCount": 11,
+            "contractSha256": "962fade718ca34104f38ae77c680c953f048a511ad15a53e8b48f4a187ae6e53"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -5115,9 +5115,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 474999,
+            "length": 480705,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "e09d49eab2c4e72d65785eaa9b0b30f2a01329fd6365949d46614cdde48c8d4d",
+            "contentSha256": "abe116c62e5b5f01291e209db42efc483580f1b8f1596d45e00274cc36f3d715",
             "binarySource": null
           },
           {
@@ -5239,7 +5239,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2262,
+        "publicApiRecordCount": 2269,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -5508,8 +5508,8 @@
           },
           {
             "type": "Fs.Fox.Cad.CurveEx",
-            "recordCount": 30,
-            "contractSha256": "6d5c160bf0bfcd354bb13e5e5383a20d0f1b4fb96cff140009762fc0ded14777"
+            "recordCount": 33,
+            "contractSha256": "9d63ec03e1ef6dabc845d8a8342427598c4b8de648cbcf44c68b0685c46e73d8"
           },
           {
             "type": "Fs.Fox.Cad.DatabaseEx",
@@ -5838,8 +5838,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PointEx",
-            "recordCount": 22,
-            "contractSha256": "28ef136750a626537da612c66624190927725e1d6b1d78c2223b5389e9da7fdb"
+            "recordCount": 24,
+            "contractSha256": "75646268c6496a2dd5a4967e254ea0a9da100d2ea297f0fe0a3e7685ed584f3c"
           },
           {
             "type": "Fs.Fox.Cad.PointOnRegionType",
@@ -5848,8 +5848,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PolylineEx",
-            "recordCount": 9,
-            "contractSha256": "c48bfdefb465abe0538f6a47fcb2c38a6d1dabfd08471dae9cf0b586d93790a5"
+            "recordCount": 11,
+            "contractSha256": "962fade718ca34104f38ae77c680c953f048a511ad15a53e8b48f4a187ae6e53"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -6106,9 +6106,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 474999,
+            "length": 480705,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "e09d49eab2c4e72d65785eaa9b0b30f2a01329fd6365949d46614cdde48c8d4d",
+            "contentSha256": "abe116c62e5b5f01291e209db42efc483580f1b8f1596d45e00274cc36f3d715",
             "binarySource": null
           },
           {
@@ -6314,7 +6314,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2285,
+        "publicApiRecordCount": 2292,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArrayEx",
@@ -6583,8 +6583,8 @@
           },
           {
             "type": "Fs.Fox.Cad.CurveEx",
-            "recordCount": 31,
-            "contractSha256": "df1ae8119f6186c84bd33e84bd8e16f25edb0c710479b992ee16fd71c78433fe"
+            "recordCount": 34,
+            "contractSha256": "2f619d24c6db81e053feddb3febad16a5e5410f2cd5c565e5f0933d16f122c6a"
           },
           {
             "type": "Fs.Fox.Cad.DatabaseEx",
@@ -6918,8 +6918,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PointEx",
-            "recordCount": 22,
-            "contractSha256": "9e1b41b7eed67f45012f34c154651b998be06bdf040aade17e826cc1000d0d9a"
+            "recordCount": 24,
+            "contractSha256": "42e375a21d084aa3234fe082a46821b8c0048244cc5a18137545c0da548b0f6c"
           },
           {
             "type": "Fs.Fox.Cad.PointOnRegionType",
@@ -6928,8 +6928,8 @@
           },
           {
             "type": "Fs.Fox.Cad.PolylineEx",
-            "recordCount": 9,
-            "contractSha256": "39e39ba8d4bcecca31a90851b7ad90e40175daa0fe3c73127848691d14c19486"
+            "recordCount": 11,
+            "contractSha256": "adf152ac3d02026f80509b72cc38f36c780d9347e6e363a049a9cb3714ae19b6"
           },
           {
             "type": "Fs.Fox.Cad.PostCmd",
@@ -7200,9 +7200,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.Gcad.xml",
-            "length": 448266,
+            "length": 454035,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "b3e04ac7ed213be3d65db0a92049f27c6df386f6c946a1dd7a303df433204bca",
+            "contentSha256": "3b89a540bf149aa9b5dddfb7b4fd46738154ea0857139bbffc212c5baa116910",
             "binarySource": null
           },
           {

--- a/Build/CADSharedCompatibilityBaseline.json
+++ b/Build/CADSharedCompatibilityBaseline.json
@@ -1009,9 +1009,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.AutoCad.xml",
-            "length": 501914,
+            "length": 502044,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "a335b72d93b05079bd4f136bde6c64840dd31c281fe558b16a34496d3d51cb83",
+            "contentSha256": "4c060325dc24372f10078fb718a45c34055559c40176d9e50fe0003f0c016297",
             "binarySource": null
           },
           {
@@ -2132,9 +2132,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.AutoCad.xml",
-            "length": 466190,
+            "length": 466320,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "be5071f83c016d92c981fc29873a4bec9dcde5230c32908cba2ec555ac88b6f8",
+            "contentSha256": "f2d4b789d22b30fa3382c1abdf5286a11ea474748195f0803d95be6d8004e35a",
             "binarySource": null
           },
           {
@@ -3138,9 +3138,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 492772,
+            "length": 492902,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "4e6dfc9a363e13bbddf8eb55c22dece3796d5d2efaccb2e715ed8fed5e2f23d3",
+            "contentSha256": "fb7f281efda77f31e22064e4f179a96a8f1be2215da65fe4226995d56f3443d8",
             "binarySource": null
           },
           {
@@ -4144,9 +4144,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 494161,
+            "length": 494291,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "4fe434615e3c66f09be0a751d3855adeff456cc5835d0a5ec3b9dfb7d900167c",
+            "contentSha256": "f53358e53cfc3de95eae9b7096102b88cb3b59f7d84ddf4159f41f3005ab955b",
             "binarySource": null
           },
           {
@@ -5140,9 +5140,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 486494,
+            "length": 486624,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "31f4675bab74d7927080369bd5da30e01e798e0276fe764a4548e0952557e54f",
+            "contentSha256": "5e8e67b90f86f7c112373d7c6a1fed5bfa28790b9afe8a91e74c330d29236809",
             "binarySource": null
           },
           {
@@ -6136,9 +6136,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 486494,
+            "length": 486624,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "31f4675bab74d7927080369bd5da30e01e798e0276fe764a4548e0952557e54f",
+            "contentSha256": "5e8e67b90f86f7c112373d7c6a1fed5bfa28790b9afe8a91e74c330d29236809",
             "binarySource": null
           },
           {
@@ -7235,9 +7235,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.Gcad.xml",
-            "length": 459860,
+            "length": 459990,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "24356b6e5700db9f4ed57cb94ba54a43b30c48a37790c51893e39022f877c7d1",
+            "contentSha256": "047e79b45bd2b491fb8b43bb614e66c92bfe03a27b9799d607895bdddb0298fe",
             "binarySource": null
           },
           {

--- a/Build/CADSharedCompatibilityBaseline.json
+++ b/Build/CADSharedCompatibilityBaseline.json
@@ -103,7 +103,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2305,
+        "publicApiRecordCount": 2321,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -726,6 +726,11 @@
             "contractSha256": "dcc41ddcb6149ae4a3d4daff0b2007faee124c437633af1c6382862b85c3a4db"
           },
           {
+            "type": "Fs.Fox.Cad.PointGridIndex",
+            "recordCount": 16,
+            "contractSha256": "abdb670a86cc02dda5649762e6c49862a536c6d48fb98775f3593fe18274e75b"
+          },
+          {
             "type": "Fs.Fox.Cad.PointOnRegionType",
             "recordCount": 6,
             "contractSha256": "4e9c7e1e10993792aabb0446c0ed8db277a92b7235f93eec63c4a0f47c70598a"
@@ -1004,9 +1009,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.AutoCad.xml",
-            "length": 496065,
+            "length": 501914,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "9461882745dedbe7016b924690be883406f565c2a625e158b42be430d2899e4b",
+            "contentSha256": "a335b72d93b05079bd4f136bde6c64840dd31c281fe558b16a34496d3d51cb83",
             "binarySource": null
           },
           {
@@ -1212,7 +1217,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2303,
+        "publicApiRecordCount": 2319,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArrayEx",
@@ -1830,6 +1835,11 @@
             "contractSha256": "230d7251a6cd2ce982cf485d63d333e82adc382250d79ef96a72da19ae56f068"
           },
           {
+            "type": "Fs.Fox.Cad.PointGridIndex",
+            "recordCount": 16,
+            "contractSha256": "3e85db78ce222e86bf120744e3e1260cec6c9db313fafd6e344768062e41fd1a"
+          },
+          {
             "type": "Fs.Fox.Cad.PointOnRegionType",
             "recordCount": 6,
             "contractSha256": "4e9c7e1e10993792aabb0446c0ed8db277a92b7235f93eec63c4a0f47c70598a"
@@ -2122,9 +2132,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.AutoCad.xml",
-            "length": 460341,
+            "length": 466190,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "5bb03f051842bf76f8ff2c4de829ec3afd37892d88af374b9de1e07703634939",
+            "contentSha256": "be5071f83c016d92c981fc29873a4bec9dcde5230c32908cba2ec555ac88b6f8",
             "binarySource": null
           },
           {
@@ -2246,7 +2256,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2282,
+        "publicApiRecordCount": 2298,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -2859,6 +2869,11 @@
             "contractSha256": "09c2fc5cef4edc22b2c0a8697d360f57f24f5a0609b09d6276fe8ad92e1ad68c"
           },
           {
+            "type": "Fs.Fox.Cad.PointGridIndex",
+            "recordCount": 16,
+            "contractSha256": "da8ca6094bd23590682e7997d177f0c353a591c72171c9012d935e2a881f0e72"
+          },
+          {
             "type": "Fs.Fox.Cad.PointOnRegionType",
             "recordCount": 6,
             "contractSha256": "4e9c7e1e10993792aabb0446c0ed8db277a92b7235f93eec63c4a0f47c70598a"
@@ -3123,9 +3138,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 486947,
+            "length": 492772,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "0a8895a513d432ecd02f44b190b9af6cab32ae20e79b8c1b21255ec21a6c53b2",
+            "contentSha256": "4e6dfc9a363e13bbddf8eb55c22dece3796d5d2efaccb2e715ed8fed5e2f23d3",
             "binarySource": null
           },
           {
@@ -3247,7 +3262,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2285,
+        "publicApiRecordCount": 2301,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -3860,6 +3875,11 @@
             "contractSha256": "09c2fc5cef4edc22b2c0a8697d360f57f24f5a0609b09d6276fe8ad92e1ad68c"
           },
           {
+            "type": "Fs.Fox.Cad.PointGridIndex",
+            "recordCount": 16,
+            "contractSha256": "da8ca6094bd23590682e7997d177f0c353a591c72171c9012d935e2a881f0e72"
+          },
+          {
             "type": "Fs.Fox.Cad.PointOnRegionType",
             "recordCount": 6,
             "contractSha256": "4e9c7e1e10993792aabb0446c0ed8db277a92b7235f93eec63c4a0f47c70598a"
@@ -4124,9 +4144,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 488336,
+            "length": 494161,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "9f732de88936fbeb1bb2ab35a07d612a49b4eadd2d31f70856116798ca14b14a",
+            "contentSha256": "4fe434615e3c66f09be0a751d3855adeff456cc5835d0a5ec3b9dfb7d900167c",
             "binarySource": null
           },
           {
@@ -4248,7 +4268,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2269,
+        "publicApiRecordCount": 2285,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -4849,6 +4869,11 @@
             "type": "Fs.Fox.Cad.PointEx",
             "recordCount": 24,
             "contractSha256": "75646268c6496a2dd5a4967e254ea0a9da100d2ea297f0fe0a3e7685ed584f3c"
+          },
+          {
+            "type": "Fs.Fox.Cad.PointGridIndex",
+            "recordCount": 16,
+            "contractSha256": "3aee8a41291f7cefe8bc8f4ade30c5f14fe435aaae57beba5f30db11a8d4fabc"
           },
           {
             "type": "Fs.Fox.Cad.PointOnRegionType",
@@ -5115,9 +5140,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 480705,
+            "length": 486494,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "abe116c62e5b5f01291e209db42efc483580f1b8f1596d45e00274cc36f3d715",
+            "contentSha256": "31f4675bab74d7927080369bd5da30e01e798e0276fe764a4548e0952557e54f",
             "binarySource": null
           },
           {
@@ -5239,7 +5264,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2269,
+        "publicApiRecordCount": 2285,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArgumentNullEx",
@@ -5842,6 +5867,11 @@
             "contractSha256": "75646268c6496a2dd5a4967e254ea0a9da100d2ea297f0fe0a3e7685ed584f3c"
           },
           {
+            "type": "Fs.Fox.Cad.PointGridIndex",
+            "recordCount": 16,
+            "contractSha256": "3aee8a41291f7cefe8bc8f4ade30c5f14fe435aaae57beba5f30db11a8d4fabc"
+          },
+          {
             "type": "Fs.Fox.Cad.PointOnRegionType",
             "recordCount": 6,
             "contractSha256": "4e9c7e1e10993792aabb0446c0ed8db277a92b7235f93eec63c4a0f47c70598a"
@@ -6106,9 +6136,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 480705,
+            "length": 486494,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "abe116c62e5b5f01291e209db42efc483580f1b8f1596d45e00274cc36f3d715",
+            "contentSha256": "31f4675bab74d7927080369bd5da30e01e798e0276fe764a4548e0952557e54f",
             "binarySource": null
           },
           {
@@ -6314,7 +6344,7 @@
             "flags": 0
           }
         ],
-        "publicApiRecordCount": 2292,
+        "publicApiRecordCount": 2308,
         "publicApi": [
           {
             "type": "Fs.Fox.Basal.ArrayEx",
@@ -6922,6 +6952,11 @@
             "contractSha256": "42e375a21d084aa3234fe082a46821b8c0048244cc5a18137545c0da548b0f6c"
           },
           {
+            "type": "Fs.Fox.Cad.PointGridIndex",
+            "recordCount": 16,
+            "contractSha256": "93aef070ce5b16001c223c9fe81df881b4f87c84cef424d9bcc3a087ffaae4bf"
+          },
+          {
             "type": "Fs.Fox.Cad.PointOnRegionType",
             "recordCount": 6,
             "contractSha256": "4e9c7e1e10993792aabb0446c0ed8db277a92b7235f93eec63c4a0f47c70598a"
@@ -7200,9 +7235,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.Gcad.xml",
-            "length": 454035,
+            "length": 459860,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "3b89a540bf149aa9b5dddfb7b4fd46738154ea0857139bbffc212c5baa116910",
+            "contentSha256": "24356b6e5700db9f4ed57cb94ba54a43b30c48a37790c51893e39022f877c7d1",
             "binarySource": null
           },
           {

--- a/Build/CADSharedCompatibilityBaseline.json
+++ b/Build/CADSharedCompatibilityBaseline.json
@@ -1009,9 +1009,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.AutoCad.xml",
-            "length": 502192,
+            "length": 502609,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "c10a3837a7ca7f726a95330bb0accf0bc7f5a957018ef95c5172b8b16928a160",
+            "contentSha256": "d9a7315df6896c88f65a05303140933208d6c07660d7e653c9cf5eeeb2ae03c1",
             "binarySource": null
           },
           {
@@ -2132,9 +2132,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.AutoCad.xml",
-            "length": 466468,
+            "length": 466885,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "d2b9a2e0164b44031d9f877f48d221b8c1cd4cd2e0fab5592fb3cf5dab6ab922",
+            "contentSha256": "67c2ae5c7ee10ea3469f0bc775cfe61cf13c65948583772a565f5f5373ec8607",
             "binarySource": null
           },
           {
@@ -3138,9 +3138,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 493042,
+            "length": 493451,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "b72ffff4d9e4a2a7dec6284777a43c333da9a37d2baefe9f5b0930c307998bfd",
+            "contentSha256": "f1f735f1e74a954b2c760f685cef89c207085960c8ae07ac65a6b0a6a8302b5f",
             "binarySource": null
           },
           {
@@ -4144,9 +4144,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 494431,
+            "length": 494840,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "0275723978fb4fe06743fd8640c0347fee13c0554e51aa4bce3162bbcee82598",
+            "contentSha256": "2c6c4655d4917f77530da3627b7829de71ddac38e0dd6b3d1ca2812effd68c03",
             "binarySource": null
           },
           {
@@ -5140,9 +5140,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 486752,
+            "length": 487149,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "a0c005c68c80b1de2fca08564aa43da9cd1b9e63325efee9105571730193e017",
+            "contentSha256": "77b40bc5e1aeb4635e2644eeaf2028eb008e35daea2d59abc79ba1d484204b2f",
             "binarySource": null
           },
           {
@@ -6136,9 +6136,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 486752,
+            "length": 487149,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "a0c005c68c80b1de2fca08564aa43da9cd1b9e63325efee9105571730193e017",
+            "contentSha256": "77b40bc5e1aeb4635e2644eeaf2028eb008e35daea2d59abc79ba1d484204b2f",
             "binarySource": null
           },
           {
@@ -7235,9 +7235,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.Gcad.xml",
-            "length": 460130,
+            "length": 460539,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "d8a2f25ef97b203abdf39e65770f4983411a94b09b7e7d28fa251924ec5180ac",
+            "contentSha256": "27e35492ae86fb0df38226753be9b6d6ff1a058a35b3f842ff78fb89a58fd768",
             "binarySource": null
           },
           {

--- a/Build/CADSharedCompatibilityBaseline.json
+++ b/Build/CADSharedCompatibilityBaseline.json
@@ -1009,9 +1009,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.AutoCad.xml",
-            "length": 502609,
+            "length": 502862,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "d9a7315df6896c88f65a05303140933208d6c07660d7e653c9cf5eeeb2ae03c1",
+            "contentSha256": "9e83a347a3614cf07f110e165a131b0150788e3f26c40d894d45b2c1efbacf7b",
             "binarySource": null
           },
           {
@@ -2132,9 +2132,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.AutoCad.xml",
-            "length": 466885,
+            "length": 467138,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "67c2ae5c7ee10ea3469f0bc775cfe61cf13c65948583772a565f5f5373ec8607",
+            "contentSha256": "925fedc695e2cccaf775e60e4cf24b9519b5b8b6149aa7e52400d69bb8f60e40",
             "binarySource": null
           },
           {
@@ -3138,9 +3138,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 493451,
+            "length": 493696,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "f1f735f1e74a954b2c760f685cef89c207085960c8ae07ac65a6b0a6a8302b5f",
+            "contentSha256": "c60b65dc5a0cebb01ac68a752aaf4207574ff30d9a923ad8c84ecc718a33ca22",
             "binarySource": null
           },
           {
@@ -4144,9 +4144,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 494840,
+            "length": 495085,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "2c6c4655d4917f77530da3627b7829de71ddac38e0dd6b3d1ca2812effd68c03",
+            "contentSha256": "61648d02b254124bb3a47cef2179880a5b4fe110f430f8ab94d5e67a73f68f7e",
             "binarySource": null
           },
           {
@@ -5140,9 +5140,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 487149,
+            "length": 487382,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "77b40bc5e1aeb4635e2644eeaf2028eb008e35daea2d59abc79ba1d484204b2f",
+            "contentSha256": "35b2eb2aa0087d6ac70ff6e860d78436918dcadd9c3e2cb49af59c37f3d61b1b",
             "binarySource": null
           },
           {
@@ -6136,9 +6136,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 487149,
+            "length": 487382,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "77b40bc5e1aeb4635e2644eeaf2028eb008e35daea2d59abc79ba1d484204b2f",
+            "contentSha256": "35b2eb2aa0087d6ac70ff6e860d78436918dcadd9c3e2cb49af59c37f3d61b1b",
             "binarySource": null
           },
           {
@@ -7235,9 +7235,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.Gcad.xml",
-            "length": 460539,
+            "length": 460784,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "27e35492ae86fb0df38226753be9b6d6ff1a058a35b3f842ff78fb89a58fd768",
+            "contentSha256": "96f98c2791934509aef48dd4ee1fcf367812b26507172ff4a5067606d41b78c7",
             "binarySource": null
           },
           {

--- a/Build/CADSharedCompatibilityBaseline.json
+++ b/Build/CADSharedCompatibilityBaseline.json
@@ -1009,9 +1009,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.AutoCad.xml",
-            "length": 502044,
+            "length": 502192,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "4c060325dc24372f10078fb718a45c34055559c40176d9e50fe0003f0c016297",
+            "contentSha256": "c10a3837a7ca7f726a95330bb0accf0bc7f5a957018ef95c5172b8b16928a160",
             "binarySource": null
           },
           {
@@ -2132,9 +2132,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.AutoCad.xml",
-            "length": 466320,
+            "length": 466468,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "f2d4b789d22b30fa3382c1abdf5286a11ea474748195f0803d95be6d8004e35a",
+            "contentSha256": "d2b9a2e0164b44031d9f877f48d221b8c1cd4cd2e0fab5592fb3cf5dab6ab922",
             "binarySource": null
           },
           {
@@ -3138,9 +3138,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 492902,
+            "length": 493042,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "fb7f281efda77f31e22064e4f179a96a8f1be2215da65fe4226995d56f3443d8",
+            "contentSha256": "b72ffff4d9e4a2a7dec6284777a43c333da9a37d2baefe9f5b0930c307998bfd",
             "binarySource": null
           },
           {
@@ -4144,9 +4144,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.ZwCad.xml",
-            "length": 494291,
+            "length": 494431,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "f53358e53cfc3de95eae9b7096102b88cb3b59f7d84ddf4159f41f3005ab955b",
+            "contentSha256": "0275723978fb4fe06743fd8640c0347fee13c0554e51aa4bce3162bbcee82598",
             "binarySource": null
           },
           {
@@ -5140,9 +5140,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 486624,
+            "length": 486752,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "5e8e67b90f86f7c112373d7c6a1fed5bfa28790b9afe8a91e74c330d29236809",
+            "contentSha256": "a0c005c68c80b1de2fca08564aa43da9cd1b9e63325efee9105571730193e017",
             "binarySource": null
           },
           {
@@ -6136,9 +6136,9 @@
           },
           {
             "path": "lib/net48/Fs.Fox.Gcad.xml",
-            "length": 486624,
+            "length": 486752,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "5e8e67b90f86f7c112373d7c6a1fed5bfa28790b9afe8a91e74c330d29236809",
+            "contentSha256": "a0c005c68c80b1de2fca08564aa43da9cd1b9e63325efee9105571730193e017",
             "binarySource": null
           },
           {
@@ -7235,9 +7235,9 @@
           },
           {
             "path": "lib/net8.0-windows7.0/Fs.Fox.Gcad.xml",
-            "length": 459990,
+            "length": 460130,
             "hashKind": "canonical-xml-v1",
-            "contentSha256": "047e79b45bd2b491fb8b43bb614e66c92bfe03a27b9799d607895bdddb0298fe",
+            "contentSha256": "d8a2f25ef97b203abdf39e65770f4983411a94b09b7e7d28fa251924ec5180ac",
             "binarySource": null
           },
           {

--- a/Build/CADSharedModuleBaseline.json
+++ b/Build/CADSharedModuleBaseline.json
@@ -1,12 +1,12 @@
 {
   "schemaVersion": 1,
   "normalizedSourceHash": "sha256-utf8-lf",
-  "expectedCompileCount": 141,
+  "expectedCompileCount": 142,
   "moduleCounts": {
     "Foundation": 11,
     "Platform.Windows": 15,
     "Cad.Interop": 3,
-    "Cad.Geometry": 16,
+    "Cad.Geometry": 17,
     "Cad.Database": 43,
     "Cad.Editor": 23,
     "Cad.Application": 8,
@@ -1308,6 +1308,14 @@
       "boundaryDebt": [],
       "boundaryFindings": [],
       "sourceSha256": "bedbc78b4b0b49654969ffc71c245c59a243beb2979ff3cf3c35f2968e785e93"
+    },
+    {
+      "order": "0970",
+      "fileName": "PointGridIndex.cs",
+      "module": "Cad.Geometry",
+      "boundaryDebt": [],
+      "boundaryFindings": [],
+      "sourceSha256": "57e7c25956d95be9201348287a362910d8fe3d2505a18e089bd56d8be52ff5a0"
     }
   ]
 }

--- a/Build/CADSharedModuleBaseline.json
+++ b/Build/CADSharedModuleBaseline.json
@@ -493,7 +493,7 @@
       "module": "Cad.Database",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "22899506a843bbd306f723681602559cc77e1eacee46db8beaa851fa6a384969"
+      "sourceSha256": "7ff0e743a6fbc8f7d7dd233e8fd8a49b586a681be34441c3d339aa03eaae5f07"
     },
     {
       "order": "0360",
@@ -540,7 +540,7 @@
       "module": "Cad.Database",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "73b7ebc51401133ae1bb75dddca60ea905bdb33450e500454e288caec6d29c32"
+      "sourceSha256": "4b4bb2512f86772953b7ae590d9276bfe0bf2a27de7b3eb11e400920b5e27a49"
     },
     {
       "order": "0410",
@@ -673,7 +673,7 @@
       "module": "Cad.Geometry",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "ec00a879c45af65a2b010e6807b0d546dea087764c4784dac5ac7fb7d4fd65ad"
+      "sourceSha256": "ef468a6537dd5769ab8db3ef5b15030ee4b6c172d45b3660269508e6bbe713c3"
     },
     {
       "order": "0480",

--- a/Build/CADSharedModuleBaseline.json
+++ b/Build/CADSharedModuleBaseline.json
@@ -493,7 +493,7 @@
       "module": "Cad.Database",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "f6a0762cbf405d2d3c1d92c5b7c8b444be112c54c41f77d5c312b7b841fbb352"
+      "sourceSha256": "29b5d5fd5339d2396f8cbec32b6f58d25532c0bc89562ae11dbe895a3a789329"
     },
     {
       "order": "0360",

--- a/Build/CADSharedModuleBaseline.json
+++ b/Build/CADSharedModuleBaseline.json
@@ -540,7 +540,7 @@
       "module": "Cad.Database",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "5d0273c6f7644cf3d89088fc96d9ae7cd02dc91ef0f21037afe6937d9b453884"
+      "sourceSha256": "21323df72cb263ebb2179e9262510547ca20ed529c7eb943ee4d03d59f654202"
     },
     {
       "order": "0410",

--- a/Build/CADSharedModuleBaseline.json
+++ b/Build/CADSharedModuleBaseline.json
@@ -493,7 +493,7 @@
       "module": "Cad.Database",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "29b5d5fd5339d2396f8cbec32b6f58d25532c0bc89562ae11dbe895a3a789329"
+      "sourceSha256": "c94db1ad0694fb400e1086aa66c377c8a1a7c0de0ab733f93f0e58d4000d7c64"
     },
     {
       "order": "0360",

--- a/Build/CADSharedModuleBaseline.json
+++ b/Build/CADSharedModuleBaseline.json
@@ -493,7 +493,7 @@
       "module": "Cad.Database",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "6d65af7c688c92312f4abe828511221ddbe0cf95dfa16110aa7f3694f36d20d2"
+      "sourceSha256": "f6a0762cbf405d2d3c1d92c5b7c8b444be112c54c41f77d5c312b7b841fbb352"
     },
     {
       "order": "0360",

--- a/Build/CADSharedModuleBaseline.json
+++ b/Build/CADSharedModuleBaseline.json
@@ -493,7 +493,7 @@
       "module": "Cad.Database",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "7ff0e743a6fbc8f7d7dd233e8fd8a49b586a681be34441c3d339aa03eaae5f07"
+      "sourceSha256": "6d65af7c688c92312f4abe828511221ddbe0cf95dfa16110aa7f3694f36d20d2"
     },
     {
       "order": "0360",
@@ -1315,7 +1315,7 @@
       "module": "Cad.Geometry",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "57e7c25956d95be9201348287a362910d8fe3d2505a18e089bd56d8be52ff5a0"
+      "sourceSha256": "4972a5290c1a2dc46c5fe34526b18d33591a9262232857d56afa31cf2f58cb0e"
     }
   ]
 }

--- a/Build/CADSharedModuleBaseline.json
+++ b/Build/CADSharedModuleBaseline.json
@@ -540,7 +540,7 @@
       "module": "Cad.Database",
       "boundaryDebt": [],
       "boundaryFindings": [],
-      "sourceSha256": "4b4bb2512f86772953b7ae590d9276bfe0bf2a27de7b3eb11e400920b5e27a49"
+      "sourceSha256": "5d0273c6f7644cf3d89088fc96d9ae7cd02dc91ef0f21037afe6937d9b453884"
     },
     {
       "order": "0410",

--- a/Build/Verify-CADSharedModuleMap.ps1
+++ b/Build/Verify-CADSharedModuleMap.ps1
@@ -28,12 +28,12 @@ $BaselinePath = [IO.Path]::GetFullPath($BaselinePath)
 $sourceRoot = [IO.Path]::GetFullPath((Split-Path -Parent $ProjectItemsPath))
 $sourceRootPrefix = $sourceRoot.TrimEnd([IO.Path]::DirectorySeparatorChar) + [IO.Path]::DirectorySeparatorChar
 
-$expectedCompileCount = 141
+$expectedCompileCount = 142
 $expectedModuleCounts = [ordered]@{
     'Foundation'       = 11
     'Platform.Windows' = 15
     'Cad.Interop'      = 3
-    'Cad.Geometry'     = 16
+    'Cad.Geometry'     = 17
     'Cad.Database'     = 43
     'Cad.Editor'       = 23
     'Cad.Application'  = 8

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@
 | 状态 | 含义 | 使用规则 |
 | --- | --- | --- |
 | `current` | 当前有效的事实、约定或已接受决策 | 可作为维护依据，仍需核对实时实现。 |
+| `active` | 已批准并正在实施的限时计划 | 只约束声明的分支和范围；完成或取消后转为 `historical`。 |
 | `draft` | 尚未完成或尚未复核 | 不作为覆盖范围或行为清单。 |
 | `proposal` | 已记录但尚未全部批准或实施 | 只能作为讨论输入，不能推断现状。 |
 | `superseded` | 已由另一份文档取代 | 只追溯决策背景，实施时转到取代文档。 |
@@ -57,7 +58,7 @@ front matter schema 和自动校验尚未落地。在迁移完成前，本页状
 | `guide.building` | `current` | [构建与项目结构](../编译说明.md) | maintainer | 正式项目、工具链、条件编译、输出和验证边界。 |
 | `guide.host-acceptance` | `current` | [CAD 真实宿主验收 Runner](../tools/HostAcceptance/README.md) | maintainer | 真实 CAD 验收的目标矩阵、证据契约、安全边界、当前限制和执行入口。 |
 | `reference.zwcad-compatibility` | `current` | [ZWCAD 版本兼容性与迁移说明](ZWCAD-version-compatibility.md) | user, maintainer | ZRXSDK 代际、当前发布策略、Build-only 边界和未验证状态。 |
-| `reference.gstarcad-support-design` | `current` | [GStarCAD 支持扩展设计](superpowers/specs/2026-08-03-gstarcad-support-design.md) | maintainer | 浩辰 CAD 2022/2023/2026 三版本支持架构。 |
+| `reference.gstarcad-support-design` | `current` | [GStarCAD 支持边界](关于IFoxCAD的架构说明.md#gstarcad浩辰cad) | maintainer | 浩辰 CAD 2022/2023/2026 的共享源码和条件编译边界。 |
 | `decision.autocad-2027-net8` | `current` | [AutoCAD 2027 .NET 8 兼容策略](AC_2027-net8-compatibility-decision.md) | maintainer | 预备项目当前使用 .NET 8 的原因、限制和回迁条件。 |
 | `concept.upstream-relationship` | `current` | [上游 IFoxCAD 与 Fs.Fox.CAD 的关系](<../IFoxCAD 说明.md>) | user, maintainer | 项目来源、独立维护边界和问题归属。 |
 | `guide.repository-maintenance` | `current` | [Fs.Fox.CAD 维护说明](../Fs分支说明.md) | maintainer | 命名、远程仓库和上游贡献边界。 |
@@ -70,7 +71,7 @@ front matter schema 和自动校验尚未落地。在迁移完成前，本页状
 
 | 状态 | 稳定 ID | 文档 | 使用边界 |
 | --- | --- | --- | --- |
-| `proposal` | `plan.zfgk-cad-migration` | [Fs.Zfgk.CAD 有价值能力迁移计划](zfgk-cad-migration-plan.md) | 从固定来源快照筛选通用能力；授权、多宿主、对象所有权和现有 API 去重门槛未满足前，不直接复制来源实现。 |
+| `active` | `plan.zfgk-cad-migration` | [Fs.Zfgk.CAD 有价值能力迁移计划](zfgk-cad-migration-plan.md) | Issue #110 的长期集成计划；逐项吸收有增量价值的能力，不以来源或当前调用情况作为价值门槛，仍须满足多宿主、对象所有权和现有 API 去重要求。 |
 | `proposal` | `contract.dbtrans-lifecycle` | [DBTrans 生命周期与释放契约](dbtrans-lifecycle-contract.md) | 同时记录 Confirmed、Decision 与 Not run；不能把后续决定表述为已实施。 |
 | `proposal` | `proposal.edgeone-site-repository` | [EdgeOne Makers 站点仓库架构评估](edgeone-site-repository-evaluation.md) | Issue #48 的实施提案；展示仓库与精确来源链路已创建，最终框架、GitHub App、EdgeOne 和云资源仍未完成。 |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,6 +69,7 @@ front matter schema 和自动校验尚未落地。在迁移完成前，本页状
 
 | 状态 | 稳定 ID | 文档 | 使用边界 |
 | --- | --- | --- | --- |
+| `proposal` | `plan.zfgk-cad-migration` | [Fs.Zfgk.CAD 有价值能力迁移计划](zfgk-cad-migration-plan.md) | 从固定来源快照筛选通用能力；授权、多宿主、对象所有权和现有 API 去重门槛未满足前，不直接复制来源实现。 |
 | `proposal` | `contract.dbtrans-lifecycle` | [DBTrans 生命周期与释放契约](dbtrans-lifecycle-contract.md) | 同时记录 Confirmed、Decision 与 Not run；不能把后续决定表述为已实施。 |
 | `proposal` | `proposal.edgeone-site-repository` | [EdgeOne Makers 站点仓库架构评估](edgeone-site-repository-evaluation.md) | Issue #48 的实施提案；展示仓库与精确来源链路已创建，最终框架、GitHub App、EdgeOne 和云资源仍未完成。 |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,7 +71,6 @@ front matter schema 和自动校验尚未落地。在迁移完成前，本页状
 
 | 状态 | 稳定 ID | 文档 | 使用边界 |
 | --- | --- | --- | --- |
-| `active` | `plan.zfgk-cad-migration` | [Fs.Zfgk.CAD 有价值能力迁移计划](zfgk-cad-migration-plan.md) | Issue #110 的长期集成计划；逐项吸收有增量价值的能力，不以来源或当前调用情况作为价值门槛，仍须满足多宿主、对象所有权和现有 API 去重要求。 |
 | `proposal` | `contract.dbtrans-lifecycle` | [DBTrans 生命周期与释放契约](dbtrans-lifecycle-contract.md) | 同时记录 Confirmed、Decision 与 Not run；不能把后续决定表述为已实施。 |
 | `proposal` | `proposal.edgeone-site-repository` | [EdgeOne Makers 站点仓库架构评估](edgeone-site-repository-evaluation.md) | Issue #48 的实施提案；展示仓库与精确来源链路已创建，最终框架、GitHub App、EdgeOne 和云资源仍未完成。 |
 
@@ -79,6 +78,7 @@ front matter schema 和自动校验尚未落地。在迁移完成前，本页状
 
 | 状态 | 稳定 ID | 文档 | 当前入口 |
 | --- | --- | --- | --- |
+| `historical` | `plan.zfgk-cad-migration` | [Fs.Zfgk.CAD 有价值能力迁移计划](zfgk-cad-migration-plan.md) | Issue #110 / PR #116 已结束来源迁移；现行行为以 `CurveEx`、`PointEx`、`PolylineEx`、`PointGridIndex` 的源码和 XML 注释为准。长期分支是否进入 `main` 另行评估。 |
 | `historical` | `plan.cad-modules` | [单程序集逻辑模块化执行计划](logical-modularization-plan.md) | 现行入口为[架构说明](关于IFoxCAD的架构说明.md)、根 [`AGENTS.md`](../AGENTS.md)、项目清单和模块基线；本文只追溯 Phase A 快照和实施过程。 |
 | `historical` | `history.upstream-v0.9` | [IFoxCAD v0.9 上游重要变更评估](ifoxcad-v0.9-upstream-merge-analysis.md) | Issue #26 已完成；后续需求重新核对实时上游和当前源码。 |
 

--- a/docs/zfgk-cad-migration-plan.md
+++ b/docs/zfgk-cad-migration-plan.md
@@ -95,7 +95,7 @@
 | 能力 | 目标位置 | 建议承载类型 | 说明 |
 | --- | --- | --- | --- |
 | 点、向量、坐标和普通几何 | `Cad/Geometry` | 现有 `PointEx`、`VectorEx`、`GeometryEx` | 只补确实缺失且可测试的方法。 |
-| 点邻域/去重网格 | `Cad/Geometry/SpatialIndex/Grid` | `PointGridIndex` 或经评审后的同义名 | 有状态索引用名词类，不叫 `DynamicPointSpatialIndexUtil`。优先稀疏桶，避免旧实现的二维巨型数组。 |
+| 点邻域/去重网格 | `Cad/Geometry/SpatialIndex/Grid` | `PointGridIndex` | 有状态索引用名词类，不叫 `DynamicPointSpatialIndexUtil`。使用无固定 extent 的稀疏桶，避免旧实现的二维巨型数组。 |
 | 曲线查询与拆分 | `Cad/Database/Entities/Curves` | 现有 `CurveEx`，必要时按能力拆文件 | 返回新曲线时必须写明释放责任。 |
 | 折线查询、采样和编辑 | `Cad/Database/Entities/Curves/Polylines` | 现有 `PolylineEx` | 只读查询与原位修改分批，不在一个 PR 混合。 |
 | 面域边界 | `Cad/Database/Entities` | 现有 `RegionEx` | 与 Issue #103/#107 记录的 `ToCurves()` 所有权风险一并设计。 |
@@ -173,7 +173,7 @@
 | `ObjectARX/Others/FormatUtil.cs` | 点/向量文本序列化可能有价值，但旧实现缺少文化区、版本和失败契约。 | 低优先条件候选；先定义 invariant/显示格式和 `TryParse`。 |
 | `ObjectARX/Others/ListUtil.cs` | 唯一有效方法为交换元素，其余为大段历史注释。 | 不迁移。 |
 | `ObjectARX/Others/ViewUtil.cs` | 已由 `EditorEx.Zoom*` 覆盖。 | 复用现有实现。 |
-| `ObjectARX/SpacialIndex/DynamicPointSpatialIndex.cs` | 点去重、邻域、最近点和范围查询有明确通用价值。旧实现存在无效状态、密集二维数组、UI 弹窗和边界错误。 | 高优先候选；重写为稀疏网格索引并补确定性测试。 |
+| `ObjectARX/SpacialIndex/DynamicPointSpatialIndex.cs` | 点去重、邻域、最近点和范围查询有明确通用价值。旧实现存在无效状态、密集二维数组、UI 弹窗和边界错误。 | 已吸收为 `PointGridIndex`：保留稳定索引、近似去重、范围和最近点能力；不保留固定 extent、公开网格行列和两阶段初始化。 |
 | `ObjectARX/SpacialIndex/EntitySpatialIndex.cs` | 实体范围查询有价值，但目标已有 `QuadTree`；旧实现把事务和网格构建耦合。 | 不迁移该类型；仅把可证明的批量建索引需求补到现有空间索引体系。 |
 | `Other/NumberUtil.cs` | 只拆尾部数字；无数字时抛异常但始终声明返回 true。 | 不迁移；真实需求使用明确 `Try*` 契约。 |
 | `Others/ApplicationUtil.cs` | 支持路径读取与现有 `Env` 边界重合。 | 复用现有实现。 |
@@ -243,6 +243,23 @@ Phase 0 的清单和结构决策已经完成。后续每个代码批次必须回
 - XY 容差、Z 容差、格长和边界闭合规则显式；
 - 不依赖 WinForms，不在失败时弹窗；
 - 与 `QuadTree` 做职责对照和基准，不能建立两套等价实体索引。
+
+Phase 2 的目标 API 与边界如下：
+
+| API/成员 | 契约 |
+| --- | --- |
+| 构造函数、`CellSize` | 构造即有效；网格边长必须是有限正数，不设置固定 extent。 |
+| `Add`、索引器、`Points`、`Count` | 无条件添加并返回稳定整数索引；点视图只读，`Clear` 前索引不变化。 |
+| `TryAdd`、`TryFind` | XY 使用欧氏距离闭区间，Z 使用独立闭区间容差；多个候选按三维距离、再按添加顺序决定。 |
+| `QueryIndices` | 查询 XY 矩形闭区间，结果按添加顺序稳定返回，不隐含 Z 过滤。 |
+| `TryGetNearest` | 在有限最大三维距离内查询，并额外应用 Z 差闭区间过滤；失败结果为索引 -1、距离正无穷。 |
+| `Clear` | 同时释放点和稀疏桶引用；之后索引重新从零开始。 |
+
+旧实现的 `Create`、`GetBlockOfPoint`、`GetNeighborPoints`、`GetExtent` 和 `IsIn` 不成为公共 API：无界稀疏索引不需要固定范围，网格桶只是实现细节。`Test_PointGridIndex` 覆盖跨桶去重、Z 分层、负坐标、闭区间范围、最近点并列、退化参数和清空重用；当前仅参加测试程序集编译，CAD 宿主状态为 `Not run`。
+
+Phase 2 的七目标公共契约基线均只新增 `PointGridIndex` 的 16 条记录。以 `migration/zfgk-cad@587e77f` 为基线重新构建并比较 AC_2019、AC_2025、ZW_2022、ZW_2025 实际程序集后，每个目标都只新增一个 TypeDef，所有既有 TypeDef 的相对顺序保持不变；由于 Roslyn 先发射 `Fs.Fox.Cad` 根类型再发射 `Fs.Fox.Cad.Assoc`，新类型位于现有根类型末尾并使其后的 token 顺延一位，这是新增公共根类型的已审查结果，不是既有类型重排。
+
+AC_2019、AC_2025、ZW_2022、ZW_2025、GC_2022、GC_2023、GC_2026 的 Release 库和测试程序集均已通过直接构建，模块期望更新为 `142` 个编译项、`Cad.Geometry = 17`；真实 CAD 宿主状态仍为 `Not run`。
 
 ### Phase 3：曲线/折线修改与 Region
 

--- a/docs/zfgk-cad-migration-plan.md
+++ b/docs/zfgk-cad-migration-plan.md
@@ -226,13 +226,15 @@ Phase 0 的清单和结构决策已经完成。后续每个代码批次必须回
 | --- | --- | --- |
 | `CurveEx` | `GetPointAtDistanceFraction` | 按总长闭区间 `[0, 1]` 取点；修正旧实现忽略输入比例、固定取 `0.5` 的问题，并拒绝无限长度域。 |
 | `CurveEx` | `GetMidpointChordDeviation` | 明确按参数中点计算三维弦偏差，不把结果表述为区间最大误差。 |
-| `CurveEx` | `GetMidpointChordDeviationByDistance` | 明确按沿曲线距离中点计算，避免把距离端点转参数后误用参数中点；`Ray`、`Xline` 及其他没有有限且有序参数或距离范围的曲线明确失败。 |
+| `CurveEx` | `GetMidpointChordDeviationByDistance` | 明确按沿曲线距离中点计算，避免把距离端点转参数后误用参数中点；`Ray` 以基点为距离原点并支持有限非负区间，`Xline` 因没有曲线起点而明确失败。 |
 | `PolylineEx` | `GetVertexData` | 一次取得顶点、bulge、起宽和终宽的独立托管快照，不暴露 `ref` 集合。 |
 | `PolylineEx` | `GetSegmentLength` | 对开放/闭合折线验证真实子段索引；直线返回线长，圆弧返回弧长。 |
 | `PointEx` | `InterpolateTo` | 使用闭区间 `[0, 1]` 的三维线性插值，非法比例抛出明确异常。 |
 | `PointEx` | `TryInterpolateAtElevation` | 只在非水平线段内存在唯一高程点时成功；修正旧实现把结果 Z 固定为 `0` 的错误，不引入隐式容差。 |
 
-批次 1 提供宿主内确定性验收命令 `Test_GeometryQuery`，覆盖直线、半圆、开放/闭合折线和高程插值边界。AC_2019、AC_2025、ZW_2022、ZW_2025、GC_2022、GC_2023、GC_2026 的 Release 库和测试程序集均已通过直接构建，模块、兼容性和 TypeDef 顺序守卫通过；这只是 Build-only 证据，命令尚未在 CAD 中执行，真实宿主状态为 `Not run`。折线按距离/弦偏差采样、点在线段左右关系和范围聚类尚未计入本批完成范围。
+ObjectARX、ZRX 和 GRX 的曲线契约均把 `Ray` 定义为起始参数 `0` 且没有终止参数，把 `Xline` 定义为没有起止参数或起止点。因此三种查询不能共用“必须具有有限总长”这一前置条件：长度比例取点明确拒绝两者；参数中点弦偏差接受有限的 `Ray`/`Xline` 参数区间，其中 `Ray` 参数不得小于 `0`；距离中点弦偏差接受从基点开始的有限非负 `Ray` 距离区间，但拒绝没有距离原点的 `Xline`。这一区分以 SDK 曲线契约为准。
+
+批次 1 提供宿主内确定性验收命令 `Test_GeometryQuery`，覆盖直线、半圆、`Ray`/`Xline` 边界、开放/闭合折线和高程插值边界。AC_2019、AC_2025、ZW_2022、ZW_2025、GC_2022、GC_2023、GC_2026 的 Release 库和测试程序集均已通过直接构建，模块、兼容性和 TypeDef 顺序守卫通过；这只是 Build-only 证据，命令尚未在 CAD 中执行，真实宿主状态为 `Not run`。折线按距离/弦偏差采样、点在线段左右关系和范围聚类尚未计入本批完成范围。
 
 ### Phase 2：点网格索引
 

--- a/docs/zfgk-cad-migration-plan.md
+++ b/docs/zfgk-cad-migration-plan.md
@@ -244,7 +244,7 @@ ObjectARX、ZRX 和 GRX 的曲线契约均把 `Ray` 定义为起始参数 `0` �
 | `PolylineEx` | `GetSamplePointsByDistance` | 每个原始子段按沿折线的最大间距独立等距细分，保留所有原始顶点；闭合折线在结果末尾重复首顶点。 |
 | `PolylineEx` | `GetSamplePointsByChordDeviation` | 直线段只保留端点；圆弧段按弓高公式细分，使每个采样子弧的弦偏差不超过给定有限正数；同样保留原始顶点和闭合点。 |
 
-两个方法均返回独立的 `Point3d` 快照，不修改输入、不访问数据库、不创建需要释放的 CAD 对象。`Test_GeometryQuery` 同步覆盖直线/圆弧混合、开放/闭合、退化折线、非零 `Normal`/`Elevation`、非法阈值和不可表示的细分数量。点在线段左右关系由现有 `GeometryEx.GetArea`/`IsClockWise` 表达，范围关系和碰撞扫描由 `Rect`/`Rect.XCollision` 表达，不再新增平行 API。
+两个方法均返回独立的 `Point3d` 快照，不修改输入、不访问数据库、不创建需要释放的 CAD 对象。为避免极小但有限的阈值同步生成海量点并阻塞 CAD，方法先计算全部子段的总点数，超过 1,000,000 时在生成任何采样点前失败。`Test_GeometryQuery` 同步覆盖直线/圆弧混合、开放/闭合、退化折线、非零 `Normal`/`Elevation`、非法阈值、不可表示的细分数量和总点数上限。点在线段左右关系由现有 `GeometryEx.GetArea`/`IsClockWise` 表达，范围关系和碰撞扫描由 `Rect`/`Rect.XCollision` 表达，不再新增平行 API。
 
 最终批次的 AC_2019、AC_2025、ZW_2022、ZW_2025、GC_2022、GC_2023、GC_2026 Release 库和测试程序集均已通过直接构建。模块守卫保持 `142 / 42 / 17`，七目标兼容性基线仅增加 `PolylineEx` 的两个公开方法及对应 XML 文档，四目标 TypeDef 顺序未变化；HostAcceptance runner 自测通过。以上仍是 Build-only 和基础设施证据，`Test_GeometryQuery` 未在 CAD 中执行，真实宿主状态为 `Not run`。
 

--- a/docs/zfgk-cad-migration-plan.md
+++ b/docs/zfgk-cad-migration-plan.md
@@ -1,7 +1,7 @@
 # Fs.Zfgk.CAD 有价值能力迁移计划
 
 > 稳定 ID：`plan.zfgk-cad-migration`<br>
-> 状态：执行中（Active）<br>
+> 状态：最终收口中（Active）<br>
 > 目标分支：`migration/zfgk-cad`<br>
 > 来源快照：`FeiSiDev/Fs.Zfgk.CAD@c38ce320c75284536c907c1046e5458da4ae0468`<br>
 > 最近 `main` 集成：`origin/main@6e6f94223be418481663833fc65386d8cf2839a4` 已由 `2e68759f710046416f4e27d2c2f87487e4160619` 合入<br>
@@ -21,13 +21,13 @@
 - 大量能力已被 `DBTrans`、`SymbolTable`、`PointEx`、`GeometryEx`、`CurveEx`、`EditorEx`、`DBDictionaryEx`、`HatchEx`、`QuadTree` 等现行实现覆盖。
 - 若干未覆盖算法仍有通用价值，但旧实现存在资源所有权、容差、异常、事务和边界条件问题，必须按目标库契约重写并验证。
 
-迁移的合理目标是“吸收能力”，不是“搬运代码”。优先级如下：
+迁移的合理目标是“吸收能力”，不是“搬运代码”。最终只吸收三组可证明的通用增量：
 
-1. 曲线、折线和面域的只读几何算法，以及明确的对象所有权契约。
-2. 面向点去重、邻域和范围查询的稀疏网格索引；它与现有四叉树互补，而不是替换四叉树。
-3. 现有块导入/属性 API 没有覆盖的 DWG 导出工作流。
-4. SHX 搜索与几何文本序列化等有明确跨产品需求的辅助能力。
-5. 图形系统预览、DWG 表格和桌面 UI 只在出现真实通用消费者并能完成宿主验证后评估。
+1. 曲线、点和折线的只读几何查询，包括距离比例取点、弦偏差、顶点数据、子段长度、插值和确定性采样；
+2. 面向点去重、邻域和范围查询的稀疏 `PointGridIndex`，与现有四叉树形成明确分工；
+3. 为以上能力配套的跨宿主编译、公共契约守卫和宿主内确定性测试命令。
+
+其余来源能力最终决定为“复用现有”或“不迁移”，不再保留后续候选。以后出现相似需求时，应从 `Fs.Fox.CAD` 的实时契约重新设计，不继续以 `Fs.Zfgk.CAD` 为迁移输入。
 
 ## 2. 不可突破的边界
 
@@ -114,9 +114,9 @@
 | `Properties/AssemblyInfo.cs` | 旧项目程序集元数据。 | 不迁移；目标项目自行生成/维护。 |
 | `Geometry/AcadPlaneUtil.cs` | 仅返回 XY 平面；厂商 API 和现有 `PlaneEx` 足以表达。 | 不迁移。 |
 | `Geometry/CoordinateUtil.cs` | UCS/WCS 转换已由 `GeometryEx`、`EditorEx` 提供；旧实现隐式取活动文档。 | 复用现有实现。 |
-| `Geometry/GePointUtil.cs` | 极坐标、中点、二维距离和方向已有等价实现；点去重、排序和折线圆角概念仍可复核。 | 部分候选；只迁移经独立测试证明的缺失算法。 |
+| `Geometry/GePointUtil.cs` | 极坐标、中点、二维距离和方向已有等价实现；其点排序和折线圆角没有形成比现有几何 API 更可靠的契约。 | 复用现有 `PointEx`、`GeometryEx` 和 `PointGridIndex`；其余不迁移。 |
 | `Geometry/GeRectangleUtil.cs` | 轴向矩形相交已由 `Rect.IntersectsWith` 覆盖。 | 复用现有实现。 |
-| `Geometry/GeTriangle.cs` | 坡度/坡向和重心有领域价值，但旧实现存在退化三角形、法向方向和重心 Z 值问题。 | 条件候选；作为新的明确几何契约重写，不复制该类型。 |
+| `Geometry/GeTriangle.cs` | 坡度/坡向偏向地形业务，旧实现还存在退化三角形、法向方向和重心 Z 值问题。 | 不迁移。 |
 | `Geometry/MathUtil.cs` | 多数函数已有 `System.Math` 等价项；采样、反函数和容差方法的边界契约不完整。 | 不迁移整类；真实需求单独设计。 |
 
 ### 6.2 ObjectARX 基础能力
@@ -124,10 +124,10 @@
 | 来源文件 | 价值与现状 | 决定 |
 | --- | --- | --- |
 | `ObjectARX/AcadDocumentUtil.cs` | 文档枚举可直接使用 `DocumentManager`；`GetOpenedDocument` 忽略文件名并返回第一个文档。 | 不迁移。 |
-| `ObjectARX/ArxOthers/DwgScaleUtil.cs` | 使用特定字典键保存“标注/信息比例”，更像产品数据协议。 | 默认不迁移；若多个产品依赖同一持久化格式，先建立独立契约。 |
-| `ObjectARX/ArxOthers/ExtentUtil.cs` | 宽高、中心、扩展已被 `Rect`、`BoundingBox9`、`PointEx` 覆盖；范围关系和相交簇合并仍有价值。 | 部分候选；基于现有范围类型重写关系/聚类，不复制事务辅助。 |
+| `ObjectARX/ArxOthers/DwgScaleUtil.cs` | 使用特定字典键保存“标注/信息比例”，属于产品持久化协议。 | 不迁移。 |
+| `ObjectARX/ArxOthers/ExtentUtil.cs` | 宽高、中心、扩展、范围关系和碰撞扫描已被 `Rect`、`BoundingBox9`、`PointEx`、`Rect.XCollision` 覆盖。 | 复用现有实现，不迁移事务辅助。 |
 | `ObjectARX/ArxOthers/GroupUtil.cs` | 已由 `DBDictionaryEx.AddGroup`/`GetGroups` 覆盖。 | 复用现有实现。 |
-| `ObjectARX/ArxOthers/GsPreviewUtil.cs` | DWG 到位图预览有价值，但直接使用 AutoCAD GraphicsSystem、设备和视图生命周期。 | 高风险条件候选；独立平台设计和真实宿主测试前不迁移。 |
+| `ObjectARX/ArxOthers/GsPreviewUtil.cs` | DWG 到位图预览直接使用 AutoCAD GraphicsSystem、设备和视图生命周期，没有可验证的共享宿主契约。 | 不迁移。 |
 | `ObjectARX/ArxOthers/SectionUtil.cs` | 道路/断面面积算法带明显业务语义和 WinForms 提示。 | 不进入通用基础库。 |
 | `ObjectARX/DictionaryUtil.cs` | XDictionary/Xrecord 能力已由 `DBDictionaryEx`、`XRecordDataList` 和对象扩展覆盖。 | 复用现有实现。 |
 | `ObjectARX/DwgDatabaseUtil.cs` | 入库、空间枚举、Handle 转 ObjectId 已由 `DBTrans`、`SymbolTableRecordEx`、`ObjectIdEx`、`EntityEx` 覆盖。 | 复用现有实现。 |
@@ -136,25 +136,25 @@
 
 | 来源文件 | 价值与现状 | 决定 |
 | --- | --- | --- |
-| `ObjectARX/DwgTable/AcadDwgTable.cs` | 自绘表格、合并单元格和布局可能有业务价值，但依赖缺失的 `ZFGK.DwgTableBase`/`ZFGK.Utility`，实现约 1,500 行。 | 暂缓；先确认基础模型源码、真实消费者和与原生 `Table` 的差异。 |
-| `ObjectARX/DwgTable/AcadSubDrawTable.cs` | 只是缺失表格基础模型的 CAD 适配。 | 随上项处理，不单独迁移。 |
+| `ObjectARX/DwgTable/AcadDwgTable.cs` | 自绘表格、合并单元格和布局依赖缺失的 `ZFGK.DwgTableBase`/`ZFGK.Utility`，且与原生 `Table` 的职责边界不清。 | 不迁移。 |
+| `ObjectARX/DwgTable/AcadSubDrawTable.cs` | 只是缺失表格基础模型的 CAD 适配。 | 不迁移。 |
 
 ### 6.4 实体、曲线和面域
 
 | 来源文件 | 价值与现状 | 决定 |
 | --- | --- | --- |
-| `ObjectARX/Entity/ArcUtil.cs` | 反转圆弧可由厂商曲线 API表达；旧实现直接改 Normal/角度，需额外验证非 XY 平面。 | 不直接迁移。 |
-| `ObjectARX/Entity/BlockUtil.cs` | 块导入、插入和属性大多已有等价实现；“选定实体导出 DWG”仍可能有增量价值。 | 部分候选；仅评估缺失的导出契约和属性度量。 |
+| `ObjectARX/Entity/ArcUtil.cs` | 反转圆弧可由厂商曲线 API 表达；旧实现直接改 Normal/角度，不能可靠处理非 XY 平面。 | 复用厂商 API，不迁移。 |
+| `ObjectARX/Entity/BlockUtil.cs` | 块导入、插入和属性已有等价实现；导出 DWG 可由厂商 Wblock API 与现有数据库能力组合，旧实现存在失败后提交和固定版本问题。 | 复用现有实现，不迁移。 |
 | `ObjectARX/Entity/CircleUtil.cs` | 仅构造并入库，现有实体添加 API 足够。 | 不迁移。 |
-| `ObjectARX/Entity/CurveUtil.cs` | 子曲线、弦高、归一化位置、偏移和交点查询具有通用价值；旧实现对返回对象的释放和异常处理不完整。 | 部分已吸收：Phase 1 批次 1 已加入长度比例取点和两种中点弦偏差；返回新对象和数据库修改仍按后续批次处理。 |
-| `ObjectARX/Entity/DimensionUtil.cs` | 旋转标注构造简单，未形成独特抽象。 | 低优先条件候选；有重复消费者时再加入窄扩展。 |
-| `ObjectARX/Entity/EntityUtil.cs` | 擦除、变换、颜色、包围盒和克隆大多已有等价实现。 | 复用现有实现；块属性克隆随 Block 项评估。 |
+| `ObjectARX/Entity/CurveUtil.cs` | 子曲线、归一化位置和弦偏差具有通用价值；目标库已有拆分、偏移和交点相关能力，旧实现对返回对象的释放和异常处理不完整。 | 已吸收长度比例取点和两种中点弦偏差；其余复用现有实现，不再迁移。 |
+| `ObjectARX/Entity/DimensionUtil.cs` | 旋转标注构造简单，未形成独特抽象。 | 不迁移。 |
+| `ObjectARX/Entity/EntityUtil.cs` | 擦除、变换、颜色、包围盒和克隆已有等价实现。 | 复用现有实现。 |
 | `ObjectARX/Entity/HatchUtil.cs` | 已有 `HatchEx`、`HatchConverter` 和边界创建能力；来源还依赖外部工具。 | 不迁移平行 API。 |
-| `ObjectARX/Entity/LineUtil.cs` | 方位、点线距离和插值有通用价值；相交状态和高程插值旧实现存在语义/结果问题。 | 部分已吸收：Phase 1 批次 1 已在 `PointEx` 加入比例插值和高程唯一点查询；方位/相交与修改操作继续去重。 |
+| `ObjectARX/Entity/LineUtil.cs` | 方位、点线距离和插值有通用价值；目标库已有面积/方向和厂商相交能力，旧实现的相交状态与高程插值存在语义问题。 | 已吸收比例插值和高程唯一点查询；其余复用现有实现，不再迁移。 |
 | `ObjectARX/Entity/PolyfaceMeshUtil.cs` | 仅创建网格并入库，现有实体添加机制可组合完成。 | 不迁移。 |
-| `ObjectARX/Entity/PolylineUtil.cs` | 连接、采样、分段、圆角、去零段和去共线点是本次最有价值的来源之一；旧实现同时操作事务、UI、对象释放和原位修改。 | 部分已吸收：Phase 1 批次 1 已加入完整顶点数据快照和单段长度；采样、创建新对象和修改操作继续分层处理。 |
-| `ObjectARX/Entity/RegionUtil.cs` | `Explode` 后转折线并连接可为 `RegionEx.ToCurves()` 提供替代思路，但旧实现泄漏临时对象且没有内外环/方向契约。 | 高优先设计输入；与 Region 所有权和 ZWCAD BRep 路径统一处理。 |
-| `ObjectARX/Entity/TextUtil.cs` | 添加文字、文字样式和去格式化大多已有实现；文字边界度量可能有宿主差异。 | 复用现有实现；度量需求单独验证。 |
+| `ObjectARX/Entity/PolylineUtil.cs` | 顶点数据、子段长度和只读采样具有明确通用价值；连接、圆角、去零段和去共线点的旧实现会混合事务、UI、对象释放和原位修改。 | 已吸收顶点快照、子段长度、按距离采样和按弦偏差采样；修改操作不迁移。 |
+| `ObjectARX/Entity/RegionUtil.cs` | `Explode` 后转折线并连接的旧实现泄漏临时对象，且没有内外环、方向、顺序和部分失败契约；当前也缺少 ZWCAD 2022 真实宿主证据。 | 不迁移；`RegionEx.ToCurves()` 的条件编译历史实现保持禁用。 |
+| `ObjectARX/Entity/TextUtil.cs` | 添加文字、文字样式和去格式化已有实现；文字边界度量存在宿主差异。 | 复用现有实现，不迁移度量包装。 |
 | `ObjectARX/Entity/XDataUtil.cs` | 已由 `TypedValueList`、`XDataList`、`DBObjectEx` 和选择过滤体系覆盖。 | 复用现有实现。 |
 
 ### 6.5 Editor、符号表和辅助能力
@@ -167,14 +167,14 @@
 | `ObjectARX/Interaction/SelectionSetUtil.cs` | implied selection 是原生 Editor API，目标代码已有使用。 | 不新增平行包装。 |
 | `ObjectARX/Interaction/ResultLocateUtil.cs` | 与专用 WinForms 结果定位窗口强耦合。 | 不进入基础库。 |
 | `ObjectARX/LayerUtil.cs` | 已由 `SymbolTable<LayerTable,...>`、`SymbolTableEx` 和 Editor 选择能力覆盖。 | 复用现有实现。 |
-| `ObjectARX/LinetypeUtil.cs` | 线型表访问已有统一符号表入口；系统线型文件加载需要单独的宿主路径契约。 | 默认复用现有实现；加载真实需求另立项。 |
-| `ObjectARX/TextStyleUtil.cs` | 文字样式写入已有实现；支持路径中的 SHX 枚举/存在性检查仍可能有增量价值。 | 条件候选；分离“路径发现”和“样式写入”，禁止弹窗和静默替换。 |
+| `ObjectARX/LinetypeUtil.cs` | 线型表访问已有统一符号表入口；系统线型文件加载属于宿主路径策略。 | 复用现有实现，不迁移。 |
+| `ObjectARX/TextStyleUtil.cs` | 文字样式写入已有实现；SHX 枚举混合宿主路径、程序集目录、外部工具和 UI 回退。 | 复用现有文字样式与 `Env` 能力，不迁移。 |
 | `ObjectARX/Others/ConvertUtil.cs` | 点/向量/集合和 UCS/WCS 转换已由 `PointEx`、`VectorEx`、`GeometryEx`、LINQ 覆盖；外部向量类型不属于目标库。 | 复用现有实现。 |
-| `ObjectARX/Others/FormatUtil.cs` | 点/向量文本序列化可能有价值，但旧实现缺少文化区、版本和失败契约。 | 低优先条件候选；先定义 invariant/显示格式和 `TryParse`。 |
+| `ObjectARX/Others/FormatUtil.cs` | 点/向量文本序列化缺少文化区、版本和失败契约，也不属于 CAD 对象核心能力。 | 不迁移。 |
 | `ObjectARX/Others/ListUtil.cs` | 唯一有效方法为交换元素，其余为大段历史注释。 | 不迁移。 |
 | `ObjectARX/Others/ViewUtil.cs` | 已由 `EditorEx.Zoom*` 覆盖。 | 复用现有实现。 |
 | `ObjectARX/SpacialIndex/DynamicPointSpatialIndex.cs` | 点去重、邻域、最近点和范围查询有明确通用价值。旧实现存在无效状态、密集二维数组、UI 弹窗和边界错误。 | 已吸收为 `PointGridIndex`：保留稳定索引、近似去重、范围和最近点能力；不保留固定 extent、公开网格行列和两阶段初始化。 |
-| `ObjectARX/SpacialIndex/EntitySpatialIndex.cs` | 实体范围查询有价值，但目标已有 `QuadTree`；旧实现把事务和网格构建耦合。 | 不迁移该类型；仅把可证明的批量建索引需求补到现有空间索引体系。 |
+| `ObjectARX/SpacialIndex/EntitySpatialIndex.cs` | 实体范围查询已由 `QuadTree` 承担；旧实现把事务和网格构建耦合。 | 复用现有 `QuadTree`，不迁移。 |
 | `Other/NumberUtil.cs` | 只拆尾部数字；无数字时抛异常但始终声明返回 true。 | 不迁移；真实需求使用明确 `Try*` 契约。 |
 | `Others/ApplicationUtil.cs` | 支持路径读取与现有 `Env` 边界重合。 | 复用现有实现。 |
 | `UI/ResultLocateForm.cs`、`UI/ResultLocateForm.Designer.cs` | 专用结果定位窗口，包含删除/定位业务流程。 | 不进入通用基础库。 |
@@ -211,7 +211,7 @@ Phase 0 的清单和结构决策已经完成。后续每个代码批次必须回
 
 ### Phase 1：只读几何查询
 
-候选范围：
+最终范围：
 
 - 曲线按归一化距离取点、弦高/逼近误差计算；
 - 折线顶点、bulge、段长和确定性采样；
@@ -234,7 +234,18 @@ Phase 0 的清单和结构决策已经完成。后续每个代码批次必须回
 
 ObjectARX、ZRX 和 GRX 的曲线契约均把 `Ray` 定义为起始参数 `0` 且没有终止参数，把 `Xline` 定义为没有起止参数或起止点。因此三种查询不能共用“必须具有有限总长”这一前置条件：长度比例取点明确拒绝两者；参数中点弦偏差接受有限的 `Ray`/`Xline` 参数区间，其中 `Ray` 参数不得小于 `0`；距离中点弦偏差接受从基点开始的有限非负 `Ray` 距离区间，但拒绝没有距离原点的 `Xline`。这一区分以 SDK 曲线契约为准。
 
-批次 1 提供宿主内确定性验收命令 `Test_GeometryQuery`，覆盖直线、半圆、`Ray`/`Xline` 边界、开放/闭合折线和高程插值边界。AC_2019、AC_2025、ZW_2022、ZW_2025、GC_2022、GC_2023、GC_2026 的 Release 库和测试程序集均已通过直接构建，模块、兼容性和 TypeDef 顺序守卫通过；这只是 Build-only 证据，命令尚未在 CAD 中执行，真实宿主状态为 `Not run`。折线按距离/弦偏差采样、点在线段左右关系和范围聚类尚未计入本批完成范围。
+批次 1 提供宿主内确定性验收命令 `Test_GeometryQuery`，覆盖直线、半圆、`Ray`/`Xline` 边界、开放/闭合折线和高程插值边界。AC_2019、AC_2025、ZW_2022、ZW_2025、GC_2022、GC_2023、GC_2026 的 Release 库和测试程序集均已通过直接构建，模块、兼容性和 TypeDef 顺序守卫通过；这只是 Build-only 证据，命令尚未在 CAD 中执行，真实宿主状态为 `Not run`。
+
+最终批次只补充折线确定性采样，不混入折线修改或数据库行为：
+
+| 目标类型 | API | 最终契约 |
+| --- | --- | --- |
+| `PolylineEx` | `GetSamplePointsByDistance` | 每个原始子段按沿折线的最大间距独立等距细分，保留所有原始顶点；闭合折线在结果末尾重复首顶点。 |
+| `PolylineEx` | `GetSamplePointsByChordDeviation` | 直线段只保留端点；圆弧段按弓高公式细分，使每个采样子弧的弦偏差不超过给定有限正数；同样保留原始顶点和闭合点。 |
+
+两个方法均返回独立的 `Point3d` 快照，不修改输入、不访问数据库、不创建需要释放的 CAD 对象。`Test_GeometryQuery` 同步覆盖直线/圆弧混合、开放/闭合、退化折线、非零 `Normal`/`Elevation`、非法阈值和不可表示的细分数量。点在线段左右关系由现有 `GeometryEx.GetArea`/`IsClockWise` 表达，范围关系和碰撞扫描由 `Rect`/`Rect.XCollision` 表达，不再新增平行 API。
+
+最终批次的 AC_2019、AC_2025、ZW_2022、ZW_2025、GC_2022、GC_2023、GC_2026 Release 库和测试程序集均已通过直接构建。模块守卫保持 `142 / 42 / 17`，七目标兼容性基线仅增加 `PolylineEx` 的两个公开方法及对应 XML 文档，四目标 TypeDef 顺序未变化；HostAcceptance runner 自测通过。以上仍是 Build-only 和基础设施证据，`Test_GeometryQuery` 未在 CAD 中执行，真实宿主状态为 `Not run`。
 
 ### Phase 2：点网格索引
 
@@ -265,42 +276,34 @@ Phase 2 的七目标公共契约基线均只新增 `PointGridIndex` 的 16 条�
 
 AC_2019、AC_2025、ZW_2022、ZW_2025、GC_2022、GC_2023、GC_2026 的 Release 库和测试程序集均已通过直接构建，模块期望更新为 `142` 个编译项、`Cad.Geometry = 17`；真实 CAD 宿主状态仍为 `Not run`。
 
-### Phase 3：曲线/折线修改与 Region
+### Phase 3：曲线/折线修改与 Region（已关闭，不迁移）
 
-- 在只读算法稳定后，再实现返回新对象的拆分、连接和简化。
-- 原位修改折线作为独立批次，保留宽度、bulge、闭合状态、Normal、Elevation 和属性。
-- Region 边界提取同时评估 `Explode` 路径、AutoCAD BRep 路径和 ZWCAD 2022 能力；定义外环/内环、方向、顺序、部分失败和对象所有权。
-- Issue #103/#107 中条件编译保留的 `RegionEx.ToCurves()` 只作为历史实现和风险清单，不因本迁移直接启用。
+- 目标库已有曲线拆分等基础能力，不从来源复制连接、圆角、去零段或去共线点实现。
+- 来源的原位修改不能完整保留宽度、bulge、闭合状态、`Normal`、`Elevation` 和实体属性，最终不迁移。
+- Region 边界提取缺少内外环、方向、顺序、部分失败、对象所有权和 ZWCAD 2022 宿主证据，最终不迁移。
+- Issue #103/#107 中条件编译保留的 `RegionEx.ToCurves()` 继续只作为历史实现和风险清单，不启用、不扩展。
 
-### Phase 4：数据库工作流
+### Phase 4：数据库工作流（已关闭，不迁移）
 
-- 先证明现有 `GetBlockFrom`、`InsertBlock`、`ChangeBlockAttribute` 等 API 的缺口。
-- 如仍有增量，再设计“选定实体导出 DWG”：目标版本、基点、重复记录、覆盖、临时文件、原子替换和失败回滚均为必填契约。
-- SHX 搜索仅在调用方确有跨宿主需求时实现；路径枚举、去重、访问异常和文件名比较需可测试。
-- 数据库写入与 UI 提示分离，不把当前 Document/Editor 隐式嵌入底层方法。
+- 块导入、插入、属性和数据库保存复用现有 `GetBlockFrom`、`InsertBlock`、`ChangeBlockAttribute`、`DatabaseEx` 及厂商 Wblock API。
+- 来源的实体导出 DWG 实现固定旧版本、隐式依赖活动文档，并在失败路径提交事务，不作为公共契约迁移。
+- SHX 搜索混合宿主支持路径、程序集目录和 UI 回退；本次不建立新的文件发现 API。
 
-### Phase 5：宿主专属和暂缓能力
+### Phase 5：宿主专属能力（已关闭，不迁移）
 
-DWG 图像预览、复杂自绘表格、结果定位窗体等不能搭便车进入共享程序集。每项需具备：
-
-1. 至少一个真实通用消费者；
-2. 完整依赖源码或可接受的独立替代设计；
-3. AutoCAD/ZWCAD 支持决策；
-4. 可执行的真实宿主验收场景。
-
-不满足时维持“暂缓/不迁移”，不使用大段 `#if false` 保存旧仓库副本。
+DWG 图像预览、复杂自绘表格、结果定位窗体和其他 WinForms/GraphicsSystem 能力均不进入共享程序集。它们缺少可重复依赖、共享宿主契约或通用基础库边界；最终清单不再保留候选状态，也不使用条件编译复制来源实现。
 
 ## 9. 分支和 PR 组织
 
-`migration/zfgk-cad` 是本次迁移的长期集成分支。具体代码使用从该分支建立的短分支，并将 PR base 指向该分支；建议批次名称保持窄小，例如：
+`migration/zfgk-cad` 是本次迁移的长期集成分支。已经完成的代码批次均从该分支建立短分支，并将 PR base 指向该分支：
 
 - `zfgk/geometry-query`
 - `zfgk/point-grid`
-- `zfgk/polyline-edit`
-- `zfgk/region-boundary`
-- `zfgk/block-export`
+- `zfgk/review-fixes`
+- `zfgk/curve-domain`
+- `zfgk/final-sampling`
 
-每个批次只处理一个所有权边界。长期分支阶段性合入最新 `main`，但冲突解决后必须重新执行模块守卫、兼容性检查和受影响构建。最终进入 `main` 前重新审查整个差异，不能把“各子 PR 已通过”替代集成验证。
+最终采样 PR 合入后不再建立新的 `Fs.Zfgk.CAD` 迁移批次。`migration/zfgk-cad` 继续与 `main` 隔离；是否以及何时进入 `main` 属于独立集成决策，必须重新同步最新 `main`、审查完整差异并获得维护者明确批准，不能用各子 PR 已通过替代最终集成验证。
 
 ## 10. 每批验收
 
@@ -336,24 +339,24 @@ DWG 图像预览、复杂自绘表格、结果定位窗体等不能搭便车进�
 | 3 | AutoCAD 2026（AC_2025 二进制基线） | .NET 8/新宿主行为和兼容性。 |
 | Not required | ZWCAD 2025 | 当前无真实宿主，不阻塞，但保持编译目标。 |
 
-当前本文只完成静态盘点，没有运行 CAD，宿主状态统一为 `Not run`。
+当前所有迁移批次均未运行 CAD，宿主状态统一为 `Not run`。七目标构建和静态守卫不代表真实宿主通过。
 
 ## 11. 完成定义
 
 本迁移不是以“来源文件全部处理”或“公共方法数量接近 451”为完成标准。满足以下条件才可收口：
 
-1. 每个来源文件都已有 `复用现有`、`已重写`、`暂缓` 或 `不迁移` 的明确结论；
+1. 每个来源文件都已有 `复用现有`、`已吸收` 或 `不迁移` 的最终结论，不再保留候选；
 2. 所有迁移能力符合当前目录、命名、事务和对象所有权契约；
 3. 没有引入来源二进制、AutoCAD-only using 泄漏或第二套平行 API；
 4. 自动构建/守卫与要求的真实宿主场景分别记录，未执行项不被包装为通过；
-5. 最终有效的公共行为写入 XML 注释和 current 文档，本文随后转为 `historical`；
-6. 长期分支相对最新 `main` 完成最终集成审查后，才建立合入 `main` 的 PR。
+5. 最终有效的公共行为写入 XML 注释，实施结果和未运行的宿主项写入本文；
+6. 最终采样 PR 合入 `migration/zfgk-cad` 后关闭 Issue #110，并将本文转为 `historical`。
 
-## 12. 下一步
+进入 `main` 不属于上述迁移完成定义。长期分支的完整集成审查和维护者批准仍是未来独立门槛。
 
-当前最合理的下一批不是整体搬运 `PolylineUtil.cs`，而是：
+## 12. 收口后状态
 
-1. 从 `CurveUtil`、`PolylineUtil`、`LineUtil` 提炼 5 至 8 个只读几何用例；
-2. 对照实时 `CurveEx`、`PolylineEx`、`PointEx` 去重，形成 Phase 1 API 草案；
-3. 先补可确定验证的算法测试，再提交第一批代码；
-4. 将每项实际结果回写第 6 节并关联 Issue #110。
+- 不再从 `Fs.Zfgk.CAD` 开展后续迁移，也不复用已删除的短期分支。
+- 新的通用 CAD 需求从 `Fs.Fox.CAD` 实时结构、厂商 SDK 和独立 Issue 出发设计，不以来源方法为规格。
+- `migration/zfgk-cad` 保留为尚未进入 `main` 的长期集成结果；在明确批准前不创建以 `main` 为 base 的迁移 PR。
+- 真实 CAD 宿主状态保持 `Not run`；未来若决定集成到 `main`，再按当时差异确定宿主验收范围。

--- a/docs/zfgk-cad-migration-plan.md
+++ b/docs/zfgk-cad-migration-plan.md
@@ -1,11 +1,12 @@
 # Fs.Zfgk.CAD 有价值能力迁移计划
 
 > 稳定 ID：`plan.zfgk-cad-migration`<br>
-> 状态：最终收口中（Active）<br>
+> 状态：已完成（Historical）<br>
 > 目标分支：`migration/zfgk-cad`<br>
 > 来源快照：`FeiSiDev/Fs.Zfgk.CAD@c38ce320c75284536c907c1046e5458da4ae0468`<br>
 > 最近 `main` 集成：`origin/main@6e6f94223be418481663833fc65386d8cf2839a4` 已由 `2e68759f710046416f4e27d2c2f87487e4160619` 合入<br>
 > 实施跟踪：[Issue #110](https://github.com/FsDiG/Fs.Fox.CAD/issues/110)<br>
+> 最终批次：[PR #116](https://github.com/FsDiG/Fs.Fox.CAD/pull/116)<br>
 > 最近复核：2026-08-03<br>
 > CAD 宿主验收：Not run
 
@@ -303,7 +304,7 @@ DWG 图像预览、复杂自绘表格、结果定位窗体和其他 WinForms/Gra
 - `zfgk/curve-domain`
 - `zfgk/final-sampling`
 
-最终采样 PR 合入后不再建立新的 `Fs.Zfgk.CAD` 迁移批次。`migration/zfgk-cad` 继续与 `main` 隔离；是否以及何时进入 `main` 属于独立集成决策，必须重新同步最新 `main`、审查完整差异并获得维护者明确批准，不能用各子 PR 已通过替代最终集成验证。
+PR #116 合入后不再建立新的 `Fs.Zfgk.CAD` 迁移批次。`migration/zfgk-cad` 继续与 `main` 隔离；是否以及何时进入 `main` 属于独立集成决策，必须重新同步最新 `main`、审查完整差异并获得维护者明确批准，不能用各子 PR 已通过替代最终集成验证。
 
 ## 10. 每批验收
 

--- a/docs/zfgk-cad-migration-plan.md
+++ b/docs/zfgk-cad-migration-plan.md
@@ -226,7 +226,7 @@ Phase 0 的清单和结构决策已经完成。后续每个代码批次必须回
 | --- | --- | --- |
 | `CurveEx` | `GetPointAtDistanceFraction` | 按总长闭区间 `[0, 1]` 取点；修正旧实现忽略输入比例、固定取 `0.5` 的问题，并拒绝无限长度域。 |
 | `CurveEx` | `GetMidpointChordDeviation` | 明确按参数中点计算三维弦偏差，不把结果表述为区间最大误差。 |
-| `CurveEx` | `GetMidpointChordDeviationByDistance` | 明确按沿曲线距离中点计算，避免把距离端点转参数后误用参数中点。 |
+| `CurveEx` | `GetMidpointChordDeviationByDistance` | 明确按沿曲线距离中点计算，避免把距离端点转参数后误用参数中点；曲线本身没有有限且有序的参数或距离范围时明确失败。 |
 | `PolylineEx` | `GetVertexData` | 一次取得顶点、bulge、起宽和终宽的独立托管快照，不暴露 `ref` 集合。 |
 | `PolylineEx` | `GetSegmentLength` | 对开放/闭合折线验证真实子段索引；直线返回线长，圆弧返回弧长。 |
 | `PointEx` | `InterpolateTo` | 使用闭区间 `[0, 1]` 的三维线性插值，非法比例抛出明确异常。 |
@@ -256,6 +256,8 @@ Phase 2 的目标 API 与边界如下：
 | `Clear` | 同时释放点和稀疏桶引用；之后索引重新从零开始。 |
 
 旧实现的 `Create`、`GetBlockOfPoint`、`GetNeighborPoints`、`GetExtent` 和 `IsIn` 不成为公共 API：无界稀疏索引不需要固定范围，网格桶只是实现细节。`Test_PointGridIndex` 覆盖跨桶去重、Z 分层、负坐标、闭区间范围、最近点并列、退化参数和清空重用；当前仅参加测试程序集编译，CAD 宿主状态为 `Not run`。
+
+PR #112 的评审收口规定：有限查询范围因坐标量级与 `CellSize` 组合而不能表示为 `long` 网格坐标时，索引退化为扫描全部已存点并继续执行精确过滤，不把实现范围限制暴露成查询异常；高频查询复用实例内候选缓冲区，仍遵守类型既有的非线程安全契约。查询结果是与索引内部状态分离的独立集合，因此不为阻止调用方修改其副本而增加只读包装分配。
 
 Phase 2 的七目标公共契约基线均只新增 `PointGridIndex` 的 16 条记录。以 `migration/zfgk-cad@587e77f` 为基线重新构建并比较 AC_2019、AC_2025、ZW_2022、ZW_2025 实际程序集后，每个目标都只新增一个 TypeDef，所有既有 TypeDef 的相对顺序保持不变；由于 Roslyn 先发射 `Fs.Fox.Cad` 根类型再发射 `Fs.Fox.Cad.Assoc`，新类型位于现有根类型末尾并使其后的 token 顺延一位，这是新增公共根类型的已审查结果，不是既有类型重排。
 

--- a/docs/zfgk-cad-migration-plan.md
+++ b/docs/zfgk-cad-migration-plan.md
@@ -1,0 +1,328 @@
+# Fs.Zfgk.CAD 有价值能力迁移计划
+
+> 稳定 ID：`plan.zfgk-cad-migration`<br>
+> 状态：提案与执行准备（Proposal）<br>
+> 目标分支：`migration/zfgk-cad`<br>
+> 来源快照：`FeiSiDev/Fs.Zfgk.CAD@c38ce320c75284536c907c1046e5458da4ae0468`<br>
+> 目标基线：`FsDiG/Fs.Fox.CAD@9faca0a4e420220bd3735de26c63f629564b6dc7`<br>
+> 授权与再分发跟踪：[Issue #105](https://github.com/FsDiG/Fs.Fox.CAD/issues/105)<br>
+> 最近复核：2026-08-03<br>
+> CAD 宿主验收：Not run
+
+本文记录从 `Fs.Zfgk.CAD` 向 `Fs.Fox.CAD` 吸收通用 CAD 能力的取舍、目标组织、实施顺序和验收边界。它不把来源仓库的文件结构、类名或实现视为迁移规格；每项代码在落地前仍须重新核对实时源码、ObjectARX/ZRX API、目标分支现状和授权范围。
+
+## 1. 结论
+
+不应整体复制 `Fs.Zfgk.CAD`，也不应在 `Fs.Fox.CAD` 中建立第二套 `ZFGK.AutoCAD.*` 或 `*Util` API。来源快照包含 49 个 C# 文件、15,856 行、53 个公开类型和约 451 个公开方法，但其形态有以下限制：
+
+- 43 个文件直接引用 Autodesk AutoCAD 类型，没有 ZWCAD 共源编译边界。
+- 11 个文件依赖未随源码提供的 `ZFGK.*` 项目类型；9 个文件直接依赖 WinForms、`MessageBox` 或相近 UI 行为。
+- 项目引用固定到 AutoCAD 2019 managed API 和本机相对路径，当前检出不能作为可重复构建基线。
+- 大量能力已被 `DBTrans`、`SymbolTable`、`PointEx`、`GeometryEx`、`CurveEx`、`EditorEx`、`DBDictionaryEx`、`HatchEx`、`QuadTree` 等现行实现覆盖。
+- 若干未覆盖算法仍有通用价值，但旧实现存在资源所有权、容差、异常、事务和边界条件问题，必须按目标库契约重写并验证。
+
+迁移的合理目标是“吸收能力”，不是“搬运代码”。优先级如下：
+
+1. 曲线、折线和面域的只读几何算法，以及明确的对象所有权契约。
+2. 面向点去重、邻域和范围查询的稀疏网格索引；它与现有四叉树互补，而不是替换四叉树。
+3. 现有块导入/属性 API 没有覆盖的 DWG 导出工作流。
+4. SHX 搜索与几何文本序列化等有明确跨产品需求的辅助能力。
+5. 图形系统预览、DWG 表格和桌面 UI 只在出现真实通用消费者并能完成宿主验证后评估。
+
+## 2. 不可突破的边界
+
+### 2.1 产品与程序集
+
+- `Fs.Fox.CAD` 仍是单产品、单套公共 API；迁移代码进入现有 `CADShared` 单程序集逻辑模块。
+- 不改变 `Fs.Fox.Cad`、`Fs.Fox.Basal` 公共命名空间，不引入 `ZFGK.AutoCAD` 兼容命名空间。
+- 不新增 `ZFGK.dll`、`ZFGK.AutoCAD.dll`、`ZFGK.WinForms.dll` 或其他来源二进制依赖。
+- 不因为来源文件较大而建立新的 DLL、NuGet 包或“兼容层”。是否拆程序集仍遵循现行架构文档的消费者、依赖方向和宿主矩阵门槛。
+
+### 2.2 API 与命名
+
+- 无状态的宿主类型扩展进入现有 `*Ex` 类；拥有索引、缓存或生命周期的能力使用表达领域含义的名词类。
+- 不沿用 `Acad*`、`Ge*`、`*Util`、`m_*`、`b*`、`p*` 等历史命名。平台差异通过现有全局别名、条件编译或平台实现表达。
+- 新 API 不使用 `ref List<T>` 作为普通返回方式；查询优先返回值或 `IReadOnlyList<T>`，条件结果使用语义明确的 `Try*`。
+- 容差参数必须说明度量单位、闭区间/开区间和零值语义，不能散落硬编码 `1e-4`、`1e-7`。
+- 失败不能在几何或数据库层弹出 `MessageBox`、写当前 Editor 或静默提交事务；应返回可判断结果或抛出可记录的异常。
+
+### 2.3 CAD 对象所有权
+
+- `GetSplitCurves`、`Explode`、`Region.CreateFromCurves`、`GetOffsetCurves` 等返回的新 `DBObject`/`Curve` 必须逐项定义由谁释放。
+- 方法不得释放调用方传入的 `Entity`、`Curve`、`Polyline`、`Database` 或 `Transaction`，除非 API 名称和 XML 注释明确转移所有权。
+- 数据库写入必须接收或复用明确的事务/`DBTrans`；只读几何算法不隐式使用 `MdiActiveDocument` 或 `HostApplicationServices.WorkingDatabase`。
+- 部分失败时应保证临时对象、目标数据库和事务被清理，不能通过 `catch` 后 `Commit()` 保留半完成状态。
+
+### 2.4 多宿主
+
+- 正式共享代码至少通过 AC_2019、AC_2025、ZW_2022、ZW_2025 四目标编译和兼容性守卫。
+- `Autodesk.AutoCAD.GraphicsSystem`、COM、native export 或仅 AutoCAD 存在的 API 默认不得进入共享实现。
+- 真实宿主验证优先 ZWCAD 2022，其次 AutoCAD 2020/2026；没有 ZWCAD 2025 宿主不是迁移阻塞项，也不能把编译表述为宿主通过。
+- 未经明确批准，不启动 CAD，不修改 profile、Trusted Paths、注册表或启动组。
+
+## 3. 授权与溯源门槛
+
+来源仓库当前为 Private，GitHub 未识别到许可证；其 README 写明“基于智帆高科 CAD 类库封装，已经过张帆授权”，多份源码头同时标注“北京智帆高科科技有限公司版权所有”。目标仓库公开并采用 MIT License。因此，在复制源码或提交可识别的改写实现前，必须在 [Issue #105](https://github.com/FsDiG/Fs.Fox.CAD/issues/105) 确认现有授权明确覆盖：
+
+1. 把相关实现并入公开的 `Fs.Fox.CAD`；
+2. 修改、发布和分发这些实现；
+3. 按目标仓库 MIT License 允许下游继续使用和再分发。
+
+授权确认应在关联 Issue 中留下可追溯结论；敏感原件不必提交仓库。若授权只允许内部使用，则公开仓库只能保留功能需求和独立设计，不复制实现。若授权范围不能确定，则停止对应代码迁移，但不影响本清单继续用于去重和需求分析。
+
+每个实际迁移 PR 需在正文中记录来源文件、来源提交和处理方式：
+
+- `adapted`：确认授权后基于来源实现改写，并保留必要版权归属；
+- `clean implementation`：仅采用公开需求/接口事实，由目标契约独立实现；
+- `existing equivalent`：确认目标已有能力，不引入来源代码。
+
+## 4. 评估方法
+
+每项能力按以下维度复核，不按当前仓库是否存在调用方决定价值：
+
+| 维度 | 需要回答的问题 |
+| --- | --- |
+| 通用性 | 是否属于 CAD 基础库，而非单一产品、图层命名或业务表格约定？ |
+| 增量价值 | 目标库是否已经用更稳定的 API 提供相同能力？ |
+| 正确性 | 边界、容差、异常、退化几何和部分失败是否可定义并验证？ |
+| 所有权 | 临时 CAD 对象、事务、数据库和返回对象由谁释放？ |
+| 多宿主 | 是否使用 AutoCAD 专属 API；ZWCAD 是否有等价行为？ |
+| 依赖成本 | 是否需要未提供的 `ZFGK.*`、WinForms、COM 或 native 组件？ |
+| 验证能力 | 能否先做确定性测试；哪些行为必须进真实 CAD 宿主？ |
+
+只有同时具备通用价值、明确增量和可验证契约的能力才进入代码批次。来源实现有价值但短期不能验证时，保留在来源快照和本文中，不用条件编译把整份未经验证的旧类塞入生产项目。
+
+## 5. 目标目录和类名
+
+| 能力 | 目标位置 | 建议承载类型 | 说明 |
+| --- | --- | --- | --- |
+| 点、向量、坐标和普通几何 | `Cad/Geometry` | 现有 `PointEx`、`VectorEx`、`GeometryEx` | 只补确实缺失且可测试的方法。 |
+| 点邻域/去重网格 | `Cad/Geometry/SpatialIndex/Grid` | `PointGridIndex` 或经评审后的同义名 | 有状态索引用名词类，不叫 `DynamicPointSpatialIndexUtil`。优先稀疏桶，避免旧实现的二维巨型数组。 |
+| 曲线查询与拆分 | `Cad/Database/Entities/Curves` | 现有 `CurveEx`，必要时按能力拆文件 | 返回新曲线时必须写明释放责任。 |
+| 折线查询、采样和编辑 | `Cad/Database/Entities/Curves/Polylines` | 现有 `PolylineEx` | 只读查询与原位修改分批，不在一个 PR 混合。 |
+| 面域边界 | `Cad/Database/Entities` | 现有 `RegionEx` | 与 Issue #103/#107 记录的 `ToCurves()` 所有权风险一并设计。 |
+| 块导入、导出和属性 | `Cad/Database/Entities/Blocks`、`Cad/Database/SymbolTables` | 现有 `BlockReferenceEx`、`SymbolTableEx`，或窄职责 `BlockExportEx` | 先复用 `GetBlockFrom`、`InsertBlock` 和属性 API，避免平行入口。 |
+| 字体与文字样式 | `Cad/Database/Entities/Text`、`Cad/Database/SymbolTables` | 现有文字扩展和 `SymbolTableEx` | 搜索路径读取属于应用边界，不能藏在文字样式写事务中。 |
+| Editor 输入与选择 | `Cad/Editor` | 现有 `EditorEx`、`PromptOptionsEx` | 原生 `Editor.Get*` 已足够时不再包一层 bool/out API。 |
+| AutoCAD 专属图形系统 | 平台专属目录，待设计 | 不预设公共类型 | 只有存在真实消费者和 ZWCAD 边界决策时再建。 |
+
+## 6. 逐文件迁移清单
+
+### 6.1 根文件与 Geometry
+
+| 来源文件 | 价值与现状 | 决定 |
+| --- | --- | --- |
+| `AutoCADCommonApp.cs` | 空壳类型，无行为。 | 不迁移。 |
+| `Properties/AssemblyInfo.cs` | 旧项目程序集元数据。 | 不迁移；目标项目自行生成/维护。 |
+| `Geometry/AcadPlaneUtil.cs` | 仅返回 XY 平面；厂商 API 和现有 `PlaneEx` 足以表达。 | 不迁移。 |
+| `Geometry/CoordinateUtil.cs` | UCS/WCS 转换已由 `GeometryEx`、`EditorEx` 提供；旧实现隐式取活动文档。 | 复用现有实现。 |
+| `Geometry/GePointUtil.cs` | 极坐标、中点、二维距离和方向已有等价实现；点去重、排序和折线圆角概念仍可复核。 | 部分候选；只迁移经独立测试证明的缺失算法。 |
+| `Geometry/GeRectangleUtil.cs` | 轴向矩形相交已由 `Rect.IntersectsWith` 覆盖。 | 复用现有实现。 |
+| `Geometry/GeTriangle.cs` | 坡度/坡向和重心有领域价值，但旧实现存在退化三角形、法向方向和重心 Z 值问题。 | 条件候选；作为新的明确几何契约重写，不复制该类型。 |
+| `Geometry/MathUtil.cs` | 多数函数已有 `System.Math` 等价项；采样、反函数和容差方法的边界契约不完整。 | 不迁移整类；真实需求单独设计。 |
+
+### 6.2 ObjectARX 基础能力
+
+| 来源文件 | 价值与现状 | 决定 |
+| --- | --- | --- |
+| `ObjectARX/AcadDocumentUtil.cs` | 文档枚举可直接使用 `DocumentManager`；`GetOpenedDocument` 忽略文件名并返回第一个文档。 | 不迁移。 |
+| `ObjectARX/ArxOthers/DwgScaleUtil.cs` | 使用特定字典键保存“标注/信息比例”，更像产品数据协议。 | 默认不迁移；若多个产品依赖同一持久化格式，先建立独立契约。 |
+| `ObjectARX/ArxOthers/ExtentUtil.cs` | 宽高、中心、扩展已被 `Rect`、`BoundingBox9`、`PointEx` 覆盖；范围关系和相交簇合并仍有价值。 | 部分候选；基于现有范围类型重写关系/聚类，不复制事务辅助。 |
+| `ObjectARX/ArxOthers/GroupUtil.cs` | 已由 `DBDictionaryEx.AddGroup`/`GetGroups` 覆盖。 | 复用现有实现。 |
+| `ObjectARX/ArxOthers/GsPreviewUtil.cs` | DWG 到位图预览有价值，但直接使用 AutoCAD GraphicsSystem、设备和视图生命周期。 | 高风险条件候选；独立平台设计和真实宿主测试前不迁移。 |
+| `ObjectARX/ArxOthers/SectionUtil.cs` | 道路/断面面积算法带明显业务语义和 WinForms 提示。 | 不进入通用基础库。 |
+| `ObjectARX/DictionaryUtil.cs` | XDictionary/Xrecord 能力已由 `DBDictionaryEx`、`XRecordDataList` 和对象扩展覆盖。 | 复用现有实现。 |
+| `ObjectARX/DwgDatabaseUtil.cs` | 入库、空间枚举、Handle 转 ObjectId 已由 `DBTrans`、`SymbolTableRecordEx`、`ObjectIdEx`、`EntityEx` 覆盖。 | 复用现有实现。 |
+
+### 6.3 DWG 表格
+
+| 来源文件 | 价值与现状 | 决定 |
+| --- | --- | --- |
+| `ObjectARX/DwgTable/AcadDwgTable.cs` | 自绘表格、合并单元格和布局可能有业务价值，但依赖缺失的 `ZFGK.DwgTableBase`/`ZFGK.Utility`，实现约 1,500 行。 | 暂缓；先确认基础模型源码、真实消费者和与原生 `Table` 的差异。 |
+| `ObjectARX/DwgTable/AcadSubDrawTable.cs` | 只是缺失表格基础模型的 CAD 适配。 | 随上项处理，不单独迁移。 |
+
+### 6.4 实体、曲线和面域
+
+| 来源文件 | 价值与现状 | 决定 |
+| --- | --- | --- |
+| `ObjectARX/Entity/ArcUtil.cs` | 反转圆弧可由厂商曲线 API表达；旧实现直接改 Normal/角度，需额外验证非 XY 平面。 | 不直接迁移。 |
+| `ObjectARX/Entity/BlockUtil.cs` | 块导入、插入和属性大多已有等价实现；“选定实体导出 DWG”仍可能有增量价值。 | 部分候选；仅评估缺失的导出契约和属性度量。 |
+| `ObjectARX/Entity/CircleUtil.cs` | 仅构造并入库，现有实体添加 API 足够。 | 不迁移。 |
+| `ObjectARX/Entity/CurveUtil.cs` | 子曲线、弦高、归一化位置、偏移和交点查询具有通用价值；旧实现对返回对象的释放和异常处理不完整。 | 高优先候选；拆为只读计算、返回新对象、数据库修改三个批次。 |
+| `ObjectARX/Entity/DimensionUtil.cs` | 旋转标注构造简单，未形成独特抽象。 | 低优先条件候选；有重复消费者时再加入窄扩展。 |
+| `ObjectARX/Entity/EntityUtil.cs` | 擦除、变换、颜色、包围盒和克隆大多已有等价实现。 | 复用现有实现；块属性克隆随 Block 项评估。 |
+| `ObjectARX/Entity/HatchUtil.cs` | 已有 `HatchEx`、`HatchConverter` 和边界创建能力；来源还依赖外部工具。 | 不迁移平行 API。 |
+| `ObjectARX/Entity/LineUtil.cs` | 方位、点线距离和插值有通用价值；相交状态和高程插值旧实现存在语义/结果问题。 | 部分候选；采用明确枚举/结果类型和退化线契约重写。 |
+| `ObjectARX/Entity/PolyfaceMeshUtil.cs` | 仅创建网格并入库，现有实体添加机制可组合完成。 | 不迁移。 |
+| `ObjectARX/Entity/PolylineUtil.cs` | 连接、采样、分段、圆角、去零段和去共线点是本次最有价值的来源之一；旧实现同时操作事务、UI、对象释放和原位修改。 | 高优先候选；按“查询 -> 创建新对象 -> 原位修改 -> 批量数据库操作”四层重写。 |
+| `ObjectARX/Entity/RegionUtil.cs` | `Explode` 后转折线并连接可为 `RegionEx.ToCurves()` 提供替代思路，但旧实现泄漏临时对象且没有内外环/方向契约。 | 高优先设计输入；与 Region 所有权和 ZWCAD BRep 路径统一处理。 |
+| `ObjectARX/Entity/TextUtil.cs` | 添加文字、文字样式和去格式化大多已有实现；文字边界度量可能有宿主差异。 | 复用现有实现；度量需求单独验证。 |
+| `ObjectARX/Entity/XDataUtil.cs` | 已由 `TypedValueList`、`XDataList`、`DBObjectEx` 和选择过滤体系覆盖。 | 复用现有实现。 |
+
+### 6.5 Editor、符号表和辅助能力
+
+| 来源文件 | 价值与现状 | 决定 |
+| --- | --- | --- |
+| `ObjectARX/Interaction/GetInputUtil.cs` | 对原生 PromptOptions 的 bool/out 包装会丢失 PromptStatus 和取消原因。 | 不迁移；增强现有 `EditorEx`/`PromptOptionsEx` 时保留原生结果。 |
+| `ObjectARX/Interaction/GetPointUtil.cs` | 同上，且隐式依赖活动 Editor。 | 不迁移。 |
+| `ObjectARX/Interaction/SelectUtil.cs` | 类型选择、窗口选择和按图层选择已可由 `EditorEx.SSGet` 和过滤器组合。 | 复用现有实现。 |
+| `ObjectARX/Interaction/SelectionSetUtil.cs` | implied selection 是原生 Editor API，目标代码已有使用。 | 不新增平行包装。 |
+| `ObjectARX/Interaction/ResultLocateUtil.cs` | 与专用 WinForms 结果定位窗口强耦合。 | 不进入基础库。 |
+| `ObjectARX/LayerUtil.cs` | 已由 `SymbolTable<LayerTable,...>`、`SymbolTableEx` 和 Editor 选择能力覆盖。 | 复用现有实现。 |
+| `ObjectARX/LinetypeUtil.cs` | 线型表访问已有统一符号表入口；系统线型文件加载需要单独的宿主路径契约。 | 默认复用现有实现；加载真实需求另立项。 |
+| `ObjectARX/TextStyleUtil.cs` | 文字样式写入已有实现；支持路径中的 SHX 枚举/存在性检查仍可能有增量价值。 | 条件候选；分离“路径发现”和“样式写入”，禁止弹窗和静默替换。 |
+| `ObjectARX/Others/ConvertUtil.cs` | 点/向量/集合和 UCS/WCS 转换已由 `PointEx`、`VectorEx`、`GeometryEx`、LINQ 覆盖；外部向量类型不属于目标库。 | 复用现有实现。 |
+| `ObjectARX/Others/FormatUtil.cs` | 点/向量文本序列化可能有价值，但旧实现缺少文化区、版本和失败契约。 | 低优先条件候选；先定义 invariant/显示格式和 `TryParse`。 |
+| `ObjectARX/Others/ListUtil.cs` | 唯一有效方法为交换元素，其余为大段历史注释。 | 不迁移。 |
+| `ObjectARX/Others/ViewUtil.cs` | 已由 `EditorEx.Zoom*` 覆盖。 | 复用现有实现。 |
+| `ObjectARX/SpacialIndex/DynamicPointSpatialIndex.cs` | 点去重、邻域、最近点和范围查询有明确通用价值。旧实现存在无效状态、密集二维数组、UI 弹窗和边界错误。 | 高优先候选；重写为稀疏网格索引并补确定性测试。 |
+| `ObjectARX/SpacialIndex/EntitySpatialIndex.cs` | 实体范围查询有价值，但目标已有 `QuadTree`；旧实现把事务和网格构建耦合。 | 不迁移该类型；仅把可证明的批量建索引需求补到现有空间索引体系。 |
+| `Other/NumberUtil.cs` | 只拆尾部数字；无数字时抛异常但始终声明返回 true。 | 不迁移；真实需求使用明确 `Try*` 契约。 |
+| `Others/ApplicationUtil.cs` | 支持路径读取与现有 `Env` 边界重合。 | 复用现有实现。 |
+| `UI/ResultLocateForm.cs`、`UI/ResultLocateForm.Designer.cs` | 专用结果定位窗口，包含删除/定位业务流程。 | 不进入通用基础库。 |
+
+## 7. 已确认不能原样继承的问题
+
+下列问题说明为何需要逐能力重写；它们不是对历史代码用途的否定：
+
+| 来源位置 | 问题 | 迁移要求 |
+| --- | --- | --- |
+| `AcadDocumentUtil.GetOpenedDocument` | 参数没有参与匹配，循环第一次就返回。 | 文档查找必须定义路径比较、大小写和未保存文档语义。 |
+| `ExtentUtil.GetExtentRelation` | 相等矩形和容差边界的包含判断不一致。 | 用表驱动测试覆盖相等、相切、包含、近似分离和退化范围。 |
+| `DynamicPointSpatialIndex.GetBlockOfPoint` | 最大边界可能计算到数组长度之外；索引采用潜在百万格的密集二维数组。 | 使用经过边界夹取的稀疏桶；构造时拒绝无效范围/格长。 |
+| `DynamicPointSpatialIndex.AddPoint` | 即使添加成功也固定返回 `false`。 | `TryAdd` 必须区分新索引、既有近似点和范围外失败。 |
+| `PolylineUtil.Join*` | 内部释放第二条折线，外层随后仍可能擦除/访问同一对象。 | 方法不释放输入；结果和所有权由调用方显式处理。 |
+| `CurveUtil.GetSubCurve`、`RegionUtil.CreatePolylineByRegion` | 只返回部分新对象，未完整释放其他 split/explode 结果。 | 对所有临时 `DBObject` 使用可审计清理路径，并定义返回对象所有权。 |
+| `LineUtil.InterpolatePoint` | 按高程插值后返回点的 Z 使用默认值 0，边界分支也丢失目标高程。 | 结果必须保留请求高程并覆盖水平线、端点和范围外情况。 |
+| `BlockUtil.CreateDwgBlockFile` | 异常路径仍提交源/目标事务，输出版本固定为 AC1800。 | 默认失败不提交；DWG 版本、覆盖和临时文件替换必须显式。 |
+| `TextStyleUtil.Add` | `finally` 中无条件提交，字体不存在时弹窗并隐式替换。 | 事务成功才提交；字体回退是调用方策略，库层不弹窗。 |
+| `GsPreviewUtil` | GraphicsSystem 设备、kernel、view 和 bitmap 生命周期为 AutoCAD 专属。 | 平台实现分别验证；禁止用 AC_2019 编译通过推断 ZWCAD 可用。 |
+
+## 8. 分阶段实施
+
+### Phase 0：基线、授权和去重
+
+- [x] 从最新 `main` 建立 `migration/zfgk-cad`。
+- [x] 固定来源/目标 commit，完成 49 个 C# 文件的首轮清单。
+- [x] 记录现有等价 API、外部依赖和已知风险。
+- [x] 将授权与再分发门槛关联到 Issue #105。
+- [ ] 确认授权是否覆盖公开 MIT 再分发，并在关联 Issue 留下结论。
+- [ ] 为第一批候选写具体 API 草案和测试样例，确认没有与实时 `main` 重复。
+
+Phase 0 只允许文档和验证基础设施变更。授权未确认前，不直接复制或改写带来源版权的实现。
+
+### Phase 1：只读几何查询
+
+候选范围：
+
+- 曲线按归一化距离取点、弦高/逼近误差计算；
+- 折线顶点、bulge、段长和确定性采样；
+- 直线/线段方位与高程插值的明确结果契约；
+- Extents/Rect 的关系和相交簇合并。
+
+约束：不写数据库、不依赖活动文档、不原位修改输入、不弹 UI。先增加测试，再增加公共 API；每个返回的新 CAD 对象都写明释放责任。
+
+### Phase 2：点网格索引
+
+以来源的需求集合为输入，重新设计稀疏 `PointGridIndex`：
+
+- 构造后始终有效，不保留需要先调用 `Create()` 的半初始化状态；
+- 支持近似点去重、范围查询和受最大距离约束的最近点查询；
+- XY 容差、Z 容差、格长和边界闭合规则显式；
+- 不依赖 WinForms，不在失败时弹窗；
+- 与 `QuadTree` 做职责对照和基准，不能建立两套等价实体索引。
+
+### Phase 3：曲线/折线修改与 Region
+
+- 在只读算法稳定后，再实现返回新对象的拆分、连接和简化。
+- 原位修改折线作为独立批次，保留宽度、bulge、闭合状态、Normal、Elevation 和属性。
+- Region 边界提取同时评估 `Explode` 路径、AutoCAD BRep 路径和 ZWCAD 2022 能力；定义外环/内环、方向、顺序、部分失败和对象所有权。
+- Issue #103/#107 中条件编译保留的 `RegionEx.ToCurves()` 只作为历史实现和风险清单，不因本迁移直接启用。
+
+### Phase 4：数据库工作流
+
+- 先证明现有 `GetBlockFrom`、`InsertBlock`、`ChangeBlockAttribute` 等 API 的缺口。
+- 如仍有增量，再设计“选定实体导出 DWG”：目标版本、基点、重复记录、覆盖、临时文件、原子替换和失败回滚均为必填契约。
+- SHX 搜索仅在调用方确有跨宿主需求时实现；路径枚举、去重、访问异常和文件名比较需可测试。
+- 数据库写入与 UI 提示分离，不把当前 Document/Editor 隐式嵌入底层方法。
+
+### Phase 5：宿主专属和暂缓能力
+
+DWG 图像预览、复杂自绘表格、结果定位窗体等不能搭便车进入共享程序集。每项需具备：
+
+1. 至少一个真实通用消费者；
+2. 完整依赖源码或可接受的独立替代设计；
+3. AutoCAD/ZWCAD 支持决策；
+4. 可执行的真实宿主验收场景。
+
+不满足时维持“暂缓/不迁移”，不使用大段 `#if false` 保存旧仓库副本。
+
+## 9. 分支和 PR 组织
+
+`migration/zfgk-cad` 是本次迁移的长期集成分支。具体代码使用从该分支建立的短分支，并将 PR base 指向该分支；建议批次名称保持窄小，例如：
+
+- `zfgk/geometry-query`
+- `zfgk/point-grid`
+- `zfgk/polyline-edit`
+- `zfgk/region-boundary`
+- `zfgk/block-export`
+
+每个批次只处理一个所有权边界。长期分支阶段性合入最新 `main`，但冲突解决后必须重新执行模块守卫、兼容性检查和受影响构建。最终进入 `main` 前重新审查整个差异，不能把“各子 PR 已通过”替代集成验证。
+
+## 10. 每批验收
+
+### 10.1 静态和构建
+
+- `git diff --check`
+- `pwsh -File Build/Verify-CADSharedModuleMap.ps1`
+- `pwsh -File tools/verification/Test-CADSharedTypeDefSequence.ps1`
+- `pwsh -File Build/Verify-CADSharedCompatibility.ps1`
+- AC_2019、AC_2025、ZW_2022、ZW_2025 Release 构建
+- 新 Markdown 相对链接和 GitHub Flavored Markdown 渲染检查
+
+新增编译文件时，在 `CADShared.projitems` 中填写正确的 `FsFoxModule`/`FsFoxOrder`，并通过守卫提供的更新流程同步模块基线；不能手工绕过预期计数或把新边界债务静默加入白名单。
+
+### 10.2 算法测试
+
+至少覆盖：
+
+- 空集合、单元素、重复点、零长度段和退化几何；
+- 正/负坐标、非常大/小的数值、端点和恰好位于容差边界；
+- 开放/闭合折线、顺/逆时针、直线段/圆弧段、非零 Normal/Elevation；
+- 方法失败后的输入不变性、临时对象释放和重复调用；
+- AutoCAD/ZWCAD API 返回集合在空、部分成功和异常时的所有权。
+
+### 10.3 真实宿主
+
+涉及数据库写入、Region/BRep、GraphicsSystem、Editor 或 UI 的批次，最终必须记录实际宿主：
+
+| 优先级 | 宿主 | 用途 |
+| --- | --- | --- |
+| 1 | ZWCAD 2022 | 共享 API、Region/折线、数据库和 Editor 的首要验收。 |
+| 2 | AutoCAD 2020（AC_2019 二进制基线） | 老 ObjectARX 行为与来源实现对照。 |
+| 3 | AutoCAD 2026（AC_2025 二进制基线） | .NET 8/新宿主行为和兼容性。 |
+| Not required | ZWCAD 2025 | 当前无真实宿主，不阻塞，但保持编译目标。 |
+
+当前本文只完成静态盘点，没有运行 CAD，宿主状态统一为 `Not run`。
+
+## 11. 完成定义
+
+本迁移不是以“来源文件全部处理”或“公共方法数量接近 451”为完成标准。满足以下条件才可收口：
+
+1. 每个来源文件都已有 `复用现有`、`已重写`、`暂缓` 或 `不迁移` 的明确结论；
+2. 所有迁移能力符合当前目录、命名、事务和对象所有权契约；
+3. 没有引入来源二进制、AutoCAD-only using 泄漏或第二套平行 API；
+4. 自动构建/守卫与要求的真实宿主场景分别记录，未执行项不被包装为通过；
+5. 最终有效的公共行为写入 XML 注释和 current 文档，本文随后转为 `historical`；
+6. 长期分支相对最新 `main` 完成最终集成审查后，才建立合入 `main` 的 PR。
+
+## 12. 下一步
+
+当前最合理的下一批不是搬运 `PolylineUtil.cs`，而是：
+
+1. 完成 MIT 再分发授权确认；
+2. 从 `CurveUtil`、`PolylineUtil`、`RegionUtil` 提炼 5 至 8 个只读几何用例；
+3. 对照实时 `CurveEx`、`PolylineEx`、`RegionEx` 去重，形成 Phase 1 API 草案；
+4. 先补算法测试和所有权测试，再提交第一批代码。
+
+若授权确认尚未完成，可以先推进完全独立的需求规格和测试向量，但不提交可识别的来源实现。

--- a/docs/zfgk-cad-migration-plan.md
+++ b/docs/zfgk-cad-migration-plan.md
@@ -1,15 +1,16 @@
 # Fs.Zfgk.CAD 有价值能力迁移计划
 
 > 稳定 ID：`plan.zfgk-cad-migration`<br>
-> 状态：提案与执行准备（Proposal）<br>
+> 状态：执行中（Active）<br>
 > 目标分支：`migration/zfgk-cad`<br>
 > 来源快照：`FeiSiDev/Fs.Zfgk.CAD@c38ce320c75284536c907c1046e5458da4ae0468`<br>
-> 目标基线：`FsDiG/Fs.Fox.CAD@9faca0a4e420220bd3735de26c63f629564b6dc7`<br>
-> 授权与再分发跟踪：[Issue #105](https://github.com/FsDiG/Fs.Fox.CAD/issues/105)<br>
+> `main` 集成基线：`FsDiG/Fs.Fox.CAD@6e6f94223be418481663833fc65386d8cf2839a4`<br>
+> 当前分支基线：`migration/zfgk-cad@2e68759f710046416f4e27d2c2f87487e4160619`<br>
+> 实施跟踪：[Issue #110](https://github.com/FsDiG/Fs.Fox.CAD/issues/110)<br>
 > 最近复核：2026-08-03<br>
 > CAD 宿主验收：Not run
 
-本文记录从 `Fs.Zfgk.CAD` 向 `Fs.Fox.CAD` 吸收通用 CAD 能力的取舍、目标组织、实施顺序和验收边界。它不把来源仓库的文件结构、类名或实现视为迁移规格；每项代码在落地前仍须重新核对实时源码、ObjectARX/ZRX API、目标分支现状和授权范围。
+本文记录从 `Fs.Zfgk.CAD` 向 `Fs.Fox.CAD` 吸收通用 CAD 能力的取舍、目标组织、实施顺序和验收边界。它不把输入仓库的文件结构、类名或实现视为迁移规格；每项能力在落地前仍须重新核对实时源码、ObjectARX/ZRX/GRX API 和目标分支现状。
 
 ## 1. 结论
 
@@ -55,26 +56,24 @@
 
 ### 2.4 多宿主
 
-- 正式共享代码至少通过 AC_2019、AC_2025、ZW_2022、ZW_2025 四目标编译和兼容性守卫。
+- 正式共享代码至少通过 AC_2019、AC_2025、ZW_2022、ZW_2025、GC_2022、GC_2023、GC_2026 七目标编译和兼容性守卫。
 - `Autodesk.AutoCAD.GraphicsSystem`、COM、native export 或仅 AutoCAD 存在的 API 默认不得进入共享实现。
 - 真实宿主验证优先 ZWCAD 2022，其次 AutoCAD 2020/2026；没有 ZWCAD 2025 宿主不是迁移阻塞项，也不能把编译表述为宿主通过。
+- 当前没有 GStarCAD 真实宿主验收约定；三个 GC 目标只记录 Build-only 结果，不能从编译推断宿主行为。
 - 未经明确批准，不启动 CAD，不修改 profile、Trusted Paths、注册表或启动组。
 
-## 3. 授权与溯源门槛
+## 3. 审查决策与可追溯性
 
-来源仓库当前为 Private，GitHub 未识别到许可证；其 README 写明“基于智帆高科 CAD 类库封装，已经过张帆授权”，多份源码头同时标注“北京智帆高科科技有限公司版权所有”。目标仓库公开并采用 MIT License。因此，在复制源码或提交可识别的改写实现前，必须在 [Issue #105](https://github.com/FsDiG/Fs.Fox.CAD/issues/105) 确认现有授权明确覆盖：
+维护者已于 2026-08-03 明确：本迁移不把源代码来源或许可核对作为能力审查和实施门槛。Issue #105 继续独立审计当前 `main` 的既有第三方代码，不阻塞本计划；迁移范围、取舍和验收统一由 [Issue #110](https://github.com/FsDiG/Fs.Fox.CAD/issues/110) 跟踪。
 
-1. 把相关实现并入公开的 `Fs.Fox.CAD`；
-2. 修改、发布和分发这些实现；
-3. 按目标仓库 MIT License 允许下游继续使用和再分发。
+固定输入快照只用于保证“审查了什么”可以复核，不决定目标代码的目录、类型或 API。每个代码批次仍需记录：
 
-授权确认应在关联 Issue 中留下可追溯结论；敏感原件不必提交仓库。若授权只允许内部使用，则公开仓库只能保留功能需求和独立设计，不复制实现。若授权范围不能确定，则停止对应代码迁移，但不影响本清单继续用于去重和需求分析。
+- 对应的输入文件和能力，以便核对 49 文件清单是否遗漏；
+- 目标库中的既有等价实现、实际增量和最终所有权位置；
+- 已修正的旧实现缺陷，以及新增 API 的容差、资源所有权和多宿主边界；
+- 自动验证和真实 CAD 宿主验证分别执行了什么，未执行项明确写为 `Not run`。
 
-每个实际迁移 PR 需在正文中记录来源文件、来源提交和处理方式：
-
-- `adapted`：确认授权后基于来源实现改写，并保留必要版权归属；
-- `clean implementation`：仅采用公开需求/接口事实，由目标契约独立实现；
-- `existing equivalent`：确认目标已有能力，不引入来源代码。
+当前调用情况不作为通用类库价值判断依据。某项能力没有现成调用方时，仍按通用性和契约质量评估；没有增量价值或无法形成可靠契约时，也不为追求迁移数量而加入平行 API。
 
 ## 4. 评估方法
 
@@ -200,16 +199,16 @@
 
 ## 8. 分阶段实施
 
-### Phase 0：基线、授权和去重
+### Phase 0：基线和去重
 
 - [x] 从最新 `main` 建立 `migration/zfgk-cad`。
 - [x] 固定来源/目标 commit，完成 49 个 C# 文件的首轮清单。
 - [x] 记录现有等价 API、外部依赖和已知风险。
-- [x] 将授权与再分发门槛关联到 Issue #105。
-- [ ] 确认授权是否覆盖公开 MIT 再分发，并在关联 Issue 留下结论。
+- [x] 明确来源核对不作为本迁移实施门槛；Issue #105 与本计划解耦。
+- [x] 创建实施总跟踪 Issue #110。
 - [ ] 为第一批候选写具体 API 草案和测试样例，确认没有与实时 `main` 重复。
 
-Phase 0 只允许文档和验证基础设施变更。授权未确认前，不直接复制或改写带来源版权的实现。
+Phase 0 的清单和结构决策已经完成。后续每个代码批次必须回写本文的最终结论，不能只在 PR 对话中记录取舍。
 
 ### Phase 1：只读几何查询
 
@@ -277,7 +276,7 @@ DWG 图像预览、复杂自绘表格、结果定位窗体等不能搭便车进�
 - `pwsh -File Build/Verify-CADSharedModuleMap.ps1`
 - `pwsh -File tools/verification/Test-CADSharedTypeDefSequence.ps1`
 - `pwsh -File Build/Verify-CADSharedCompatibility.ps1`
-- AC_2019、AC_2025、ZW_2022、ZW_2025 Release 构建
+- AC_2019、AC_2025、ZW_2022、ZW_2025、GC_2022、GC_2023、GC_2026 Release 构建
 - 新 Markdown 相对链接和 GitHub Flavored Markdown 渲染检查
 
 新增编译文件时，在 `CADShared.projitems` 中填写正确的 `FsFoxModule`/`FsFoxOrder`，并通过守卫提供的更新流程同步模块基线；不能手工绕过预期计数或把新边界债务静默加入白名单。
@@ -318,11 +317,9 @@ DWG 图像预览、复杂自绘表格、结果定位窗体等不能搭便车进�
 
 ## 12. 下一步
 
-当前最合理的下一批不是搬运 `PolylineUtil.cs`，而是：
+当前最合理的下一批不是整体搬运 `PolylineUtil.cs`，而是：
 
-1. 完成 MIT 再分发授权确认；
-2. 从 `CurveUtil`、`PolylineUtil`、`RegionUtil` 提炼 5 至 8 个只读几何用例；
-3. 对照实时 `CurveEx`、`PolylineEx`、`RegionEx` 去重，形成 Phase 1 API 草案；
-4. 先补算法测试和所有权测试，再提交第一批代码。
-
-若授权确认尚未完成，可以先推进完全独立的需求规格和测试向量，但不提交可识别的来源实现。
+1. 从 `CurveUtil`、`PolylineUtil`、`LineUtil` 提炼 5 至 8 个只读几何用例；
+2. 对照实时 `CurveEx`、`PolylineEx`、`PointEx` 去重，形成 Phase 1 API 草案；
+3. 先补可确定验证的算法测试，再提交第一批代码；
+4. 将每项实际结果回写第 6 节并关联 Issue #110。

--- a/docs/zfgk-cad-migration-plan.md
+++ b/docs/zfgk-cad-migration-plan.md
@@ -226,7 +226,7 @@ Phase 0 的清单和结构决策已经完成。后续每个代码批次必须回
 | --- | --- | --- |
 | `CurveEx` | `GetPointAtDistanceFraction` | 按总长闭区间 `[0, 1]` 取点；修正旧实现忽略输入比例、固定取 `0.5` 的问题，并拒绝无限长度域。 |
 | `CurveEx` | `GetMidpointChordDeviation` | 明确按参数中点计算三维弦偏差，不把结果表述为区间最大误差。 |
-| `CurveEx` | `GetMidpointChordDeviationByDistance` | 明确按沿曲线距离中点计算，避免把距离端点转参数后误用参数中点；曲线本身没有有限且有序的参数或距离范围时明确失败。 |
+| `CurveEx` | `GetMidpointChordDeviationByDistance` | 明确按沿曲线距离中点计算，避免把距离端点转参数后误用参数中点；`Ray`、`Xline` 及其他没有有限且有序参数或距离范围的曲线明确失败。 |
 | `PolylineEx` | `GetVertexData` | 一次取得顶点、bulge、起宽和终宽的独立托管快照，不暴露 `ref` 集合。 |
 | `PolylineEx` | `GetSegmentLength` | 对开放/闭合折线验证真实子段索引；直线返回线长，圆弧返回弧长。 |
 | `PointEx` | `InterpolateTo` | 使用闭区间 `[0, 1]` 的三维线性插值，非法比例抛出明确异常。 |

--- a/docs/zfgk-cad-migration-plan.md
+++ b/docs/zfgk-cad-migration-plan.md
@@ -4,8 +4,7 @@
 > 状态：执行中（Active）<br>
 > 目标分支：`migration/zfgk-cad`<br>
 > 来源快照：`FeiSiDev/Fs.Zfgk.CAD@c38ce320c75284536c907c1046e5458da4ae0468`<br>
-> `main` 集成基线：`FsDiG/Fs.Fox.CAD@6e6f94223be418481663833fc65386d8cf2839a4`<br>
-> 当前分支基线：`migration/zfgk-cad@2e68759f710046416f4e27d2c2f87487e4160619`<br>
+> 最近 `main` 集成：`origin/main@6e6f94223be418481663833fc65386d8cf2839a4` 已由 `2e68759f710046416f4e27d2c2f87487e4160619` 合入<br>
 > 实施跟踪：[Issue #110](https://github.com/FsDiG/Fs.Fox.CAD/issues/110)<br>
 > 最近复核：2026-08-03<br>
 > CAD 宿主验收：Not run
@@ -147,13 +146,13 @@
 | `ObjectARX/Entity/ArcUtil.cs` | 反转圆弧可由厂商曲线 API表达；旧实现直接改 Normal/角度，需额外验证非 XY 平面。 | 不直接迁移。 |
 | `ObjectARX/Entity/BlockUtil.cs` | 块导入、插入和属性大多已有等价实现；“选定实体导出 DWG”仍可能有增量价值。 | 部分候选；仅评估缺失的导出契约和属性度量。 |
 | `ObjectARX/Entity/CircleUtil.cs` | 仅构造并入库，现有实体添加 API 足够。 | 不迁移。 |
-| `ObjectARX/Entity/CurveUtil.cs` | 子曲线、弦高、归一化位置、偏移和交点查询具有通用价值；旧实现对返回对象的释放和异常处理不完整。 | 高优先候选；拆为只读计算、返回新对象、数据库修改三个批次。 |
+| `ObjectARX/Entity/CurveUtil.cs` | 子曲线、弦高、归一化位置、偏移和交点查询具有通用价值；旧实现对返回对象的释放和异常处理不完整。 | 部分已吸收：Phase 1 批次 1 已加入长度比例取点和两种中点弦偏差；返回新对象和数据库修改仍按后续批次处理。 |
 | `ObjectARX/Entity/DimensionUtil.cs` | 旋转标注构造简单，未形成独特抽象。 | 低优先条件候选；有重复消费者时再加入窄扩展。 |
 | `ObjectARX/Entity/EntityUtil.cs` | 擦除、变换、颜色、包围盒和克隆大多已有等价实现。 | 复用现有实现；块属性克隆随 Block 项评估。 |
 | `ObjectARX/Entity/HatchUtil.cs` | 已有 `HatchEx`、`HatchConverter` 和边界创建能力；来源还依赖外部工具。 | 不迁移平行 API。 |
-| `ObjectARX/Entity/LineUtil.cs` | 方位、点线距离和插值有通用价值；相交状态和高程插值旧实现存在语义/结果问题。 | 部分候选；采用明确枚举/结果类型和退化线契约重写。 |
+| `ObjectARX/Entity/LineUtil.cs` | 方位、点线距离和插值有通用价值；相交状态和高程插值旧实现存在语义/结果问题。 | 部分已吸收：Phase 1 批次 1 已在 `PointEx` 加入比例插值和高程唯一点查询；方位/相交与修改操作继续去重。 |
 | `ObjectARX/Entity/PolyfaceMeshUtil.cs` | 仅创建网格并入库，现有实体添加机制可组合完成。 | 不迁移。 |
-| `ObjectARX/Entity/PolylineUtil.cs` | 连接、采样、分段、圆角、去零段和去共线点是本次最有价值的来源之一；旧实现同时操作事务、UI、对象释放和原位修改。 | 高优先候选；按“查询 -> 创建新对象 -> 原位修改 -> 批量数据库操作”四层重写。 |
+| `ObjectARX/Entity/PolylineUtil.cs` | 连接、采样、分段、圆角、去零段和去共线点是本次最有价值的来源之一；旧实现同时操作事务、UI、对象释放和原位修改。 | 部分已吸收：Phase 1 批次 1 已加入完整顶点数据快照和单段长度；采样、创建新对象和修改操作继续分层处理。 |
 | `ObjectARX/Entity/RegionUtil.cs` | `Explode` 后转折线并连接可为 `RegionEx.ToCurves()` 提供替代思路，但旧实现泄漏临时对象且没有内外环/方向契约。 | 高优先设计输入；与 Region 所有权和 ZWCAD BRep 路径统一处理。 |
 | `ObjectARX/Entity/TextUtil.cs` | 添加文字、文字样式和去格式化大多已有实现；文字边界度量可能有宿主差异。 | 复用现有实现；度量需求单独验证。 |
 | `ObjectARX/Entity/XDataUtil.cs` | 已由 `TypedValueList`、`XDataList`、`DBObjectEx` 和选择过滤体系覆盖。 | 复用现有实现。 |
@@ -206,7 +205,7 @@
 - [x] 记录现有等价 API、外部依赖和已知风险。
 - [x] 明确来源核对不作为本迁移实施门槛；Issue #105 与本计划解耦。
 - [x] 创建实施总跟踪 Issue #110。
-- [ ] 为第一批候选写具体 API 草案和测试样例，确认没有与实时 `main` 重复。
+- [x] 为第一批候选写具体 API 草案，确认没有与实时 `main` 重复。
 
 Phase 0 的清单和结构决策已经完成。后续每个代码批次必须回写本文的最终结论，不能只在 PR 对话中记录取舍。
 
@@ -220,6 +219,20 @@ Phase 0 的清单和结构决策已经完成。后续每个代码批次必须回
 - Extents/Rect 的关系和相交簇合并。
 
 约束：不写数据库、不依赖活动文档、不原位修改输入、不弹 UI。先增加测试，再增加公共 API；每个返回的新 CAD 对象都写明释放责任。
+
+批次 1 的 API 决定如下；它们都只返回值或托管快照，不创建需要调用方释放的 CAD 对象：
+
+| 目标类型 | API | 吸收的价值与契约修正 |
+| --- | --- | --- |
+| `CurveEx` | `GetPointAtDistanceFraction` | 按总长闭区间 `[0, 1]` 取点；修正旧实现忽略输入比例、固定取 `0.5` 的问题，并拒绝无限长度域。 |
+| `CurveEx` | `GetMidpointChordDeviation` | 明确按参数中点计算三维弦偏差，不把结果表述为区间最大误差。 |
+| `CurveEx` | `GetMidpointChordDeviationByDistance` | 明确按沿曲线距离中点计算，避免把距离端点转参数后误用参数中点。 |
+| `PolylineEx` | `GetVertexData` | 一次取得顶点、bulge、起宽和终宽的独立托管快照，不暴露 `ref` 集合。 |
+| `PolylineEx` | `GetSegmentLength` | 对开放/闭合折线验证真实子段索引；直线返回线长，圆弧返回弧长。 |
+| `PointEx` | `InterpolateTo` | 使用闭区间 `[0, 1]` 的三维线性插值，非法比例抛出明确异常。 |
+| `PointEx` | `TryInterpolateAtElevation` | 只在非水平线段内存在唯一高程点时成功；修正旧实现把结果 Z 固定为 `0` 的错误，不引入隐式容差。 |
+
+批次 1 提供宿主内确定性验收命令 `Test_GeometryQuery`，覆盖直线、半圆、开放/闭合折线和高程插值边界。AC_2019、AC_2025、ZW_2022、ZW_2025、GC_2022、GC_2023、GC_2026 的 Release 库和测试程序集均已通过直接构建，模块、兼容性和 TypeDef 顺序守卫通过；这只是 Build-only 证据，命令尚未在 CAD 中执行，真实宿主状态为 `Not run`。折线按距离/弦偏差采样、点在线段左右关系和范围聚类尚未计入本批完成范围。
 
 ### Phase 2：点网格索引
 

--- a/src/CADShared/CADShared.projitems
+++ b/src/CADShared/CADShared.projitems
@@ -615,6 +615,10 @@
       <FsFoxModule>Cad.Editor</FsFoxModule>
       <FsFoxOrder>0962</FsFoxOrder>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Cad\Geometry\SpatialIndex\Grid\PointGridIndex.cs">
+      <FsFoxModule>Cad.Geometry</FsFoxModule>
+      <FsFoxOrder>0970</FsFoxOrder>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="$(MSBuildThisFileDirectory)ExtensionMethod\Geometry\ToDo\" />

--- a/src/CADShared/Cad/Database/Entities/Curves/CurveEx.cs
+++ b/src/CADShared/Cad/Database/Entities/Curves/CurveEx.cs
@@ -35,18 +35,21 @@ public static class CurveEx
         ArgumentNullException.ThrowIfNull(curve);
         if (double.IsNaN(fraction) || double.IsInfinity(fraction) || fraction < 0 || fraction > 1)
             throw new ArgumentOutOfRangeException(nameof(fraction), fraction, "The fraction must be in [0, 1].");
+        if (curve is Ray || curve is Xline)
+            throw new InvalidOperationException("The curve does not have a finite total length.");
 
         var startParameter = curve.StartParam;
         var endParameter = curve.EndParam;
         if (double.IsNaN(startParameter) || double.IsInfinity(startParameter) ||
-            double.IsNaN(endParameter) || double.IsInfinity(endParameter))
+            double.IsNaN(endParameter) || double.IsInfinity(endParameter) ||
+            endParameter < startParameter)
         {
-            throw new InvalidOperationException("The curve does not have a finite parameter range.");
+            throw new InvalidOperationException("The curve does not have a finite, ordered parameter range.");
         }
 
         var startDistance = curve.GetDistanceAtParameter(startParameter);
         var endDistance = curve.GetDistanceAtParameter(endParameter);
-        if (double.IsNaN(startDistance) || double.IsInfinity(startDistance) ||
+        if (double.IsNaN(startDistance) || double.IsInfinity(startDistance) || startDistance < 0 ||
             double.IsNaN(endDistance) || double.IsInfinity(endDistance) ||
             endDistance < startDistance)
         {
@@ -69,6 +72,7 @@ public static class CurveEx
     /// </summary>
     /// <remarks>
     /// 返回曲线参数中点与区间端点弦中点之间的三维距离；该值不是区间内的最大偏差。
+    /// <see cref="Ray"/> 的参数区间必须位于 [0, +∞)，<see cref="Xline"/> 支持任意有限参数区间。
     /// </remarks>
     /// <param name="curve">曲线</param>
     /// <param name="startParameter">区间起始参数</param>
@@ -76,6 +80,7 @@ public static class CurveEx
     /// <returns>参数中点处的弦偏差</returns>
     /// <exception cref="ArgumentNullException"><paramref name="curve"/> 为 <see langword="null"/></exception>
     /// <exception cref="ArgumentOutOfRangeException">参数不是有限数、顺序错误或超出曲线参数域</exception>
+    /// <exception cref="InvalidOperationException">有界曲线没有有限且有序的参数域</exception>
     public static double GetMidpointChordDeviation(this Curve curve, double startParameter, double endParameter)
     {
         ArgumentNullException.ThrowIfNull(curve);
@@ -85,8 +90,30 @@ public static class CurveEx
             throw new ArgumentOutOfRangeException(nameof(endParameter), endParameter, "The parameter must be finite.");
         if (startParameter > endParameter)
             throw new ArgumentOutOfRangeException(nameof(endParameter), endParameter, "The end parameter must not precede the start parameter.");
-        if (startParameter < curve.StartParam || endParameter > curve.EndParam)
-            throw new ArgumentOutOfRangeException(nameof(startParameter), "The parameter interval must be inside the curve domain.");
+        if (curve is Ray)
+        {
+            if (startParameter < 0)
+                throw new ArgumentOutOfRangeException(nameof(startParameter), startParameter,
+                    "The ray parameter interval must start at or after zero.");
+        }
+        else if (!(curve is Xline))
+        {
+            var curveStartParameter = curve.StartParam;
+            var curveEndParameter = curve.EndParam;
+            if (double.IsNaN(curveStartParameter) || double.IsInfinity(curveStartParameter) ||
+                double.IsNaN(curveEndParameter) || double.IsInfinity(curveEndParameter) ||
+                curveEndParameter < curveStartParameter)
+            {
+                throw new InvalidOperationException("The curve does not have a finite, ordered parameter range.");
+            }
+
+            if (startParameter < curveStartParameter)
+                throw new ArgumentOutOfRangeException(nameof(startParameter), startParameter,
+                    "The start parameter must be inside the curve domain.");
+            if (endParameter > curveEndParameter)
+                throw new ArgumentOutOfRangeException(nameof(endParameter), endParameter,
+                    "The end parameter must be inside the curve domain.");
+        }
 
         var startPoint = curve.GetPointAtParameter(startParameter);
         var endPoint = curve.GetPointAtParameter(endParameter);
@@ -101,7 +128,8 @@ public static class CurveEx
     /// </summary>
     /// <remarks>
     /// 距离从曲线起点沿曲线测量。返回距离中点与区间端点弦中点之间的三维距离；
-    /// 该值不是区间内的最大偏差。无有限总长的 <see cref="Ray"/> 和 <see cref="Xline"/> 不受支持。
+    /// 该值不是区间内的最大偏差。<see cref="Ray"/> 以基点为距离起点并支持有限非负区间；
+    /// <see cref="Xline"/> 没有曲线起点，因此不受支持。
     /// </remarks>
     /// <param name="curve">曲线</param>
     /// <param name="startDistance">区间起始距离</param>
@@ -109,7 +137,7 @@ public static class CurveEx
     /// <returns>距离中点处的弦偏差</returns>
     /// <exception cref="ArgumentNullException"><paramref name="curve"/> 为 <see langword="null"/></exception>
     /// <exception cref="ArgumentOutOfRangeException">距离不是有限数、顺序错误或超出曲线长度范围</exception>
-    /// <exception cref="InvalidOperationException">曲线没有有限且有序的参数或距离范围</exception>
+    /// <exception cref="InvalidOperationException">曲线没有距离起点，或没有有限且有序的参数或距离范围</exception>
     public static double GetMidpointChordDeviationByDistance(this Curve curve, double startDistance, double endDistance)
     {
         ArgumentNullException.ThrowIfNull(curve);
@@ -119,28 +147,43 @@ public static class CurveEx
             throw new ArgumentOutOfRangeException(nameof(endDistance), endDistance, "The distance must be finite.");
         if (startDistance > endDistance)
             throw new ArgumentOutOfRangeException(nameof(endDistance), endDistance, "The end distance must not precede the start distance.");
-        if (curve is Ray || curve is Xline)
-            throw new InvalidOperationException("The curve must have a finite parameter and distance range.");
+        if (curve is Xline)
+            throw new InvalidOperationException("An Xline has no curve start from which to measure distance.");
 
-        var curveStartParameter = curve.StartParam;
-        var curveEndParameter = curve.EndParam;
-        if (double.IsNaN(curveStartParameter) || double.IsInfinity(curveStartParameter) ||
-            double.IsNaN(curveEndParameter) || double.IsInfinity(curveEndParameter))
+        if (curve is Ray)
         {
-            throw new InvalidOperationException("The curve does not have a finite parameter range.");
+            if (startDistance < 0)
+                throw new ArgumentOutOfRangeException(nameof(startDistance), startDistance,
+                    "The ray distance interval must start at or after zero.");
         }
-
-        var curveStartDistance = curve.GetDistanceAtParameter(curveStartParameter);
-        var curveEndDistance = curve.GetDistanceAtParameter(curveEndParameter);
-        if (double.IsNaN(curveStartDistance) || double.IsInfinity(curveStartDistance) ||
-            double.IsNaN(curveEndDistance) || double.IsInfinity(curveEndDistance) ||
-            curveEndDistance < curveStartDistance)
+        else
         {
-            throw new InvalidOperationException("The curve does not have a finite, non-negative distance range.");
-        }
+            var curveStartParameter = curve.StartParam;
+            var curveEndParameter = curve.EndParam;
+            if (double.IsNaN(curveStartParameter) || double.IsInfinity(curveStartParameter) ||
+                double.IsNaN(curveEndParameter) || double.IsInfinity(curveEndParameter) ||
+                curveEndParameter < curveStartParameter)
+            {
+                throw new InvalidOperationException("The curve does not have a finite, ordered parameter range.");
+            }
 
-        if (startDistance < curveStartDistance || endDistance > curveEndDistance)
-            throw new ArgumentOutOfRangeException(nameof(startDistance), "The distance interval must be inside the curve range.");
+            var curveStartDistance = curve.GetDistanceAtParameter(curveStartParameter);
+            var curveEndDistance = curve.GetDistanceAtParameter(curveEndParameter);
+            if (double.IsNaN(curveStartDistance) || double.IsInfinity(curveStartDistance) ||
+                curveStartDistance < 0 ||
+                double.IsNaN(curveEndDistance) || double.IsInfinity(curveEndDistance) ||
+                curveEndDistance < curveStartDistance)
+            {
+                throw new InvalidOperationException("The curve does not have a finite, non-negative distance range.");
+            }
+
+            if (startDistance < curveStartDistance)
+                throw new ArgumentOutOfRangeException(nameof(startDistance), startDistance,
+                    "The start distance must be inside the curve range.");
+            if (endDistance > curveEndDistance)
+                throw new ArgumentOutOfRangeException(nameof(endDistance), endDistance,
+                    "The end distance must be inside the curve range.");
+        }
 
         var startPoint = curve.GetPointAtDist(startDistance);
         var endPoint = curve.GetPointAtDist(endDistance);

--- a/src/CADShared/Cad/Database/Entities/Curves/CurveEx.cs
+++ b/src/CADShared/Cad/Database/Entities/Curves/CurveEx.cs
@@ -21,6 +21,117 @@ public static class CurveEx
         return curve.GetDistanceAtParameter(curve.EndParam);
     }
 
+    /// <summary>
+    /// 按曲线总长的比例获取点
+    /// </summary>
+    /// <param name="curve">曲线</param>
+    /// <param name="fraction">从起点计算的长度比例，取值范围为闭区间 [0, 1]</param>
+    /// <returns>指定长度比例处的点</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="curve"/> 为 <see langword="null"/></exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="fraction"/> 不是有限数或超出 [0, 1]</exception>
+    /// <exception cref="InvalidOperationException">曲线没有有限且非负的长度范围</exception>
+    public static Point3d GetPointAtDistanceFraction(this Curve curve, double fraction)
+    {
+        ArgumentNullException.ThrowIfNull(curve);
+        if (double.IsNaN(fraction) || double.IsInfinity(fraction) || fraction < 0 || fraction > 1)
+            throw new ArgumentOutOfRangeException(nameof(fraction), fraction, "The fraction must be in [0, 1].");
+
+        var startParameter = curve.StartParam;
+        var endParameter = curve.EndParam;
+        if (double.IsNaN(startParameter) || double.IsInfinity(startParameter) ||
+            double.IsNaN(endParameter) || double.IsInfinity(endParameter))
+        {
+            throw new InvalidOperationException("The curve does not have a finite parameter range.");
+        }
+
+        var startDistance = curve.GetDistanceAtParameter(startParameter);
+        var endDistance = curve.GetDistanceAtParameter(endParameter);
+        if (double.IsNaN(startDistance) || double.IsInfinity(startDistance) ||
+            double.IsNaN(endDistance) || double.IsInfinity(endDistance) ||
+            endDistance < startDistance)
+        {
+            throw new InvalidOperationException("The curve does not have a finite, non-negative distance range.");
+        }
+
+        if (fraction == 0)
+            return curve.StartPoint;
+        if (fraction == 1)
+            return curve.EndPoint;
+        if (endDistance == startDistance)
+            return curve.StartPoint;
+
+        var distance = startDistance * (1 - fraction) + endDistance * fraction;
+        return curve.GetPointAtDist(distance);
+    }
+
+    /// <summary>
+    /// 计算参数区间中点处的弦偏差
+    /// </summary>
+    /// <remarks>
+    /// 返回曲线参数中点与区间端点弦中点之间的三维距离；该值不是区间内的最大偏差。
+    /// </remarks>
+    /// <param name="curve">曲线</param>
+    /// <param name="startParameter">区间起始参数</param>
+    /// <param name="endParameter">区间结束参数，必须大于或等于起始参数</param>
+    /// <returns>参数中点处的弦偏差</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="curve"/> 为 <see langword="null"/></exception>
+    /// <exception cref="ArgumentOutOfRangeException">参数不是有限数、顺序错误或超出曲线参数域</exception>
+    public static double GetMidpointChordDeviation(this Curve curve, double startParameter, double endParameter)
+    {
+        ArgumentNullException.ThrowIfNull(curve);
+        if (double.IsNaN(startParameter) || double.IsInfinity(startParameter))
+            throw new ArgumentOutOfRangeException(nameof(startParameter), startParameter, "The parameter must be finite.");
+        if (double.IsNaN(endParameter) || double.IsInfinity(endParameter))
+            throw new ArgumentOutOfRangeException(nameof(endParameter), endParameter, "The parameter must be finite.");
+        if (startParameter > endParameter)
+            throw new ArgumentOutOfRangeException(nameof(endParameter), endParameter, "The end parameter must not precede the start parameter.");
+        if (startParameter < curve.StartParam || endParameter > curve.EndParam)
+            throw new ArgumentOutOfRangeException(nameof(startParameter), "The parameter interval must be inside the curve domain.");
+
+        var startPoint = curve.GetPointAtParameter(startParameter);
+        var endPoint = curve.GetPointAtParameter(endParameter);
+        var chordMidpoint = startPoint.GetMidPointTo(endPoint);
+        var midpointParameter = startParameter * 0.5 + endParameter * 0.5;
+        var curveMidpoint = curve.GetPointAtParameter(midpointParameter);
+        return chordMidpoint.DistanceTo(curveMidpoint);
+    }
+
+    /// <summary>
+    /// 计算距离区间中点处的弦偏差
+    /// </summary>
+    /// <remarks>
+    /// 距离从曲线起点沿曲线测量。返回距离中点与区间端点弦中点之间的三维距离；
+    /// 该值不是区间内的最大偏差。
+    /// </remarks>
+    /// <param name="curve">曲线</param>
+    /// <param name="startDistance">区间起始距离</param>
+    /// <param name="endDistance">区间结束距离，必须大于或等于起始距离</param>
+    /// <returns>距离中点处的弦偏差</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="curve"/> 为 <see langword="null"/></exception>
+    /// <exception cref="ArgumentOutOfRangeException">距离不是有限数、顺序错误或超出曲线长度范围</exception>
+    public static double GetMidpointChordDeviationByDistance(this Curve curve, double startDistance, double endDistance)
+    {
+        ArgumentNullException.ThrowIfNull(curve);
+        if (double.IsNaN(startDistance) || double.IsInfinity(startDistance))
+            throw new ArgumentOutOfRangeException(nameof(startDistance), startDistance, "The distance must be finite.");
+        if (double.IsNaN(endDistance) || double.IsInfinity(endDistance))
+            throw new ArgumentOutOfRangeException(nameof(endDistance), endDistance, "The distance must be finite.");
+        if (startDistance > endDistance)
+            throw new ArgumentOutOfRangeException(nameof(endDistance), endDistance, "The end distance must not precede the start distance.");
+
+        var curveStartDistance = curve.GetDistanceAtParameter(curve.StartParam);
+        var curveEndDistance = curve.GetDistanceAtParameter(curve.EndParam);
+        if (startDistance < curveStartDistance || endDistance > curveEndDistance)
+            throw new ArgumentOutOfRangeException(nameof(startDistance), "The distance interval must be inside the curve range.");
+
+        var startPoint = curve.GetPointAtDist(startDistance);
+        var endPoint = curve.GetPointAtDist(endDistance);
+        var chordMidpoint = startPoint.GetMidPointTo(endPoint);
+        var midpointDistance = startDistance * 0.5 + endDistance * 0.5;
+        var curveMidpoint = curve.GetPointAtDist(midpointDistance);
+        return chordMidpoint.DistanceTo(curveMidpoint);
+    }
+
     /*/// <summary>
     /// 获取分割曲线集合
     /// </summary>

--- a/src/CADShared/Cad/Database/Entities/Curves/CurveEx.cs
+++ b/src/CADShared/Cad/Database/Entities/Curves/CurveEx.cs
@@ -24,12 +24,13 @@ public static class CurveEx
     /// <summary>
     /// 按曲线总长的比例获取点
     /// </summary>
+    /// <remarks>没有有限总长的 <see cref="Ray"/> 和 <see cref="Xline"/> 不受支持。</remarks>
     /// <param name="curve">曲线</param>
     /// <param name="fraction">从起点计算的长度比例，取值范围为闭区间 [0, 1]</param>
     /// <returns>指定长度比例处的点</returns>
     /// <exception cref="ArgumentNullException"><paramref name="curve"/> 为 <see langword="null"/></exception>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="fraction"/> 不是有限数或超出 [0, 1]</exception>
-    /// <exception cref="InvalidOperationException">曲线没有有限且非负的长度范围</exception>
+    /// <exception cref="InvalidOperationException">曲线没有有限总长，参数域不是有限且有序的，或距离范围不是有限、非负且有序的</exception>
     public static Point3d GetPointAtDistanceFraction(this Curve curve, double fraction)
     {
         ArgumentNullException.ThrowIfNull(curve);

--- a/src/CADShared/Cad/Database/Entities/Curves/CurveEx.cs
+++ b/src/CADShared/Cad/Database/Entities/Curves/CurveEx.cs
@@ -101,7 +101,7 @@ public static class CurveEx
     /// </summary>
     /// <remarks>
     /// 距离从曲线起点沿曲线测量。返回距离中点与区间端点弦中点之间的三维距离；
-    /// 该值不是区间内的最大偏差。
+    /// 该值不是区间内的最大偏差。无有限总长的 <see cref="Ray"/> 和 <see cref="Xline"/> 不受支持。
     /// </remarks>
     /// <param name="curve">曲线</param>
     /// <param name="startDistance">区间起始距离</param>
@@ -119,6 +119,8 @@ public static class CurveEx
             throw new ArgumentOutOfRangeException(nameof(endDistance), endDistance, "The distance must be finite.");
         if (startDistance > endDistance)
             throw new ArgumentOutOfRangeException(nameof(endDistance), endDistance, "The end distance must not precede the start distance.");
+        if (curve is Ray || curve is Xline)
+            throw new InvalidOperationException("The curve must have a finite parameter and distance range.");
 
         var curveStartParameter = curve.StartParam;
         var curveEndParameter = curve.EndParam;

--- a/src/CADShared/Cad/Database/Entities/Curves/CurveEx.cs
+++ b/src/CADShared/Cad/Database/Entities/Curves/CurveEx.cs
@@ -109,6 +109,7 @@ public static class CurveEx
     /// <returns>距离中点处的弦偏差</returns>
     /// <exception cref="ArgumentNullException"><paramref name="curve"/> 为 <see langword="null"/></exception>
     /// <exception cref="ArgumentOutOfRangeException">距离不是有限数、顺序错误或超出曲线长度范围</exception>
+    /// <exception cref="InvalidOperationException">曲线没有有限且有序的参数或距离范围</exception>
     public static double GetMidpointChordDeviationByDistance(this Curve curve, double startDistance, double endDistance)
     {
         ArgumentNullException.ThrowIfNull(curve);
@@ -119,8 +120,23 @@ public static class CurveEx
         if (startDistance > endDistance)
             throw new ArgumentOutOfRangeException(nameof(endDistance), endDistance, "The end distance must not precede the start distance.");
 
-        var curveStartDistance = curve.GetDistanceAtParameter(curve.StartParam);
-        var curveEndDistance = curve.GetDistanceAtParameter(curve.EndParam);
+        var curveStartParameter = curve.StartParam;
+        var curveEndParameter = curve.EndParam;
+        if (double.IsNaN(curveStartParameter) || double.IsInfinity(curveStartParameter) ||
+            double.IsNaN(curveEndParameter) || double.IsInfinity(curveEndParameter))
+        {
+            throw new InvalidOperationException("The curve does not have a finite parameter range.");
+        }
+
+        var curveStartDistance = curve.GetDistanceAtParameter(curveStartParameter);
+        var curveEndDistance = curve.GetDistanceAtParameter(curveEndParameter);
+        if (double.IsNaN(curveStartDistance) || double.IsInfinity(curveStartDistance) ||
+            double.IsNaN(curveEndDistance) || double.IsInfinity(curveEndDistance) ||
+            curveEndDistance < curveStartDistance)
+        {
+            throw new InvalidOperationException("The curve does not have a finite, non-negative distance range.");
+        }
+
         if (startDistance < curveStartDistance || endDistance > curveEndDistance)
             throw new ArgumentOutOfRangeException(nameof(startDistance), "The distance interval must be inside the curve range.");
 

--- a/src/CADShared/Cad/Database/Entities/Curves/Polylines/PolylineEx.cs
+++ b/src/CADShared/Cad/Database/Entities/Curves/Polylines/PolylineEx.cs
@@ -5,6 +5,8 @@ namespace Fs.Fox.Cad;
 /// </summary>
 public static class PolylineEx
 {
+    private const int MaximumSamplePointCount = 1_000_000;
+
     #region 获取多段线端点
 
     /// <summary>
@@ -107,7 +109,7 @@ public static class PolylineEx
     /// <returns>按折线行进方向排列的采样点快照</returns>
     /// <exception cref="ArgumentNullException"><paramref name="pl"/> 为 <see langword="null"/></exception>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="maximumSpacing"/> 不是有限正数</exception>
-    /// <exception cref="InvalidOperationException">折线距离域无效，或阈值要求的细分数量无法表示</exception>
+    /// <exception cref="InvalidOperationException">折线距离域无效、阈值要求的细分数量无法表示，或结果将超过 1,000,000 个点</exception>
     public static IReadOnlyList<Point3d> GetSamplePointsByDistance(this Polyline pl, double maximumSpacing)
     {
         if (pl is null)
@@ -130,7 +132,7 @@ public static class PolylineEx
     /// <returns>按折线行进方向排列的采样点快照</returns>
     /// <exception cref="ArgumentNullException"><paramref name="pl"/> 为 <see langword="null"/></exception>
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="maximumChordDeviation"/> 不是有限正数</exception>
-    /// <exception cref="InvalidOperationException">圆弧或折线距离域无效，或阈值要求的细分数量无法表示</exception>
+    /// <exception cref="InvalidOperationException">圆弧或折线距离域无效、阈值要求的细分数量无法表示，或结果将超过 1,000,000 个点</exception>
     public static IReadOnlyList<Point3d> GetSamplePointsByChordDeviation(this Polyline pl,
         double maximumChordDeviation)
     {
@@ -170,8 +172,17 @@ public static class PolylineEx
         if (vertexCount == 0)
             return Array.Empty<Point3d>();
 
-        var points = new List<Point3d> { pl.GetPoint3dAt(0) };
         var segmentCount = GetSegmentCount(pl);
+        if (segmentCount > MaximumSamplePointCount - 1)
+        {
+            throw new InvalidOperationException(
+                $"The requested sampling would contain more than {MaximumSamplePointCount} points.");
+        }
+
+        var startDistances = new double[segmentCount];
+        var endDistances = new double[segmentCount];
+        var subdivisionCounts = new int[segmentCount];
+        var totalPointCount = 1;
         for (var segmentIndex = 0; segmentIndex < segmentCount; segmentIndex++)
         {
             var startDistance = pl.GetDistanceAtParameter(segmentIndex);
@@ -187,6 +198,24 @@ public static class PolylineEx
             var subdivisionCount = getSubdivisionCount(segmentIndex, segmentLength);
             if (subdivisionCount < 1)
                 throw new InvalidOperationException("The subdivision count must be positive.");
+            if (subdivisionCount > MaximumSamplePointCount - totalPointCount)
+            {
+                throw new InvalidOperationException(
+                    $"The requested sampling would contain more than {MaximumSamplePointCount} points.");
+            }
+
+            startDistances[segmentIndex] = startDistance;
+            endDistances[segmentIndex] = endDistance;
+            subdivisionCounts[segmentIndex] = subdivisionCount;
+            totalPointCount += subdivisionCount;
+        }
+
+        var points = new List<Point3d>(totalPointCount) { pl.GetPoint3dAt(0) };
+        for (var segmentIndex = 0; segmentIndex < segmentCount; segmentIndex++)
+        {
+            var startDistance = startDistances[segmentIndex];
+            var endDistance = endDistances[segmentIndex];
+            var subdivisionCount = subdivisionCounts[segmentIndex];
 
             for (var sampleIndex = 1; sampleIndex < subdivisionCount; sampleIndex++)
             {

--- a/src/CADShared/Cad/Database/Entities/Curves/Polylines/PolylineEx.cs
+++ b/src/CADShared/Cad/Database/Entities/Curves/Polylines/PolylineEx.cs
@@ -85,9 +85,7 @@ public static class PolylineEx
         if (pl is null)
             throw new ArgumentNullException(nameof(pl));
 
-        var segmentCount = pl.NumberOfVertices < 2
-            ? 0
-            : pl.Closed ? pl.NumberOfVertices : pl.NumberOfVertices - 1;
+        var segmentCount = GetSegmentCount(pl);
         if (segmentIndex < 0 || segmentIndex >= segmentCount)
         {
             throw new ArgumentOutOfRangeException(nameof(segmentIndex), segmentIndex,
@@ -95,6 +93,138 @@ public static class PolylineEx
         }
 
         return pl.GetDistanceAtParameter(segmentIndex + 1) - pl.GetDistanceAtParameter(segmentIndex);
+    }
+
+    /// <summary>
+    /// 按沿折线的最大间距获取采样点
+    /// </summary>
+    /// <remarks>
+    /// 每个原始子段独立等距细分，因此所有原始顶点都会保留。开放折线的结果从首顶点到末顶点；
+    /// 闭合折线会在结果末尾再次包含首顶点，以完整表示闭合路径。返回值是独立的点快照，不修改原折线。
+    /// </remarks>
+    /// <param name="pl">轻量多段线</param>
+    /// <param name="maximumSpacing">相邻采样点沿折线的最大距离，必须是有限正数</param>
+    /// <returns>按折线行进方向排列的采样点快照</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="pl"/> 为 <see langword="null"/></exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="maximumSpacing"/> 不是有限正数</exception>
+    /// <exception cref="InvalidOperationException">折线距离域无效，或阈值要求的细分数量无法表示</exception>
+    public static IReadOnlyList<Point3d> GetSamplePointsByDistance(this Polyline pl, double maximumSpacing)
+    {
+        if (pl is null)
+            throw new ArgumentNullException(nameof(pl));
+        ValidatePositiveFinite(maximumSpacing, nameof(maximumSpacing));
+
+        return GetSegmentSamplePoints(pl, (_, segmentLength) =>
+            GetSubdivisionCount(segmentLength / maximumSpacing));
+    }
+
+    /// <summary>
+    /// 按圆弧段的最大弦偏差获取采样点
+    /// </summary>
+    /// <remarks>
+    /// 直线段只保留端点；圆弧段按弓高公式等弧长细分，使每个采样子弧的弦偏差不超过指定值。
+    /// 所有原始顶点都会保留。闭合折线会在结果末尾再次包含首顶点。返回值是独立的点快照，不修改原折线。
+    /// </remarks>
+    /// <param name="pl">轻量多段线</param>
+    /// <param name="maximumChordDeviation">圆弧采样子段允许的最大弦偏差，必须是有限正数</param>
+    /// <returns>按折线行进方向排列的采样点快照</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="pl"/> 为 <see langword="null"/></exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="maximumChordDeviation"/> 不是有限正数</exception>
+    /// <exception cref="InvalidOperationException">圆弧或折线距离域无效，或阈值要求的细分数量无法表示</exception>
+    public static IReadOnlyList<Point3d> GetSamplePointsByChordDeviation(this Polyline pl,
+        double maximumChordDeviation)
+    {
+        if (pl is null)
+            throw new ArgumentNullException(nameof(pl));
+        ValidatePositiveFinite(maximumChordDeviation, nameof(maximumChordDeviation));
+
+        return GetSegmentSamplePoints(pl, (segmentIndex, segmentLength) =>
+        {
+            if (segmentLength == 0 || pl.GetSegmentType(segmentIndex) != SegmentType.Arc)
+                return 1;
+
+            using var arc = pl.GetArcSegment2dAt(segmentIndex);
+            var radius = arc.Radius;
+            if (double.IsNaN(radius) || double.IsInfinity(radius) || radius <= 0)
+                throw new InvalidOperationException("The polyline contains an arc with an invalid radius.");
+
+            var deviationRatio = maximumChordDeviation / radius * 0.5;
+            var maximumAngle = deviationRatio >= 1
+                ? Math.PI * 2
+                : 4 * Math.Asin(Math.Sqrt(deviationRatio));
+            if (double.IsNaN(maximumAngle) || double.IsInfinity(maximumAngle) || maximumAngle <= 0)
+            {
+                throw new InvalidOperationException(
+                    "The chord deviation requires a subdivision count that cannot be represented.");
+            }
+
+            var includedAngle = segmentLength / radius;
+            return GetSubdivisionCount(includedAngle / maximumAngle);
+        });
+    }
+
+    private static IReadOnlyList<Point3d> GetSegmentSamplePoints(Polyline pl,
+        Func<int, double, int> getSubdivisionCount)
+    {
+        var vertexCount = pl.NumberOfVertices;
+        if (vertexCount == 0)
+            return Array.Empty<Point3d>();
+
+        var points = new List<Point3d> { pl.GetPoint3dAt(0) };
+        var segmentCount = GetSegmentCount(pl);
+        for (var segmentIndex = 0; segmentIndex < segmentCount; segmentIndex++)
+        {
+            var startDistance = pl.GetDistanceAtParameter(segmentIndex);
+            var endDistance = pl.GetDistanceAtParameter(segmentIndex + 1);
+            if (double.IsNaN(startDistance) || double.IsInfinity(startDistance) || startDistance < 0 ||
+                double.IsNaN(endDistance) || double.IsInfinity(endDistance) || endDistance < startDistance)
+            {
+                throw new InvalidOperationException(
+                    "The polyline does not have a finite, non-negative, ordered distance range.");
+            }
+
+            var segmentLength = endDistance - startDistance;
+            var subdivisionCount = getSubdivisionCount(segmentIndex, segmentLength);
+            if (subdivisionCount < 1)
+                throw new InvalidOperationException("The subdivision count must be positive.");
+
+            for (var sampleIndex = 1; sampleIndex < subdivisionCount; sampleIndex++)
+            {
+                var fraction = (double)sampleIndex / subdivisionCount;
+                var distance = startDistance * (1 - fraction) + endDistance * fraction;
+                points.Add(pl.GetPointAtDist(distance));
+            }
+
+            points.Add(pl.GetPoint3dAt((segmentIndex + 1) % vertexCount));
+        }
+
+        return points;
+    }
+
+    private static int GetSegmentCount(Polyline pl)
+    {
+        return pl.NumberOfVertices < 2
+            ? 0
+            : pl.Closed ? pl.NumberOfVertices : pl.NumberOfVertices - 1;
+    }
+
+    private static int GetSubdivisionCount(double requiredCount)
+    {
+        var subdivisionCount = Math.Ceiling(requiredCount);
+        if (double.IsNaN(subdivisionCount) || double.IsInfinity(subdivisionCount) ||
+            subdivisionCount > int.MaxValue)
+        {
+            throw new InvalidOperationException(
+                "The sampling threshold requires a subdivision count that cannot be represented.");
+        }
+
+        return Math.Max(1, (int)subdivisionCount);
+    }
+
+    private static void ValidatePositiveFinite(double value, string parameterName)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value) || value <= 0)
+            throw new ArgumentOutOfRangeException(parameterName, value, "The value must be finite and greater than zero.");
     }
 
     #endregion

--- a/src/CADShared/Cad/Database/Entities/Curves/Polylines/PolylineEx.cs
+++ b/src/CADShared/Cad/Database/Entities/Curves/Polylines/PolylineEx.cs
@@ -53,6 +53,50 @@ public static class PolylineEx
                 .ToList();
     }
 
+    /// <summary>
+    /// 获取轻量多段线的顶点、凸度和宽度快照
+    /// </summary>
+    /// <param name="pl">轻量多段线</param>
+    /// <returns>按顶点索引排列的独立数据对象；修改返回值不会修改原多段线</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="pl"/> 为 <see langword="null"/></exception>
+    public static IReadOnlyList<BulgeVertexWidth> GetVertexData(this Polyline pl)
+    {
+        if (pl is null)
+            throw new ArgumentNullException(nameof(pl));
+
+        var vertices = new List<BulgeVertexWidth>(pl.NumberOfVertices);
+        for (var index = 0; index < pl.NumberOfVertices; index++)
+            vertices.Add(new BulgeVertexWidth(pl, index));
+
+        return vertices;
+    }
+
+    /// <summary>
+    /// 获取轻量多段线指定子段的实际长度
+    /// </summary>
+    /// <remarks>直线段返回直线长度，圆弧段返回沿弧长度。</remarks>
+    /// <param name="pl">轻量多段线</param>
+    /// <param name="segmentIndex">从零开始的子段索引</param>
+    /// <returns>指定子段的长度</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="pl"/> 为 <see langword="null"/></exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="segmentIndex"/> 不是有效子段索引</exception>
+    public static double GetSegmentLength(this Polyline pl, int segmentIndex)
+    {
+        if (pl is null)
+            throw new ArgumentNullException(nameof(pl));
+
+        var segmentCount = pl.NumberOfVertices < 2
+            ? 0
+            : pl.Closed ? pl.NumberOfVertices : pl.NumberOfVertices - 1;
+        if (segmentIndex < 0 || segmentIndex >= segmentCount)
+        {
+            throw new ArgumentOutOfRangeException(nameof(segmentIndex), segmentIndex,
+                "The polyline does not contain the requested segment.");
+        }
+
+        return pl.GetDistanceAtParameter(segmentIndex + 1) - pl.GetDistanceAtParameter(segmentIndex);
+    }
+
     #endregion
 
     #region 创建多段线

--- a/src/CADShared/Cad/Geometry/PointEx.cs
+++ b/src/CADShared/Cad/Geometry/PointEx.cs
@@ -90,6 +90,67 @@ public static class PointEx
     }
 
     /// <summary>
+    /// 按比例在两个三维点之间进行线性插值
+    /// </summary>
+    /// <param name="startPoint">起点</param>
+    /// <param name="endPoint">终点</param>
+    /// <param name="fraction">从起点到终点的比例，取值范围为闭区间 [0, 1]</param>
+    /// <returns>插值得到的三维点</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="fraction"/> 不是有限数或超出 [0, 1]</exception>
+    public static Point3d InterpolateTo(this Point3d startPoint, Point3d endPoint, double fraction)
+    {
+        if (double.IsNaN(fraction) || double.IsInfinity(fraction) || fraction < 0 || fraction > 1)
+            throw new ArgumentOutOfRangeException(nameof(fraction), fraction, "The fraction must be in [0, 1].");
+
+        var startWeight = 1 - fraction;
+        return new Point3d(
+            startPoint.X * startWeight + endPoint.X * fraction,
+            startPoint.Y * startWeight + endPoint.Y * fraction,
+            startPoint.Z * startWeight + endPoint.Z * fraction);
+    }
+
+    /// <summary>
+    /// 获取三维线段上指定高程处的唯一插值点
+    /// </summary>
+    /// <remarks>
+    /// 线段水平时没有唯一结果；指定高程超出线段 Z 值闭区间时也返回 <see langword="false"/>。
+    /// 本方法不使用隐式容差。
+    /// </remarks>
+    /// <param name="startPoint">线段起点</param>
+    /// <param name="endPoint">线段终点</param>
+    /// <param name="elevation">目标 Z 值</param>
+    /// <param name="point">成功时为目标高程处的点；失败时为默认值</param>
+    /// <returns>存在唯一插值点时返回 <see langword="true"/>，否则返回 <see langword="false"/></returns>
+    public static bool TryInterpolateAtElevation(this Point3d startPoint, Point3d endPoint,
+        double elevation, out Point3d point)
+    {
+        point = default;
+        if (double.IsNaN(elevation) || double.IsInfinity(elevation) ||
+            double.IsNaN(startPoint.Z) || double.IsInfinity(startPoint.Z) ||
+            double.IsNaN(endPoint.Z) || double.IsInfinity(endPoint.Z))
+        {
+            return false;
+        }
+
+        var elevationDelta = endPoint.Z - startPoint.Z;
+        if (elevationDelta == 0 || double.IsInfinity(elevationDelta))
+            return false;
+
+        var fraction = (elevation - startPoint.Z) / elevationDelta;
+        if (double.IsNaN(fraction) || double.IsInfinity(fraction) || fraction < 0 || fraction > 1)
+            return false;
+
+        var startWeight = 1 - fraction;
+        var x = startPoint.X * startWeight + endPoint.X * fraction;
+        var y = startPoint.Y * startWeight + endPoint.Y * fraction;
+        if (double.IsNaN(x) || double.IsInfinity(x) || double.IsNaN(y) || double.IsInfinity(y))
+            return false;
+
+        point = new Point3d(x, y, elevation);
+        return true;
+    }
+
+    /// <summary>
     /// Z值归零
     /// </summary>
     /// <param name="point">点</param>

--- a/src/CADShared/Cad/Geometry/SpatialIndex/Grid/PointGridIndex.cs
+++ b/src/CADShared/Cad/Geometry/SpatialIndex/Grid/PointGridIndex.cs
@@ -1,0 +1,372 @@
+namespace Fs.Fox.Cad;
+
+/// <summary>
+/// 基于 XY 稀疏网格的三维点索引
+/// </summary>
+/// <remarks>
+/// 索引没有固定空间边界，点索引在调用 <see cref="Clear"/> 前保持稳定。
+/// 本类型不是线程安全的；同一实例的读取和写入应由调用方同步。
+/// </remarks>
+public sealed class PointGridIndex
+{
+    private readonly Dictionary<(long X, long Y), List<int>> _buckets = [];
+    private readonly List<Point3d> _points = [];
+    private readonly IReadOnlyList<Point3d> _readOnlyPoints;
+
+    /// <summary>
+    /// 初始化稀疏点网格索引
+    /// </summary>
+    /// <param name="cellSize">XY 网格边长，必须为有限正数</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="cellSize"/> 不是有限正数</exception>
+    public PointGridIndex(double cellSize)
+    {
+        if (!IsFinite(cellSize) || cellSize <= 0)
+            throw new ArgumentOutOfRangeException(nameof(cellSize), cellSize, "The cell size must be finite and positive.");
+
+        CellSize = cellSize;
+        _readOnlyPoints = _points.AsReadOnly();
+    }
+
+    /// <summary>
+    /// XY 网格边长
+    /// </summary>
+    public double CellSize { get; }
+
+    /// <summary>
+    /// 索引中的点数
+    /// </summary>
+    public int Count => _points.Count;
+
+    /// <summary>
+    /// 按稳定索引排列的只读点视图
+    /// </summary>
+    public IReadOnlyList<Point3d> Points => _readOnlyPoints;
+
+    /// <summary>
+    /// 按索引获取点
+    /// </summary>
+    /// <param name="index">点索引</param>
+    /// <returns>对应的三维点</returns>
+    public Point3d this[int index] => _points[index];
+
+    /// <summary>
+    /// 无条件添加一个点
+    /// </summary>
+    /// <param name="point">要添加的有限三维点</param>
+    /// <returns>新点的稳定索引</returns>
+    /// <exception cref="ArgumentOutOfRangeException">点包含 NaN、无穷值或无法映射到网格的坐标</exception>
+    public int Add(Point3d point)
+    {
+        ValidatePoint(point, nameof(point));
+        return AddValidated(point);
+    }
+
+    /// <summary>
+    /// 在不存在近似点时添加一个点
+    /// </summary>
+    /// <remarks>
+    /// 近似点必须同时满足：XY 欧氏距离小于或等于 <paramref name="xyTolerance"/>，
+    /// 且 Z 差绝对值小于或等于 <paramref name="zTolerance"/>。
+    /// </remarks>
+    /// <param name="point">要添加的有限三维点</param>
+    /// <param name="xyTolerance">XY 欧氏距离容差，必须为有限非负数</param>
+    /// <param name="zTolerance">Z 差容差，必须为非负数；允许正无穷</param>
+    /// <param name="pointIndex">添加成功时为新索引；存在近似点时为最接近的既有索引</param>
+    /// <returns>添加新点时返回 <see langword="true"/>；复用既有点时返回 <see langword="false"/></returns>
+    public bool TryAdd(Point3d point, double xyTolerance, double zTolerance, out int pointIndex)
+    {
+        ValidatePoint(point, nameof(point));
+        ValidateTolerance(xyTolerance, nameof(xyTolerance), false);
+        ValidateTolerance(zTolerance, nameof(zTolerance), true);
+
+        if (TryFindCore(point, xyTolerance, zTolerance, out pointIndex))
+            return false;
+
+        pointIndex = AddValidated(point);
+        return true;
+    }
+
+    /// <summary>
+    /// 查找与指定点近似的既有点
+    /// </summary>
+    /// <remarks>
+    /// 候选点必须同时满足 XY 欧氏距离和 Z 差的闭区间容差；有多个候选时返回三维距离最近者，
+    /// 距离相同时返回较早添加的点。
+    /// </remarks>
+    /// <param name="point">查询点</param>
+    /// <param name="xyTolerance">XY 欧氏距离容差，必须为有限非负数</param>
+    /// <param name="zTolerance">Z 差容差，必须为非负数；允许正无穷</param>
+    /// <param name="pointIndex">成功时为匹配点索引；失败时为 -1</param>
+    /// <returns>找到近似点时返回 <see langword="true"/></returns>
+    public bool TryFind(Point3d point, double xyTolerance, double zTolerance, out int pointIndex)
+    {
+        ValidatePoint(point, nameof(point));
+        ValidateTolerance(xyTolerance, nameof(xyTolerance), false);
+        ValidateTolerance(zTolerance, nameof(zTolerance), true);
+        return TryFindCore(point, xyTolerance, zTolerance, out pointIndex);
+    }
+
+    /// <summary>
+    /// 查询 XY 矩形闭区间内的点索引
+    /// </summary>
+    /// <param name="minPoint">矩形最小 XY 坐标</param>
+    /// <param name="maxPoint">矩形最大 XY 坐标</param>
+    /// <returns>按添加顺序排列的点索引</returns>
+    /// <exception cref="ArgumentOutOfRangeException">坐标不是有限数或最小坐标大于最大坐标</exception>
+    public IReadOnlyList<int> QueryIndices(Point2d minPoint, Point2d maxPoint)
+    {
+        ValidatePoint(minPoint, nameof(minPoint));
+        ValidatePoint(maxPoint, nameof(maxPoint));
+        if (minPoint.X > maxPoint.X || minPoint.Y > maxPoint.Y)
+            throw new ArgumentOutOfRangeException(nameof(maxPoint), "The maximum point must not precede the minimum point.");
+
+        var results = new List<int>();
+        foreach (var index in GetCandidateIndices(minPoint.X, minPoint.Y, maxPoint.X, maxPoint.Y))
+        {
+            var point = _points[index];
+            if (point.X >= minPoint.X && point.X <= maxPoint.X &&
+                point.Y >= minPoint.Y && point.Y <= maxPoint.Y)
+            {
+                results.Add(index);
+            }
+        }
+
+        results.Sort();
+        return results;
+    }
+
+    /// <summary>
+    /// 在最大三维距离内查找最近点
+    /// </summary>
+    /// <remarks>
+    /// 候选点还必须满足 Z 差绝对值小于或等于 <paramref name="zTolerance"/>。
+    /// 距离边界为闭区间；距离相同时返回较早添加的点。
+    /// </remarks>
+    /// <param name="point">查询点</param>
+    /// <param name="maxDistance">允许的最大三维距离，必须为有限非负数</param>
+    /// <param name="zTolerance">Z 差容差，必须为非负数；允许正无穷</param>
+    /// <param name="pointIndex">成功时为最近点索引；失败时为 -1</param>
+    /// <param name="distance">成功时为三维距离；失败时为正无穷</param>
+    /// <returns>在约束范围内找到点时返回 <see langword="true"/></returns>
+    public bool TryGetNearest(Point3d point, double maxDistance, double zTolerance,
+        out int pointIndex, out double distance)
+    {
+        ValidatePoint(point, nameof(point));
+        ValidateTolerance(maxDistance, nameof(maxDistance), false);
+        ValidateTolerance(zTolerance, nameof(zTolerance), true);
+
+        pointIndex = -1;
+        distance = double.PositiveInfinity;
+        var bestDistance = double.PositiveInfinity;
+
+        foreach (var index in GetCandidateIndices(
+                     point.X - maxDistance,
+                     point.Y - maxDistance,
+                     point.X + maxDistance,
+                     point.Y + maxDistance))
+        {
+            var candidate = _points[index];
+            var zDifference = Math.Abs(candidate.Z - point.Z);
+            if (zDifference > zTolerance)
+                continue;
+
+            var xDifference = candidate.X - point.X;
+            var yDifference = candidate.Y - point.Y;
+            var candidateDistance = GetLength(xDifference, yDifference, zDifference);
+            if (candidateDistance > maxDistance)
+                continue;
+
+            if (pointIndex < 0 || candidateDistance < bestDistance ||
+                candidateDistance == bestDistance && index < pointIndex)
+            {
+                pointIndex = index;
+                bestDistance = candidateDistance;
+            }
+        }
+
+        if (pointIndex < 0)
+            return false;
+
+        distance = bestDistance;
+        return true;
+    }
+
+    /// <summary>
+    /// 清空所有点和网格桶
+    /// </summary>
+    /// <remarks>清空后新点索引重新从零开始。</remarks>
+    public void Clear()
+    {
+        _points.Clear();
+        _buckets.Clear();
+    }
+
+    private int AddValidated(Point3d point)
+    {
+        var cell = GetCell(point.X, point.Y);
+        var pointIndex = _points.Count;
+        _points.Add(point);
+
+        if (!_buckets.TryGetValue(cell, out var bucket))
+        {
+            bucket = [];
+            _buckets.Add(cell, bucket);
+        }
+
+        bucket.Add(pointIndex);
+        return pointIndex;
+    }
+
+    private bool TryFindCore(Point3d point, double xyTolerance, double zTolerance, out int pointIndex)
+    {
+        pointIndex = -1;
+        var bestDistance = double.PositiveInfinity;
+
+        foreach (var index in GetCandidateIndices(
+                     point.X - xyTolerance,
+                     point.Y - xyTolerance,
+                     point.X + xyTolerance,
+                     point.Y + xyTolerance))
+        {
+            var candidate = _points[index];
+            var xDifference = candidate.X - point.X;
+            var yDifference = candidate.Y - point.Y;
+            var planarDistance = GetLength(xDifference, yDifference);
+            if (planarDistance > xyTolerance)
+                continue;
+
+            var zDifference = Math.Abs(candidate.Z - point.Z);
+            if (zDifference > zTolerance)
+                continue;
+
+            var distance = GetLength(xDifference, yDifference, zDifference);
+            if (pointIndex < 0 || distance < bestDistance ||
+                distance == bestDistance && index < pointIndex)
+            {
+                pointIndex = index;
+                bestDistance = distance;
+            }
+        }
+
+        return pointIndex >= 0;
+    }
+
+    private List<int> GetCandidateIndices(double minX, double minY, double maxX, double maxY)
+    {
+        var results = new List<int>();
+        if (_points.Count == 0)
+            return results;
+
+        if (double.IsNaN(minX) || double.IsNaN(minY) || double.IsNaN(maxX) || double.IsNaN(maxY))
+            throw new ArgumentOutOfRangeException(nameof(minX), "The query bounds must not contain NaN.");
+
+        if (double.IsInfinity(minX) || double.IsInfinity(minY) ||
+            double.IsInfinity(maxX) || double.IsInfinity(maxY))
+        {
+            for (var index = 0; index < _points.Count; index++)
+                results.Add(index);
+            return results;
+        }
+
+        var minCell = GetCell(minX, minY);
+        var maxCell = GetCell(maxX, maxY);
+        var columnCount = (double)maxCell.X - minCell.X + 1;
+        var rowCount = (double)maxCell.Y - minCell.Y + 1;
+        var gridCellCount = columnCount * rowCount;
+
+        if (gridCellCount <= _buckets.Count)
+        {
+            for (var row = minCell.Y;; row++)
+            {
+                for (var column = minCell.X;; column++)
+                {
+                    if (_buckets.TryGetValue((column, row), out var bucket))
+                        results.AddRange(bucket);
+
+                    if (column == maxCell.X)
+                        break;
+                }
+
+                if (row == maxCell.Y)
+                    break;
+            }
+
+            return results;
+        }
+
+        foreach (var entry in _buckets)
+        {
+            if (entry.Key.X < minCell.X || entry.Key.X > maxCell.X ||
+                entry.Key.Y < minCell.Y || entry.Key.Y > maxCell.Y)
+            {
+                continue;
+            }
+
+            results.AddRange(entry.Value);
+        }
+
+        return results;
+    }
+
+    private (long X, long Y) GetCell(double x, double y)
+    {
+        return (GetCellCoordinate(x), GetCellCoordinate(y));
+    }
+
+    private long GetCellCoordinate(double value)
+    {
+        var coordinate = Math.Floor(value / CellSize);
+        if (!IsFinite(coordinate) || coordinate <= long.MinValue || coordinate >= long.MaxValue)
+        {
+            throw new ArgumentOutOfRangeException(nameof(value), value,
+                "The coordinate cannot be represented by this grid cell size.");
+        }
+
+        return (long)coordinate;
+    }
+
+    private static void ValidatePoint(Point3d point, string parameterName)
+    {
+        if (!IsFinite(point.X) || !IsFinite(point.Y) || !IsFinite(point.Z))
+            throw new ArgumentOutOfRangeException(parameterName, "Point coordinates must be finite.");
+    }
+
+    private static void ValidatePoint(Point2d point, string parameterName)
+    {
+        if (!IsFinite(point.X) || !IsFinite(point.Y))
+            throw new ArgumentOutOfRangeException(parameterName, "Point coordinates must be finite.");
+    }
+
+    private static void ValidateTolerance(double value, string parameterName, bool allowPositiveInfinity)
+    {
+        if (double.IsNaN(value) || value < 0 || !allowPositiveInfinity && double.IsInfinity(value))
+        {
+            throw new ArgumentOutOfRangeException(parameterName, value,
+                allowPositiveInfinity
+                    ? "The tolerance must be non-negative and must not be NaN."
+                    : "The value must be finite and non-negative.");
+        }
+    }
+
+    private static bool IsFinite(double value)
+    {
+        return !double.IsNaN(value) && !double.IsInfinity(value);
+    }
+
+    private static double GetLength(double x, double y, double z = 0)
+    {
+        x = Math.Abs(x);
+        y = Math.Abs(y);
+        z = Math.Abs(z);
+        var scale = Math.Max(x, Math.Max(y, z));
+        if (double.IsInfinity(scale))
+            return double.PositiveInfinity;
+        if (scale == 0)
+            return 0;
+
+        x /= scale;
+        y /= scale;
+        z /= scale;
+        return scale * Math.Sqrt(x * x + y * y + z * z);
+    }
+}

--- a/src/CADShared/Cad/Geometry/SpatialIndex/Grid/PointGridIndex.cs
+++ b/src/CADShared/Cad/Geometry/SpatialIndex/Grid/PointGridIndex.cs
@@ -11,6 +11,7 @@ public sealed class PointGridIndex
 {
     private readonly Dictionary<(long X, long Y), List<int>> _buckets = [];
     private readonly List<Point3d> _points = [];
+    private readonly List<int> _candidateIndices = [];
     private readonly IReadOnlyList<Point3d> _readOnlyPoints;
 
     /// <summary>
@@ -199,6 +200,7 @@ public sealed class PointGridIndex
     {
         _points.Clear();
         _buckets.Clear();
+        _candidateIndices.Clear();
     }
 
     private int AddValidated(Point3d point)
@@ -253,7 +255,8 @@ public sealed class PointGridIndex
 
     private List<int> GetCandidateIndices(double minX, double minY, double maxX, double maxY)
     {
-        var results = new List<int>();
+        var results = _candidateIndices;
+        results.Clear();
         if (_points.Count == 0)
             return results;
 
@@ -263,13 +266,18 @@ public sealed class PointGridIndex
         if (double.IsInfinity(minX) || double.IsInfinity(minY) ||
             double.IsInfinity(maxX) || double.IsInfinity(maxY))
         {
-            for (var index = 0; index < _points.Count; index++)
-                results.Add(index);
+            AddAllPointIndices(results);
             return results;
         }
 
-        var minCell = GetCell(minX, minY);
-        var maxCell = GetCell(maxX, maxY);
+        var hasMinCell = TryGetCell(minX, minY, out var minCell);
+        var hasMaxCell = TryGetCell(maxX, maxY, out var maxCell);
+        if (!hasMinCell || !hasMaxCell)
+        {
+            AddAllPointIndices(results);
+            return results;
+        }
+
         var columnCount = (double)maxCell.X - minCell.X + 1;
         var rowCount = (double)maxCell.Y - minCell.Y + 1;
         var gridCellCount = columnCount * rowCount;
@@ -308,21 +316,53 @@ public sealed class PointGridIndex
         return results;
     }
 
+    private void AddAllPointIndices(List<int> results)
+    {
+        for (var index = 0; index < _points.Count; index++)
+            results.Add(index);
+    }
+
     private (long X, long Y) GetCell(double x, double y)
     {
         return (GetCellCoordinate(x), GetCellCoordinate(y));
     }
 
+    private bool TryGetCell(double x, double y, out (long X, long Y) cell)
+    {
+        var hasX = TryGetCellCoordinate(x, out var cellX);
+        var hasY = TryGetCellCoordinate(y, out var cellY);
+        if (!hasX || !hasY)
+        {
+            cell = default;
+            return false;
+        }
+
+        cell = (cellX, cellY);
+        return true;
+    }
+
     private long GetCellCoordinate(double value)
     {
-        var coordinate = Math.Floor(value / CellSize);
-        if (!IsFinite(coordinate) || coordinate <= long.MinValue || coordinate >= long.MaxValue)
+        if (!TryGetCellCoordinate(value, out var coordinate))
         {
             throw new ArgumentOutOfRangeException(nameof(value), value,
                 "The coordinate cannot be represented by this grid cell size.");
         }
 
-        return (long)coordinate;
+        return coordinate;
+    }
+
+    private bool TryGetCellCoordinate(double value, out long cellCoordinate)
+    {
+        var coordinate = Math.Floor(value / CellSize);
+        if (!IsFinite(coordinate) || coordinate <= long.MinValue || coordinate >= long.MaxValue)
+        {
+            cellCoordinate = default;
+            return false;
+        }
+
+        cellCoordinate = (long)coordinate;
+        return true;
     }
 
     private static void ValidatePoint(Point3d point, string parameterName)

--- a/tests/TestShared/TestGeometryQuery.cs
+++ b/tests/TestShared/TestGeometryQuery.cs
@@ -2,7 +2,7 @@ namespace Test;
 
 public class TestGeometryQuery
 {
-    private const double Tolerance = 1e-8;
+    private const double Tolerance = 1e-6;
 
     [CommandMethod(nameof(Test_GeometryQuery))]
     public void Test_GeometryQuery()

--- a/tests/TestShared/TestGeometryQuery.cs
+++ b/tests/TestShared/TestGeometryQuery.cs
@@ -36,6 +36,13 @@ public class TestGeometryQuery
         AssertClose(arc.GetMidpointChordDeviationByDistance(0, Math.PI * 10), 10,
             "Semicircle distance midpoint deviation");
 
+        using var ray = new Ray();
+        AssertThrowsInvalidOperation(() => ray.GetMidpointChordDeviationByDistance(0, 1),
+            "Ray distance domain");
+        using var xline = new Xline();
+        AssertThrowsInvalidOperation(() => xline.GetMidpointChordDeviationByDistance(0, 1),
+            "Xline distance domain");
+
         using var polyline = new Polyline();
         polyline.AddVertexAt(0, new Point2d(0, 0), 1, 2, 3);
         polyline.AddVertexAt(1, new Point2d(10, 0), 0, 4, 5);
@@ -100,5 +107,19 @@ public class TestGeometryQuery
         }
 
         throw new InvalidOperationException($"{name}: expected ArgumentOutOfRangeException.");
+    }
+
+    private static void AssertThrowsInvalidOperation(Action action, string name)
+    {
+        try
+        {
+            action();
+        }
+        catch (InvalidOperationException)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException($"{name}: expected InvalidOperationException.");
     }
 }

--- a/tests/TestShared/TestGeometryQuery.cs
+++ b/tests/TestShared/TestGeometryQuery.cs
@@ -37,11 +37,28 @@ public class TestGeometryQuery
             "Semicircle distance midpoint deviation");
 
         using var ray = new Ray();
-        AssertThrowsInvalidOperation(() => ray.GetMidpointChordDeviationByDistance(0, 1),
-            "Ray distance domain");
+        ray.BasePoint = Point3d.Origin;
+        ray.UnitDir = Vector3d.XAxis;
+        AssertThrowsInvalidOperation(() => ray.GetPointAtDistanceFraction(0.5),
+            "Ray has no finite total length");
+        AssertClose(ray.GetMidpointChordDeviation(0, 1), 0,
+            "Ray parameter midpoint deviation");
+        AssertClose(ray.GetMidpointChordDeviationByDistance(0, 1), 0,
+            "Ray distance midpoint deviation");
+        AssertThrowsArgumentOutOfRange(() => ray.GetMidpointChordDeviation(-1, 1),
+            "Ray parameter range");
+        AssertThrowsArgumentOutOfRange(() => ray.GetMidpointChordDeviationByDistance(-1, 1),
+            "Ray distance range");
+
         using var xline = new Xline();
+        xline.BasePoint = Point3d.Origin;
+        xline.UnitDir = Vector3d.XAxis;
+        AssertThrowsInvalidOperation(() => xline.GetPointAtDistanceFraction(0.5),
+            "Xline has no finite total length");
+        AssertClose(xline.GetMidpointChordDeviation(-1, 1), 0,
+            "Xline parameter midpoint deviation");
         AssertThrowsInvalidOperation(() => xline.GetMidpointChordDeviationByDistance(0, 1),
-            "Xline distance domain");
+            "Xline has no distance origin");
 
         using var polyline = new Polyline();
         polyline.AddVertexAt(0, new Point2d(0, 0), 1, 2, 3);

--- a/tests/TestShared/TestGeometryQuery.cs
+++ b/tests/TestShared/TestGeometryQuery.cs
@@ -109,6 +109,10 @@ public class TestGeometryQuery
             "Distance sampling representable count");
         AssertThrowsInvalidOperation(() => polyline.GetSamplePointsByChordDeviation(double.Epsilon),
             "Chord sampling representable count");
+        AssertThrowsInvalidOperation(() => polyline.GetSamplePointsByDistance(1e-6),
+            "Distance sampling total point limit");
+        AssertThrowsInvalidOperation(() => polyline.GetSamplePointsByChordDeviation(1e-12),
+            "Chord sampling total point limit");
 
         polyline.Closed = true;
         AssertClose(polyline.GetSegmentLength(2), Math.Sqrt(200), "Closing segment length");

--- a/tests/TestShared/TestGeometryQuery.cs
+++ b/tests/TestShared/TestGeometryQuery.cs
@@ -1,0 +1,104 @@
+namespace Test;
+
+public class TestGeometryQuery
+{
+    private const double Tolerance = 1e-8;
+
+    [CommandMethod(nameof(Test_GeometryQuery))]
+    public void Test_GeometryQuery()
+    {
+        var startPoint = new Point3d(0, 0, 0);
+        var endPoint = new Point3d(10, 20, 30);
+
+        AssertPoint(startPoint.InterpolateTo(endPoint, 0.25), new Point3d(2.5, 5, 7.5),
+            nameof(PointEx.InterpolateTo));
+        AssertTrue(startPoint.TryInterpolateAtElevation(endPoint, 15, out var elevationPoint),
+            nameof(PointEx.TryInterpolateAtElevation));
+        AssertPoint(elevationPoint, new Point3d(5, 10, 15), nameof(PointEx.TryInterpolateAtElevation));
+        AssertFalse(startPoint.TryInterpolateAtElevation(new Point3d(10, 20, 0), 0, out _),
+            "Horizontal segment must not return an arbitrary point.");
+        AssertFalse(startPoint.TryInterpolateAtElevation(endPoint, 31, out _),
+            "Elevation outside the segment must fail.");
+
+        using var line = new Line(startPoint, endPoint);
+        AssertPoint(line.GetPointAtDistanceFraction(0.25), new Point3d(2.5, 5, 7.5),
+            nameof(CurveEx.GetPointAtDistanceFraction));
+        AssertThrowsArgumentOutOfRange(() => line.GetPointAtDistanceFraction(1.01),
+            "Curve distance fraction range");
+        AssertClose(line.GetMidpointChordDeviation(line.StartParam, line.EndParam), 0,
+            nameof(CurveEx.GetMidpointChordDeviation));
+        AssertClose(line.GetMidpointChordDeviationByDistance(0, line.Length), 0,
+            nameof(CurveEx.GetMidpointChordDeviationByDistance));
+
+        using var arc = new Arc(Point3d.Origin, 10, 0, Math.PI);
+        AssertClose(arc.GetMidpointChordDeviation(arc.StartParam, arc.EndParam), 10,
+            "Semicircle parameter midpoint deviation");
+        AssertClose(arc.GetMidpointChordDeviationByDistance(0, Math.PI * 10), 10,
+            "Semicircle distance midpoint deviation");
+
+        using var polyline = new Polyline();
+        polyline.AddVertexAt(0, new Point2d(0, 0), 1, 2, 3);
+        polyline.AddVertexAt(1, new Point2d(10, 0), 0, 4, 5);
+        polyline.AddVertexAt(2, new Point2d(10, 10), 0, 0, 0);
+
+        var vertexData = polyline.GetVertexData();
+        AssertTrue(vertexData.Count == 3, "Vertex snapshot count");
+        AssertPoint(vertexData[0].Vertex.Point3d(), Point3d.Origin, "Vertex snapshot position");
+        AssertClose(vertexData[0].Bulge, 1, "Vertex snapshot bulge");
+        AssertClose(vertexData[0].StartWidth, 2, "Vertex snapshot start width");
+        AssertClose(vertexData[0].EndWidth, 3, "Vertex snapshot end width");
+        vertexData[0].X = 100;
+        AssertPoint(polyline.GetPoint3dAt(0), Point3d.Origin, "Vertex snapshot independence");
+        AssertClose(polyline.GetSegmentLength(0), Math.PI * 5, "Arc segment length");
+        AssertClose(polyline.GetSegmentLength(1), 10, "Line segment length");
+        AssertThrowsArgumentOutOfRange(() => polyline.GetSegmentLength(2), "Open polyline segment range");
+
+        polyline.Closed = true;
+        AssertClose(polyline.GetSegmentLength(2), Math.Sqrt(200), "Closing segment length");
+
+        using var degeneratePolyline = new Polyline { Closed = true };
+        degeneratePolyline.AddVertexAt(0, Point2d.Origin, 0, 0, 0);
+        AssertThrowsArgumentOutOfRange(() => degeneratePolyline.GetSegmentLength(0),
+            "Degenerate closed polyline segment range");
+
+        Env.Printl("Test_GeometryQuery passed.");
+    }
+
+    private static void AssertPoint(Point3d actual, Point3d expected, string name)
+    {
+        if (actual.DistanceTo(expected) > Tolerance)
+            throw new InvalidOperationException($"{name}: expected {expected}, actual {actual}.");
+    }
+
+    private static void AssertClose(double actual, double expected, string name)
+    {
+        if (Math.Abs(actual - expected) > Tolerance)
+            throw new InvalidOperationException($"{name}: expected {expected}, actual {actual}.");
+    }
+
+    private static void AssertTrue(bool condition, string name)
+    {
+        if (!condition)
+            throw new InvalidOperationException($"{name}: expected true.");
+    }
+
+    private static void AssertFalse(bool condition, string name)
+    {
+        if (condition)
+            throw new InvalidOperationException($"{name}: expected false.");
+    }
+
+    private static void AssertThrowsArgumentOutOfRange(Action action, string name)
+    {
+        try
+        {
+            action();
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException($"{name}: expected ArgumentOutOfRangeException.");
+    }
+}

--- a/tests/TestShared/TestGeometryQuery.cs
+++ b/tests/TestShared/TestGeometryQuery.cs
@@ -77,13 +77,71 @@ public class TestGeometryQuery
         AssertClose(polyline.GetSegmentLength(1), 10, "Line segment length");
         AssertThrowsArgumentOutOfRange(() => polyline.GetSegmentLength(2), "Open polyline segment range");
 
+        var distanceSamples = polyline.GetSamplePointsByDistance(6);
+        AssertTrue(distanceSamples.Count == 6, "Distance sampling count");
+        AssertPoint(distanceSamples[0], polyline.GetPoint3dAt(0), "Distance sampling start vertex");
+        AssertPoint(distanceSamples[3], polyline.GetPoint3dAt(1), "Distance sampling preserved arc vertex");
+        AssertPoint(distanceSamples[5], polyline.GetPoint3dAt(2), "Distance sampling end vertex");
+        for (var index = 1; index < distanceSamples.Count; index++)
+        {
+            AssertTrue(distanceSamples[index - 1].DistanceTo(distanceSamples[index]) <= 6 + Tolerance,
+                "Distance sampling maximum spacing");
+        }
+
+        var chordSamples = polyline.GetSamplePointsByChordDeviation(1.5);
+        AssertTrue(chordSamples.Count == 4, "Chord deviation sampling count");
+        AssertPoint(chordSamples[0], polyline.GetPoint3dAt(0), "Chord sampling start vertex");
+        AssertPoint(chordSamples[2], polyline.GetPoint3dAt(1), "Chord sampling preserved arc vertex");
+        AssertPoint(chordSamples[3], polyline.GetPoint3dAt(2), "Chord sampling end vertex");
+        AssertClose(chordSamples[1].DistanceTo(new Point3d(5, 0, 0)), 5,
+            "Semicircle chord sampling midpoint deviation");
+        AssertClose(polyline.GetBulgeAt(0), 1, "Sampling leaves bulge unchanged");
+        AssertClose(polyline.GetStartWidthAt(0), 2, "Sampling leaves start width unchanged");
+        AssertClose(polyline.GetEndWidthAt(0), 3, "Sampling leaves end width unchanged");
+
+        AssertThrowsArgumentOutOfRange(() => polyline.GetSamplePointsByDistance(0),
+            "Distance sampling positive threshold");
+        AssertThrowsArgumentOutOfRange(() => polyline.GetSamplePointsByDistance(double.NaN),
+            "Distance sampling finite threshold");
+        AssertThrowsArgumentOutOfRange(() => polyline.GetSamplePointsByChordDeviation(double.PositiveInfinity),
+            "Chord sampling finite threshold");
+        AssertThrowsInvalidOperation(() => polyline.GetSamplePointsByDistance(double.Epsilon),
+            "Distance sampling representable count");
+        AssertThrowsInvalidOperation(() => polyline.GetSamplePointsByChordDeviation(double.Epsilon),
+            "Chord sampling representable count");
+
         polyline.Closed = true;
         AssertClose(polyline.GetSegmentLength(2), Math.Sqrt(200), "Closing segment length");
+        var closedSamples = polyline.GetSamplePointsByDistance(100);
+        AssertTrue(closedSamples.Count == 4, "Closed sampling count");
+        AssertPoint(closedSamples[0], closedSamples[closedSamples.Count - 1],
+            "Closed sampling repeats first vertex");
+
+        using var orientedPolyline = new Polyline
+        {
+            Elevation = 7,
+            Normal = Vector3d.YAxis
+        };
+        orientedPolyline.AddVertexAt(0, Point2d.Origin, 0, 0, 0);
+        orientedPolyline.AddVertexAt(1, new Point2d(10, 0), 0, 0, 0);
+        var orientedSamples = orientedPolyline.GetSamplePointsByDistance(4);
+        AssertPoint(orientedSamples[0], orientedPolyline.GetPoint3dAt(0),
+            "Oriented sampling preserves start point");
+        AssertPoint(orientedSamples[orientedSamples.Count - 1], orientedPolyline.GetPoint3dAt(1),
+            "Oriented sampling preserves end point");
 
         using var degeneratePolyline = new Polyline { Closed = true };
         degeneratePolyline.AddVertexAt(0, Point2d.Origin, 0, 0, 0);
         AssertThrowsArgumentOutOfRange(() => degeneratePolyline.GetSegmentLength(0),
             "Degenerate closed polyline segment range");
+        AssertTrue(degeneratePolyline.GetSamplePointsByDistance(1).Count == 1,
+            "Degenerate distance sampling");
+        AssertTrue(degeneratePolyline.GetSamplePointsByChordDeviation(1).Count == 1,
+            "Degenerate chord sampling");
+
+        using var emptyPolyline = new Polyline();
+        AssertTrue(emptyPolyline.GetSamplePointsByDistance(1).Count == 0, "Empty distance sampling");
+        AssertTrue(emptyPolyline.GetSamplePointsByChordDeviation(1).Count == 0, "Empty chord sampling");
 
         Env.Printl("Test_GeometryQuery passed.");
     }

--- a/tests/TestShared/TestPointGridIndex.cs
+++ b/tests/TestShared/TestPointGridIndex.cs
@@ -1,0 +1,113 @@
+namespace Test;
+
+public class TestPointGridIndex
+{
+    private const double Tolerance = 1e-8;
+
+    [CommandMethod(nameof(Test_PointGridIndex))]
+    public void Test_PointGridIndex()
+    {
+        AssertThrowsArgumentOutOfRange(() => _ = new PointGridIndex(0), "Zero cell size");
+        AssertThrowsArgumentOutOfRange(() => _ = new PointGridIndex(double.PositiveInfinity),
+            "Infinite cell size");
+
+        var index = new PointGridIndex(1);
+        var firstIndex = index.Add(new Point3d(0.95, 0, 0));
+        AssertTrue(firstIndex == 0, "First point index");
+
+        var added = index.TryAdd(new Point3d(1.05, 0, 0.05), 0.11, 0.1, out var nearIndex);
+        AssertFalse(added, "Cross-cell approximate duplicate");
+        AssertTrue(nearIndex == firstIndex, "Approximate duplicate index");
+
+        added = index.TryAdd(new Point3d(1.05, 0, 2), 0.11, 0.5, out var elevatedIndex);
+        AssertTrue(added, "Z-separated point addition");
+        AssertTrue(elevatedIndex == 1, "Z-separated point index");
+
+        var negativeIndex = index.Add(new Point3d(-1, -1, 0));
+        var farIndex = index.Add(new Point3d(3, 3, 0));
+        AssertTrue(index.Count == 4 && index.Points.Count == 4, "Point count and read-only view");
+        AssertPoint(index[firstIndex], new Point3d(0.95, 0, 0), "Point indexer");
+
+        AssertTrue(index.TryFind(new Point3d(1.04, 0, 2.1), 0.1, 0.2, out var foundIndex),
+            "Approximate find");
+        AssertTrue(foundIndex == elevatedIndex, "Approximate find index");
+        AssertFalse(index.TryFind(new Point3d(1.04, 0, 2.1), 0.1, 0.05, out _),
+            "Approximate find Z boundary");
+
+        var rangeIndices = index.QueryIndices(new Point2d(-1, -1), new Point2d(1, 1));
+        AssertTrue(rangeIndices.Count == 2, "Inclusive XY range count");
+        AssertTrue(rangeIndices[0] == firstIndex && rangeIndices[1] == negativeIndex,
+            "Range results use insertion order");
+        AssertFalse(rangeIndices.Contains(elevatedIndex) || rangeIndices.Contains(farIndex),
+            "Range excludes outside points");
+        var boundaryIndices = index.QueryIndices(new Point2d(-1, -1), new Point2d(-1, -1));
+        AssertTrue(boundaryIndices.Count == 1 && boundaryIndices[0] == negativeIndex,
+            "Range includes exact boundary point");
+        AssertThrowsArgumentOutOfRange(
+            () => index.QueryIndices(new Point2d(1, 0), new Point2d(0, 1)),
+            "Reversed range");
+
+        AssertTrue(index.TryGetNearest(new Point3d(1, 0, 0), 0.2, 0.1,
+                out var nearestIndex, out var distance),
+            "Nearest point query");
+        AssertTrue(nearestIndex == firstIndex, "Nearest point index");
+        AssertClose(distance, 0.05, "Nearest point distance");
+        AssertFalse(index.TryGetNearest(new Point3d(1, 0, 0), 0.01, double.PositiveInfinity,
+                out _, out _),
+            "Nearest point maximum distance");
+        AssertThrowsArgumentOutOfRange(
+            () => index.TryFind(Point3d.Origin, -1, 0, out _),
+            "Negative XY tolerance");
+
+        var tieIndex = new PointGridIndex(1);
+        tieIndex.Add(new Point3d(-1, 0, 0));
+        tieIndex.Add(new Point3d(1, 0, 0));
+        AssertTrue(tieIndex.TryGetNearest(Point3d.Origin, 1, 0, out var tieResult, out _),
+            "Nearest point tie query");
+        AssertTrue(tieResult == 0, "Nearest point tie uses insertion order");
+
+        index.Clear();
+        AssertTrue(index.Count == 0 && index.Points.Count == 0, "Clear");
+        AssertTrue(index.Add(Point3d.Origin) == 0, "Index restarts after clear");
+
+        Env.Printl("Test_PointGridIndex passed.");
+    }
+
+    private static void AssertPoint(Point3d actual, Point3d expected, string name)
+    {
+        if (actual.DistanceTo(expected) > Tolerance)
+            throw new InvalidOperationException($"{name}: expected {expected}, actual {actual}.");
+    }
+
+    private static void AssertClose(double actual, double expected, string name)
+    {
+        if (Math.Abs(actual - expected) > Tolerance)
+            throw new InvalidOperationException($"{name}: expected {expected}, actual {actual}.");
+    }
+
+    private static void AssertTrue(bool condition, string name)
+    {
+        if (!condition)
+            throw new InvalidOperationException($"{name}: expected true.");
+    }
+
+    private static void AssertFalse(bool condition, string name)
+    {
+        if (condition)
+            throw new InvalidOperationException($"{name}: expected false.");
+    }
+
+    private static void AssertThrowsArgumentOutOfRange(Action action, string name)
+    {
+        try
+        {
+            action();
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException($"{name}: expected ArgumentOutOfRangeException.");
+    }
+}

--- a/tests/TestShared/TestPointGridIndex.cs
+++ b/tests/TestShared/TestPointGridIndex.cs
@@ -2,7 +2,7 @@ namespace Test;
 
 public class TestPointGridIndex
 {
-    private const double Tolerance = 1e-8;
+    private const double Tolerance = 1e-6;
 
     [CommandMethod(nameof(Test_PointGridIndex))]
     public void Test_PointGridIndex()
@@ -43,6 +43,13 @@ public class TestPointGridIndex
         var boundaryIndices = index.QueryIndices(new Point2d(-1, -1), new Point2d(-1, -1));
         AssertTrue(boundaryIndices.Count == 1 && boundaryIndices[0] == negativeIndex,
             "Range includes exact boundary point");
+        var extremeRangeIndices = index.QueryIndices(
+            new Point2d(-double.MaxValue, -double.MaxValue),
+            new Point2d(double.MaxValue, double.MaxValue));
+        AssertTrue(extremeRangeIndices.Count == index.Count &&
+                   extremeRangeIndices[0] == firstIndex &&
+                   extremeRangeIndices[extremeRangeIndices.Count - 1] == farIndex,
+            "Unmappable finite range falls back to exact point filtering");
         AssertThrowsArgumentOutOfRange(
             () => index.QueryIndices(new Point2d(1, 0), new Point2d(0, 1)),
             "Reversed range");

--- a/tests/TestShared/TestShared.projitems
+++ b/tests/TestShared/TestShared.projitems
@@ -41,6 +41,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)TestMarshal.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestMirrorFile.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestPoint.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TestPointGridIndex.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestPointOnRegion.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestProgressMeter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestQuadTree.cs" />

--- a/tests/TestShared/TestShared.projitems
+++ b/tests/TestShared/TestShared.projitems
@@ -29,6 +29,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)TestEnv.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestExtents.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestFileDatabase.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TestGeometryQuery.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestHatchinfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestId.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestJig.cs" />


### PR DESCRIPTION
## 目的

将长期分支 `migration/zfgk-cad` 中已经分批实现和审查的通用 CAD 能力提交到 `main` 做最终集成评审。本 PR 只整合已收口结果，不再扩展 `Fs.Zfgk.CAD` 来源迁移范围。

Refs #110

## 主要变更

- 扩展 `CurveEx`：按距离比例取点、参数中点弦偏差、距离中点弦偏差，并明确有限曲线、`Ray` 与 `Xline` 的不同定义域。
- 扩展 `PointEx`：三维线性插值，以及按高程查找线段内唯一插值点。
- 扩展 `PolylineEx`：顶点数据快照、子段实际长度、按最大沿线间距采样、按最大弦偏差采样。
- 新增稀疏 `PointGridIndex`：稳定索引、近似去重、范围查询和带最大距离约束的最近点查询。
- 增加 `Test_GeometryQuery`、`Test_PointGridIndex`，并同步共享项目清单、模块基线、兼容性基线和历史迁移记录。

## 契约与边界

- 新增能力均为通用查询或独立内存索引，不写数据库、不依赖活动文档、UI、GraphicsSystem 或产品持久化协议。
- 折线采样保留原始顶点和任意 `Normal`/`Elevation`；闭合折线在结果末尾重复首点。
- 两个采样 API 在生成前精确计算结果规模，超过 1,000,000 点时失败，避免极小阈值造成同步阻塞或内存耗尽。
- 极端有限坐标无法映射到网格坐标时，`PointGridIndex` 退化为精确扫描，不把实现范围暴露为查询异常。
- 不修改程序集名称、NuGet 产品边界、目标框架、宿主配置或既有公共 API。
- 49 个来源 C# 文件均已形成“复用现有、已吸收或不迁移”的最终结论；本 PR 后不再建立来源迁移批次。

## 差异概况

- base：`main@6e6f942`
- head：`migration/zfgk-cad@ef03bfc`
- `main` 是当前长期分支的 merge base；创建 PR 前为 17 commits ahead、0 behind。
- 相对 `main` 共变更 14 个文件，主要为公共 API、测试、基线与迁移文档。

## 验证证据

长期分支最终 head 已完成：

- AC_2019、AC_2025、ZW_2022、ZW_2025、GC_2022、GC_2023、GC_2026 七目标 Release 库和测试程序集构建，均为 0 warnings / 0 errors。
- 模块守卫：`142 / 42 / 17`。
- 七目标公共兼容性守卫通过。
- AC_2019、AC_2025、ZW_2022、ZW_2025 四目标 TypeDef 顺序比较通过。
- HostAcceptance runner smoke 通过。
- `git diff --check`、Markdown 相对链接与 GitHub GFM 渲染检查通过。

创建本 PR 前重新执行 `git diff --check` 和模块守卫，结果通过。

真实 CAD 宿主未启动；`Test_GeometryQuery` 与 `Test_PointGridIndex` 尚未在 ZWCAD 2022、AutoCAD 2020/2026 中运行，宿主验收状态为 `Not run`。自动构建证据不代表宿主通过。

## 评审重点

- 新增公共 API 的命名、异常、返回值和只读/所有权契约是否适合作为长期基础库能力。
- `Ray`、`Xline`、圆弧、闭合/退化折线及任意 OCS 法向的定义域是否清晰。
- `PointGridIndex` 的容差、极端坐标退化和非线程安全边界是否可接受。
- 合并前是否需要补充 ZWCAD 2022 优先的真实宿主验收。

本 PR 仅建立 `main` 集成评审入口；不会自动合并，合并仍需单独审查与明确批准。