### PR TITLE
fix(ci): keep CadDiagnostics outputs platform-independent

### DIFF
--- a/tools/CadDiagnostics/Fs.Fox.CAD.Diagnostics.AutoCad2019/Fs.Fox.CAD.Diagnostics.AutoCad2019.csproj
+++ b/tools/CadDiagnostics/Fs.Fox.CAD.Diagnostics.AutoCad2019/Fs.Fox.CAD.Diagnostics.AutoCad2019.csproj
@@ -7,13 +7,14 @@
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+  <!-- Keep the versioned output contract independent of AnyCPU/"Any CPU" spelling. -->
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <DebugType>none</DebugType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <OutputPath>..\..\..\Build\AC_$(ACADVersion)_$(Configuration)\</OutputPath>
     <DocumentationFile>..\..\..\Build\AC_$(ACADVersion)_$(Configuration)\Fs.Fox.CAD.Diagnostics.AutoCad2019.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <DebugType>none</DebugType>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <OutputPath>..\..\..\Build\AC_$(ACADVersion)_$(Configuration)\</OutputPath>

--- a/tools/CadDiagnostics/Fs.Fox.CAD.Diagnostics.AutoCad2025/Fs.Fox.CAD.Diagnostics.AutoCad2025.csproj
+++ b/tools/CadDiagnostics/Fs.Fox.CAD.Diagnostics.AutoCad2025/Fs.Fox.CAD.Diagnostics.AutoCad2025.csproj
@@ -6,13 +6,14 @@
     <EnableDynamicLoading>true</EnableDynamicLoading>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+  <!-- Keep the versioned output contract independent of AnyCPU/"Any CPU" spelling. -->
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <DebugType>none</DebugType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <OutputPath>..\..\..\Build\AC_$(ACADVersion)_$(Configuration)\</OutputPath>
     <DocumentationFile>..\..\..\Build\AC_$(ACADVersion)_$(Configuration)\Fs.Fox.CAD.Diagnostics.AutoCad2025.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <DebugType>none</DebugType>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <OutputPath>..\..\..\Build\AC_$(ACADVersion)_$(Configuration)\</OutputPath>


### PR DESCRIPTION
## Summary

修复合并 PR #126 后 `Build All Targets` 失败的问题。AutoCAD 2019/2025 诊断项目的版本化输出路径不再依赖 MSBuild 对 `AnyCPU` / `Any CPU` 的具体拼写，避免回退到 `tools/bin`。

## Changes

- 将两个诊断项目的 Debug/Release 输出条件改为只依赖 `$(Configuration)`。
- 保留既有 `Build/AC_2019_<Configuration>` 和 `Build/AC_2025_<Configuration>` 输出契约。
- 增加注释说明平台名称拼写不应影响输出目录。
- 未修改诊断代码、公共 API、工作流矩阵或部署行为。

## Validation

- AutoCAD 2019 diagnostics：Debug、Release 编译通过。
- AutoCAD 2025 diagnostics：Debug、Release 编译通过（保留已有 2 个 `MSB3825` 资源警告，0 错误）。
- `Verify-CadDiagnostics.ps1 -Configuration Debug`：通过。
- `Verify-CadDiagnostics.ps1 -Configuration Release`：通过。
- 已确认四个输出目录均包含对应 DLL/XML。
- 未启动 AutoCAD，未执行宿主加载、NETLOAD、命令或写操作；本 PR 只验证编译和产物契约。

## Context

PR #126 的 CI 在 NUC11 和 NUC12 两台 self-hosted runner 上均复现相同的产物路径错误。该修复不依赖 runner 盘符或环境差异。

Refs #124
Follow-up to #126