### PR TITLE
refactor: 统一 CadDiagnostics 多版本输出文件名

### DIFF
--- a/tools/CadDiagnostics/Fs.Fox.CAD.Diagnostics.AutoCad2019/Fs.Fox.CAD.Diagnostics.AutoCad2019.csproj
+++ b/tools/CadDiagnostics/Fs.Fox.CAD.Diagnostics.AutoCad2019/Fs.Fox.CAD.Diagnostics.AutoCad2019.csproj
@@ -2,7 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net48</TargetFramework>
     <ACADVersion>2019</ACADVersion>
-    <AssemblyName>Fs.Fox.CAD.Diagnostics.AutoCad2019</AssemblyName>
+    <!-- The versioned Build directory is the SDK identity; keep the file name stable. -->
+    <AssemblyName>Fs.Fox.AutoCad.Diagnostics</AssemblyName>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
@@ -12,13 +13,13 @@
     <DebugType>none</DebugType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <OutputPath>..\..\..\Build\AC_$(ACADVersion)_$(Configuration)\</OutputPath>
-    <DocumentationFile>..\..\..\Build\AC_$(ACADVersion)_$(Configuration)\Fs.Fox.CAD.Diagnostics.AutoCad2019.xml</DocumentationFile>
+    <DocumentationFile>..\..\..\Build\AC_$(ACADVersion)_$(Configuration)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <DebugType>none</DebugType>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <OutputPath>..\..\..\Build\AC_$(ACADVersion)_$(Configuration)\</OutputPath>
-    <DocumentationFile>..\..\..\Build\AC_$(ACADVersion)_$(Configuration)\Fs.Fox.CAD.Diagnostics.AutoCad2019.xml</DocumentationFile>
+    <DocumentationFile>..\..\..\Build\AC_$(ACADVersion)_$(Configuration)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tools/CadDiagnostics/Fs.Fox.CAD.Diagnostics.AutoCad2025/Fs.Fox.CAD.Diagnostics.AutoCad2025.csproj
+++ b/tools/CadDiagnostics/Fs.Fox.CAD.Diagnostics.AutoCad2025/Fs.Fox.CAD.Diagnostics.AutoCad2025.csproj
@@ -2,7 +2,8 @@
   <PropertyGroup>
     <TargetFramework>net8.0-windows7.0</TargetFramework>
     <ACADVersion>2025</ACADVersion>
-    <AssemblyName>Fs.Fox.CAD.Diagnostics.AutoCad2025</AssemblyName>
+    <!-- The versioned Build directory is the SDK identity; keep the file name stable. -->
+    <AssemblyName>Fs.Fox.AutoCad.Diagnostics</AssemblyName>
     <EnableDynamicLoading>true</EnableDynamicLoading>
   </PropertyGroup>
 
@@ -11,13 +12,13 @@
     <DebugType>none</DebugType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <OutputPath>..\..\..\Build\AC_$(ACADVersion)_$(Configuration)\</OutputPath>
-    <DocumentationFile>..\..\..\Build\AC_$(ACADVersion)_$(Configuration)\Fs.Fox.CAD.Diagnostics.AutoCad2025.xml</DocumentationFile>
+    <DocumentationFile>..\..\..\Build\AC_$(ACADVersion)_$(Configuration)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <DebugType>none</DebugType>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <OutputPath>..\..\..\Build\AC_$(ACADVersion)_$(Configuration)\</OutputPath>
-    <DocumentationFile>..\..\..\Build\AC_$(ACADVersion)_$(Configuration)\Fs.Fox.CAD.Diagnostics.AutoCad2025.xml</DocumentationFile>
+    <DocumentationFile>..\..\..\Build\AC_$(ACADVersion)_$(Configuration)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/tools/CadDiagnostics/README.md
+++ b/tools/CadDiagnostics/README.md
@@ -39,12 +39,15 @@ for those products; those targets remain work under Issue #124.
 
 | SDK baseline | Target framework | Constants | Output assembly | Runtime validation |
 | --- | --- | --- | --- | --- |
-| AutoCAD 2019 / `AutoCAD.NET` 23.0.0 | .NET Framework 4.8 | `ACAD;AC_2019;AC_NET48` | `Build/AC_2019_<Configuration>/Fs.Fox.CAD.Diagnostics.AutoCad2019.dll` | `Not run` |
-| AutoCAD 2025 / `AutoCAD.NET` 25.0.1 | .NET 8 | `ACAD;AC_2025` | `Build/AC_2025_<Configuration>/Fs.Fox.CAD.Diagnostics.AutoCad2025.dll` | `Not run` |
+| AutoCAD 2019 / `AutoCAD.NET` 23.0.0 | .NET Framework 4.8 | `ACAD;AC_2019;AC_NET48` | `Build/AC_2019_<Configuration>/Fs.Fox.AutoCad.Diagnostics.dll` | `Not run` |
+| AutoCAD 2025 / `AutoCAD.NET` 25.0.1 | .NET 8 | `ACAD;AC_2025` | `Build/AC_2025_<Configuration>/Fs.Fox.AutoCad.Diagnostics.dll` | `Not run` |
 
-Each output includes the same-named XML documentation file and follows the main
-AutoCAD projects' no-PDB build policy. The SDK year identifies the compile-time
-API baseline, not the actual AutoCAD product in which the DLL is loaded.
+Each output includes `Fs.Fox.AutoCad.Diagnostics.xml` and follows the main
+AutoCAD projects' no-PDB build policy. Generated `.deps.json`,
+`.runtimeconfig.json` and any future PDB use the same `AssemblyName` base name
+automatically. The versioned output directory, not the common file name,
+identifies the compile-time SDK baseline. Do not merge files from different
+`AC_<year>_<Configuration>` directories into one folder.
 
 From a Visual Studio Developer PowerShell:
 

--- a/tools/CadDiagnostics/Verify-CadDiagnostics.ps1
+++ b/tools/CadDiagnostics/Verify-CadDiagnostics.ps1
@@ -49,6 +49,50 @@ function Get-TopLevelPublicTypeNames {
     }
 }
 
+function Get-AssemblyReferenceNames {
+    param([string]$AssemblyPath)
+
+    $stream = [System.IO.File]::OpenRead($AssemblyPath)
+    $peReader = $null
+    try {
+        $peReader = [System.Reflection.PortableExecutable.PEReader]::new($stream)
+        $metadata = [System.Reflection.Metadata.PEReaderExtensions]::GetMetadataReader($peReader)
+        $names = foreach ($handle in $metadata.AssemblyReferences) {
+            $reference = $metadata.GetAssemblyReference($handle)
+            $metadata.GetString($reference.Name)
+        }
+        return @($names | Sort-Object)
+    }
+    finally {
+        if ($null -ne $peReader) {
+            $peReader.Dispose()
+        }
+        $stream.Dispose()
+    }
+}
+
+function Get-ManifestResourceNames {
+    param([string]$AssemblyPath)
+
+    $stream = [System.IO.File]::OpenRead($AssemblyPath)
+    $peReader = $null
+    try {
+        $peReader = [System.Reflection.PortableExecutable.PEReader]::new($stream)
+        $metadata = [System.Reflection.Metadata.PEReaderExtensions]::GetMetadataReader($peReader)
+        $names = foreach ($handle in $metadata.ManifestResources) {
+            $resource = $metadata.GetManifestResource($handle)
+            $metadata.GetString($resource.Name)
+        }
+        return @($names | Sort-Object)
+    }
+    finally {
+        if ($null -ne $peReader) {
+            $peReader.Dispose()
+        }
+        $stream.Dispose()
+    }
+}
+
 function Test-Binary {
     param(
         [string]$SdkYear,
@@ -73,12 +117,13 @@ function Test-Binary {
             "Autodesk SDK assembly must not be copied to diagnostics output: $fileName"
     }
 
-    $assembly = [System.Reflection.Assembly]::LoadFile((Resolve-Path $assemblyPath).Path)
-    $references = @($assembly.GetReferencedAssemblies() | ForEach-Object Name)
+    # Both SDK targets now share one assembly identity. Read metadata directly
+    # so verification never loads one target in place of the other.
+    $references = Get-AssemblyReferenceNames -AssemblyPath $assemblyPath
     Assert-Condition (-not ($references | Where-Object { $_ -like 'Fs.Fox.AutoCad*' })) `
         "$AssemblyName must not reference Fs.Fox.AutoCad."
 
-    $resourceNames = @($assembly.GetManifestResourceNames())
+    $resourceNames = Get-ManifestResourceNames -AssemblyPath $assemblyPath
     $reportResources = @($resourceNames | Where-Object {
         $_.StartsWith('Fs.Fox.CAD.Diagnostics.ReportBrowser/', [System.StringComparison]::Ordinal)
     })
@@ -142,12 +187,19 @@ $commandDifference = @(Compare-Object $expectedCommandNames $migratedCommandName
 Assert-Condition ($commandDifference.Count -eq 0) `
     "The migrated command-name set differs from the legacy commands plus MgdDbgAbout: $($commandDifference | Out-String)"
 
+$diagnosticAssemblyName = 'Fs.Fox.AutoCad.Diagnostics'
 $projectFiles = @(
     'Fs.Fox.CAD.Diagnostics.AutoCad2019\Fs.Fox.CAD.Diagnostics.AutoCad2019.csproj',
     'Fs.Fox.CAD.Diagnostics.AutoCad2025\Fs.Fox.CAD.Diagnostics.AutoCad2025.csproj'
 )
 foreach ($relativeProjectPath in $projectFiles) {
     [xml]$project = Get-Content -Raw (Join-Path $PSScriptRoot $relativeProjectPath)
+    $assemblyNames = @($project.SelectNodes("//*[local-name()='AssemblyName']") |
+        ForEach-Object { $_.InnerText } |
+        Sort-Object -Unique)
+    Assert-Condition ($assemblyNames.Count -eq 1 -and $assemblyNames[0] -eq $diagnosticAssemblyName) `
+        "$relativeProjectPath must produce $diagnosticAssemblyName."
+
     $projectReferences = @($project.SelectNodes("//*[local-name()='ProjectReference']"))
     Assert-Condition ($projectReferences.Count -eq 0) `
         "$relativeProjectPath must not contain project references."
@@ -163,7 +215,9 @@ $migratedSourceText = (Get-ChildItem -LiteralPath $sharedRoot -Recurse -Filter '
 Assert-Condition ($migratedSourceText -notmatch '\bnamespace\s+MgdDbg\b') `
     'A legacy MgdDbg namespace remains in migrated source.'
 
-Test-Binary -SdkYear '2019' -AssemblyName 'Fs.Fox.CAD.Diagnostics.AutoCad2019'
-Test-Binary -SdkYear '2025' -AssemblyName 'Fs.Fox.CAD.Diagnostics.AutoCad2025'
+# The SDK year belongs to the output directory; both targets intentionally
+# expose the same stable plug-in file name.
+Test-Binary -SdkYear '2019' -AssemblyName $diagnosticAssemblyName
+Test-Binary -SdkYear '2025' -AssemblyName $diagnosticAssemblyName
 
 Write-Host "CadDiagnostics migration verification passed for $Configuration."

--- a/编译说明.md
+++ b/编译说明.md
@@ -35,10 +35,10 @@ NuGet 发布工作流当前发布以下七组类库，全部面向 Windows x64�
 
 | 诊断项目 | 目标框架 | 编译期 SDK | 输出程序集 |
 | --- | --- | --- | --- |
-| `Fs.Fox.CAD.Diagnostics.AutoCad2019` | `net48` | `AutoCAD.NET` 23.0.0 | `Build/AC_2019_<配置>/Fs.Fox.CAD.Diagnostics.AutoCad2019.dll` |
-| `Fs.Fox.CAD.Diagnostics.AutoCad2025` | `net8.0-windows7.0` | `AutoCAD.NET` 25.0.1 | `Build/AC_2025_<配置>/Fs.Fox.CAD.Diagnostics.AutoCad2025.dll` |
+| `Fs.Fox.CAD.Diagnostics.AutoCad2019` | `net48` | `AutoCAD.NET` 23.0.0 | `Build/AC_2019_<配置>/Fs.Fox.AutoCad.Diagnostics.dll` |
+| `Fs.Fox.CAD.Diagnostics.AutoCad2025` | `net8.0-windows7.0` | `AutoCAD.NET` 25.0.1 | `Build/AC_2025_<配置>/Fs.Fox.AutoCad.Diagnostics.dll` |
 
-诊断工具不创建 Bundle、安装器、部署脚本或 NuGet 包。完整命令、NETLOAD 方法、依赖边界和宿主验收状态见 [CadDiagnostics 组件说明](tools/CadDiagnostics/README.md)。
+两个目标使用相同的程序集、XML 文档基础文件名，SDK 年代由 `AC_2019_<配置>` / `AC_2025_<配置>` 目录承担。不同年代的文件不得合并到同一目录；`MgdDbgAbout` 可在加载后报告编译 SDK、目标框架、实际宿主与程序集路径。诊断工具不创建 Bundle、安装器、部署脚本或 NuGet 包。完整命令、NETLOAD 方法、依赖边界和宿主验收状态见 [CadDiagnostics 组件说明](tools/CadDiagnostics/README.md)。
 
 ### 测试入口
 


### PR DESCRIPTION
## 概要

- AutoCAD 2019 与 2025 诊断项目统一输出 `Fs.Fox.AutoCad.Diagnostics.dll`。
- XML 文档改为 `$(AssemblyName).xml`；net8 的 `.deps.json`、`.runtimeconfig.json` 及未来可能启用的 PDB 会自动使用同一基础文件名。
- 保留版本化项目名和输出目录：
  - `Build/AC_2019_<Configuration>/Fs.Fox.AutoCad.Diagnostics.dll`
  - `Build/AC_2025_<Configuration>/Fs.Fox.AutoCad.Diagnostics.dll`
- 文档明确：SDK 年代由目录承担，不得把不同年代文件合并到同一目录；`MgdDbgAbout` 继续报告 SDK、TFM、实际宿主与加载路径。

## 校验适配

两个目标现在具有相同程序集身份。为避免 PowerShell 校验进程把一个目标误当成另一个目标，依赖、嵌入资源和公共类型检查改为直接读取 PE 元数据，不再执行 `Assembly.LoadFile`。这也避免校验期间加载插件代码或 Autodesk 依赖。

## 验证

- AutoCAD 2019 / net48 Release x64：编译通过，生成统一 DLL/XML 名称。
- AutoCAD 2025 / net8 Release x64：编译通过，生成统一 DLL/XML/deps/runtimeconfig 名称；0 error，保留已记录的 4 条旧 WinForms `.resx` `MSB3825` 警告。
- `Verify-CadDiagnostics.ps1 -Configuration Release`：两个目录均通过。
- 旧输出文件名引用、项目 XML、CRLF、`git diff --check`：通过。
- Markdown 相对链接及 GitHub GFM 渲染：通过。
- CAD 宿主加载：`Not run`（本次仅做编译验证）。

本 PR 叠加在 #129 上；合并顺序为 #127 → #129 → 本 PR。

Refs #124
Depends on #127
Depends on #129