### PR TITLE
CadDiagnostics: 增强动态块与注释比例只读下钻

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -72,7 +72,7 @@ front matter schema 和自动校验尚未落地。在迁移完成前，本页状
 | --- | --- | --- | --- |
 | `proposal` | `contract.dbtrans-lifecycle` | [DBTrans 生命周期与释放契约](dbtrans-lifecycle-contract.md) | 同时记录 Confirmed、Decision 与 Not run；不能把后续决定表述为已实施。 |
 | `proposal` | `proposal.edgeone-site-repository` | [EdgeOne Makers 站点仓库架构评估](edgeone-site-repository-evaluation.md) | Issue #48 的实施提案；展示仓库与精确来源链路已创建，最终框架、GitHub App、EdgeOne 和云资源仍未完成。 |
-| `proposal` | `proposal.cad-diagnostics-open-source-intake` | [CadDiagnostics 开源诊断项目评估](../tools/CadDiagnostics/OPEN-SOURCE-EVALUATION.md) | Issue #124 下的候选、去重依据和阶段边界；P1 已实施，P2 仍需独立 PR。 |
+| `proposal` | `proposal.cad-diagnostics-open-source-intake` | [CadDiagnostics 开源诊断项目评估](../tools/CadDiagnostics/OPEN-SOURCE-EVALUATION.md) | Issue #124 下的候选、去重依据和阶段边界；P1、P2-A 已实施，P2-B 仍需独立 PR。 |
 
 ## 6. 历史材料
 

--- a/tools/CadDiagnostics/CADDiagnosticsShared/Snoop/CollectorExts/DbMisc.cs
+++ b/tools/CadDiagnostics/CADDiagnosticsShared/Snoop/CollectorExts/DbMisc.cs
@@ -308,6 +308,12 @@ namespace Fs.Fox.CAD.Diagnostics.Snoop.CollectorExts
                 return;
             }
 
+            ObjectContextManager objContextMgr = e.ObjToSnoop as ObjectContextManager;
+            if (objContextMgr != null) {
+                Stream(snoopCollector.Data(), objContextMgr);
+                return;
+            }
+
             ObjectContext objContext = e.ObjToSnoop as ObjectContext;
             if (objContext != null) {
                 Stream(snoopCollector.Data(), objContext);
@@ -1025,11 +1031,21 @@ namespace Fs.Fox.CAD.Diagnostics.Snoop.CollectorExts
         {
             data.Add(new Snoop.Data.ClassSeparator(typeof(DynamicBlockReferenceProperty)));
 
-            data.Add(new Snoop.Data.ObjectId("Block Id", dynBlkRefProp.BlockId));
-            data.Add(new Snoop.Data.String("Description", dynBlkRefProp.Description));
-            data.Add(new Snoop.Data.String("Property name", dynBlkRefProp.PropertyName));
-            data.Add(new Snoop.Data.Int("Property type code", dynBlkRefProp.PropertyTypeCode));
-            data.Add(new Snoop.Data.String("Units type", dynBlkRefProp.UnitsType.ToString()));
+            // Dynamic property getters can fail independently when a block definition or
+            // visibility state is no longer available. Keep every failure local so the
+            // remaining diagnostic values are still useful.
+            AddSafely(data, "Block Id", () => new Snoop.Data.ObjectId("Block Id", dynBlkRefProp.BlockId));
+            AddSafely(data, "Description", () => new Snoop.Data.String("Description", dynBlkRefProp.Description));
+            AddSafely(data, "Property name", () => new Snoop.Data.String("Property name", dynBlkRefProp.PropertyName));
+            AddSafely(data, "Property type code", () => new Snoop.Data.Int("Property type code", dynBlkRefProp.PropertyTypeCode));
+            AddSafely(data, "Units type", () => new Snoop.Data.String("Units type", dynBlkRefProp.UnitsType.ToString()));
+            AddSafely(data, "Value", () => {
+                object value = dynBlkRefProp.Value;
+                return new Snoop.Data.String("Value", value == null ? "(null)" : value.ToString());
+            });
+            AddSafely(data, "Read only", () => new Snoop.Data.Bool("Read only", dynBlkRefProp.ReadOnly));
+            AddSafely(data, "Show", () => new Snoop.Data.Bool("Show", dynBlkRefProp.Show));
+            AddSafely(data, "Allowed values", () => new Snoop.Data.Enumerable("Allowed values", dynBlkRefProp.GetAllowedValues()));
         }
 
         private void
@@ -1327,12 +1343,36 @@ namespace Fs.Fox.CAD.Diagnostics.Snoop.CollectorExts
         }
 
         private void
+        Stream(ArrayList data, ObjectContextManager objContextMgr)
+        {
+            data.Add(new Snoop.Data.ClassSeparator(typeof(ObjectContextManager)));
+
+            // ObjectContextManager and its collections are owned by the database. This
+            // collector only exposes the registered annotation scales and never creates,
+            // removes, switches or disposes a context.
+            AddSafely(data, "Annotation scales", () => new Snoop.Data.Enumerable(
+                "Annotation scales",
+                objContextMgr.GetContextCollection("ACDB_ANNOTATIONSCALES")));
+        }
+
+        private void
         Stream(ArrayList data, ObjectContext objContext)
         {
             data.Add(new Snoop.Data.ClassSeparator(typeof(ObjectContext)));
 
             data.Add(new Snoop.Data.String("Collection name", objContext.CollectionName));
             data.Add(new Snoop.Data.String("Name", objContext.Name));
+        }
+
+        private static void
+        AddSafely(ArrayList data, string label, Func<Snoop.Data.Data> createData)
+        {
+            try {
+                data.Add(createData());
+            }
+            catch (System.Exception e) {
+                data.Add(new Snoop.Data.Exception(label, e));
+            }
         }
 
         private void

--- a/tools/CadDiagnostics/OPEN-SOURCE-EVALUATION.md
+++ b/tools/CadDiagnostics/OPEN-SOURCE-EVALUATION.md
@@ -1,6 +1,6 @@
 # CadDiagnostics 开源诊断项目评估
 
-> 状态：`proposal`，第一优先级已实施，第二优先级待独立 PR<br>
+> 状态：`proposal`，第一优先级及 P2-A 已实施，P2-B 待独立 PR<br>
 > 评估日期：2026-08-04<br>
 > Fs.Fox.CAD 基线：`main@18c9cb5e2828655db26e9ed303eef82d1e60491e`<br>
 > 跟踪：[父路线 #124](https://github.com/FsDiG/Fs.Fox.CAD/issues/124)、
@@ -152,22 +152,31 @@ WPF 窗口或完整 ViewModel。与当前实现逐项比对如下：
 ## 5. 第二优先级详细拆分
 
 第二优先级由 [Issue #132](https://github.com/FsDiG/Fs.Fox.CAD/issues/132)
-跟踪。在 #131 合并后从最新 `main` 建立新分支，不能混入当前修复 PR。
+跟踪，并按 P2-A、P2-B 两个独立 PR 依次实施。
 
-### P2-A：动态块属性与注释比例
+### P2-A：动态块属性与注释比例（已实施）
 
-建议一个独立 PR，范围限定为只读 collector：
+P2-A 只修改维护中的只读 collector：
 
-1. 为 `DynamicBlockReferenceProperty` 补充 Value、ReadOnly、Show 和
-   `GetAllowedValues()`；允许值使用现有 `Snoop.Data` 下钻，不新增窗口。
-2. 为 `ObjectContextManager` 提供 `ACDB_ANNOTATIONSCALES` 集合入口；只读取
-   已有 context collection，不创建、删除或设置当前比例。
-3. 单个 getter 或集合读取异常转成 `Snoop.Data.Exception`，不能中止整个
-   对象收集；禁止静默吞错。
-4. 不新增公共类型、命令、WPF 依赖或 Fs.Fox.AutoCad 引用。
+1. `DynamicBlockReferenceProperty` 已补充 Value、ReadOnly、Show 和
+   `GetAllowedValues()`；原有属性与新增属性均逐 getter 隔离异常，允许值复用
+   `Snoop.Data.Enumerable` 下钻。
+2. `ObjectContextManager` 已提供 `ACDB_ANNOTATIONSCALES` 集合入口；仅枚举
+   数据库拥有的 manager 和 context collection，不创建、删除、切换或处置
+   context。
+3. 单个 getter、集合获取或枚举失败会生成 `Snoop.Data.Exception`，其余属性
+   继续收集，不静默吞错。
+4. 未新增公共类型、命令、WPF 依赖或 Fs.Fox.AutoCad 引用。实现仅采用
+   Gile.Inspector 的行为思路，没有复制其 wrapper 或 UI 代码。
 
-验收仅执行 AutoCAD 2019/2025 Release x64 编译和静态检查。实际动态块、
-注释比例下钻保持 `Not run`，直至人工宿主验收另行记录。
+验证结果：
+
+| 目标 | 结果 |
+| --- | --- |
+| AutoCAD 2019 / .NET Framework 4.8 / Release x64 | Build passed |
+| AutoCAD 2025 / .NET 8 / Release x64 | Build passed；保留 2 个既有 `MSB3825` WinForms 资源警告 |
+| 迁移边界与输出静态检查 | Passed |
+| 动态块与注释比例 CAD 宿主下钻 | `Not run`，按本阶段边界不执行 |
 
 ### P2-B：Hatch loop
 


### PR DESCRIPTION
### 相关的 Issue

Refs #124
Refs #132

### 原因

CadDiagnostics 当前能进入动态块属性和数据库的 `ObjectContextManager`，但缺少关键只读语义值及注释比例集合入口。单个宿主 getter 失败还会中断该对象后续信息收集。

### 描述

- 为 `DynamicBlockReferenceProperty` 补充 Value、ReadOnly、Show、Allowed values，并将全部相关 getter 逐项隔离为可见 `Snoop.Data.Exception`。
- 为 `ObjectContextManager` 增加只读 `ACDB_ANNOTATIONSCALES` 集合下钻；不创建、删除、切换或处置数据库拥有的 context。
- 更新开源评估实施记录和文档索引；仅采用 Gile.Inspector 的行为思路，没有复制 wrapper 或 UI 代码。
- 不新增公共 API、命令、WPF 或 `Fs.Fox.AutoCad.dll` 依赖。

### 验证

- AutoCAD 2019 / .NET Framework 4.8 / Release x64：Build passed。
- AutoCAD 2025 / .NET 8 / Release x64：Build passed；仅保留既有 `MSB3825` WinForms 资源警告。
- `Verify-CadDiagnostics.ps1 -Configuration Release`：passed。
- `git diff --check`、Markdown 相对链接和 GitHub GFM 渲染：passed。
- CAD 宿主动态块/注释比例下钻：`Not run`（本阶段明确不执行宿主加载验证）。