### PR TITLE
CadDiagnostics: 恢复 Hatch loop 只读下钻

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -72,7 +72,7 @@ front matter schema 和自动校验尚未落地。在迁移完成前，本页状
 | --- | --- | --- | --- |
 | `proposal` | `contract.dbtrans-lifecycle` | [DBTrans 生命周期与释放契约](dbtrans-lifecycle-contract.md) | 同时记录 Confirmed、Decision 与 Not run；不能把后续决定表述为已实施。 |
 | `proposal` | `proposal.edgeone-site-repository` | [EdgeOne Makers 站点仓库架构评估](edgeone-site-repository-evaluation.md) | Issue #48 的实施提案；展示仓库与精确来源链路已创建，最终框架、GitHub App、EdgeOne 和云资源仍未完成。 |
-| `proposal` | `proposal.cad-diagnostics-open-source-intake` | [CadDiagnostics 开源诊断项目评估](../tools/CadDiagnostics/OPEN-SOURCE-EVALUATION.md) | Issue #124 下的候选、去重依据和阶段边界；P1、P2-A 已实施，P2-B 仍需独立 PR。 |
+| `proposal` | `proposal.cad-diagnostics-open-source-intake` | [CadDiagnostics 开源诊断项目评估](../tools/CadDiagnostics/OPEN-SOURCE-EVALUATION.md) | Issue #124 下的候选、去重依据和阶段边界；P1、P2 已实施，后续候选仍需独立评估。 |
 
 ## 6. 历史材料
 

--- a/tools/CadDiagnostics/CADDiagnosticsShared/Snoop/CollectorExts/DbMisc.cs
+++ b/tools/CadDiagnostics/CADDiagnosticsShared/Snoop/CollectorExts/DbMisc.cs
@@ -66,6 +66,12 @@ namespace Fs.Fox.CAD.Diagnostics.Snoop.CollectorExts
                 return;
             }
 
+            HatchLoop hatchLoop = e.ObjToSnoop as HatchLoop;
+            if (hatchLoop != null) {
+                Stream(snoopCollector.Data(), hatchLoop);
+                return;
+            }
+
             LoftOptions loftOpt = e.ObjToSnoop as LoftOptions;
             if (loftOpt != null) {
                 Stream(snoopCollector.Data(), loftOpt);
@@ -785,13 +791,6 @@ namespace Fs.Fox.CAD.Diagnostics.Snoop.CollectorExts
 
             data.Add(new Snoop.Data.Point2d("Vertex", bulgeVert.Vertex));
             data.Add(new Snoop.Data.Double("Bulge", bulgeVert.Bulge));
-
-
-            //HatchLoop loop = bulgeVerts as HatchLoop;
-            //if (bulgeVerts != null) {
-            //    Stream(data, bulgeVerts);
-            //    return;
-            //}
         }
 
         private void
@@ -799,7 +798,15 @@ namespace Fs.Fox.CAD.Diagnostics.Snoop.CollectorExts
         {
             data.Add(new Snoop.Data.ClassSeparator(typeof(HatchLoop)));
 
-            data.Add(new Snoop.Data.String("Loop type", loop.LoopType.ToString()));
+            AddSafely(data, "Loop type", () => new Snoop.Data.String("Loop type", loop.LoopType.ToString()));
+            AddSafely(data, "Is polyline", () => new Snoop.Data.Bool("Is polyline", loop.IsPolyline));
+
+            // A HatchLoop contains exactly one boundary representation. Do not ask for
+            // Curves on a polyline loop (or Polyline on an edge loop), because AutoCAD
+            // reports that mismatched accessor as NotApplicable.
+            AddSafely(data, "Boundary", () => loop.IsPolyline
+                ? new Snoop.Data.Enumerable("Polyline", loop.Polyline)
+                : new Snoop.Data.Enumerable("Curves", loop.Curves));
         }
 
         private void

--- a/tools/CadDiagnostics/CADDiagnosticsShared/Snoop/CollectorExts/Entity.cs
+++ b/tools/CadDiagnostics/CADDiagnosticsShared/Snoop/CollectorExts/Entity.cs
@@ -1393,22 +1393,25 @@ namespace Fs.Fox.CAD.Diagnostics.Snoop.CollectorExts {
                 data.Add(new Snoop.Data.ObjectCollection("Hatch lines data", (System.Collections.ICollection)hatch.GetHatchLinesData()));
             }
 
-            data.Add(new Snoop.Data.Int("Number of loops", hatch.NumberOfLoops));
+            int numberOfLoops = hatch.NumberOfLoops;
+            data.Add(new Snoop.Data.Int("Number of loops", numberOfLoops));
 
-            // TBD: thows exception even though it reports a loop! Only works if
-            // HatchLoopType is Polyline
-            /*try {
-                ArrayList hatchLoops = new ArrayList();
-                for (int i=0; i<hatch.NumberOfLoops; i++)
+            ArrayList hatchLoops = new ArrayList();
+            for (int i = 0; i < numberOfLoops; i++) {
+                try {
+                    // HatchLoop is a managed value object in both supported SDKs and does
+                    // not implement IDisposable. Keep it available for the Snoop dialog;
+                    // never dispose the database-owned Hatch or transaction objects here.
                     hatchLoops.Add(hatch.GetLoopAt(i));
-                data.Add(new Snoop.Data.ObjectCollection("Hatch loops", hatchLoops));
+                }
+                catch (Autodesk.AutoCAD.Runtime.Exception e) {
+                    // Some drawings report a loop count but return NotApplicable (or
+                    // another host error) for an individual loop. Preserve the remaining
+                    // loops and expose the failed index instead of hiding the exception.
+                    data.Add(new Snoop.Data.Exception(string.Format("Hatch loop [{0:d}]", i), e));
+                }
             }
-            catch (Autodesk.AutoCAD.Runtime.Exception e) {
-                if (e.ErrorStatus == (int)Autodesk.AutoCAD.Runtime.ErrorStatus.NotApplicable)
-                    data.Add(new Snoop.Data.String("Hatch loops", Autodesk.AutoCAD.Runtime.ErrorStatus.NotApplicable.ToString()));
-                else
-                    throw;
-            }*/
+            data.Add(new Snoop.Data.ObjectCollection("Hatch loops", hatchLoops));
 
             data.Add(new Snoop.Data.Int("Number of pattern defs", hatch.NumberOfPatternDefinitions));
             ArrayList patternDefs = new ArrayList();

--- a/tools/CadDiagnostics/OPEN-SOURCE-EVALUATION.md
+++ b/tools/CadDiagnostics/OPEN-SOURCE-EVALUATION.md
@@ -1,6 +1,6 @@
 # CadDiagnostics 开源诊断项目评估
 
-> 状态：`proposal`，第一优先级及 P2-A 已实施，P2-B 待独立 PR<br>
+> 状态：`proposal`，第一优先级及 P2 已实施，P2 后候选仍待独立评估<br>
 > 评估日期：2026-08-04<br>
 > Fs.Fox.CAD 基线：`main@18c9cb5e2828655db26e9ed303eef82d1e60491e`<br>
 > 跟踪：[父路线 #124](https://github.com/FsDiG/Fs.Fox.CAD/issues/124)、
@@ -178,19 +178,30 @@ P2-A 只修改维护中的只读 collector：
 | 迁移边界与输出静态检查 | Passed |
 | 动态块与注释比例 CAD 宿主下钻 | `Not run`，按本阶段边界不执行 |
 
-### P2-B：Hatch loop
+### P2-B：Hatch loop（已实施）
 
-建议在 P2-A 审核后使用另一个 PR：
+P2-B 使用独立 PR 恢复原 MgdDbg 中被禁用的集合入口，并补齐原本不可达的
+`HatchLoop` collector：
 
-1. 替换当前 `Entity.cs` 中整段注释掉的旧代码；
-2. 按 loop index 调用 `GetLoopAt()`，polyline 与非 polyline loop 都作为
-   `Snoop.Data.ObjectCollection` 子项；
-3. 每个 loop 独立捕获 AutoCAD 异常并生成可见错误项，不能因一个 loop
-   失败而丢失其他 loop 或整个实体信息；
-4. 不处置数据库或事务拥有的对象，不把临时对象保存到窗口生命周期之外。
+1. 按 loop index 调用 `GetLoopAt()`，不按 `HatchLoopTypes` 过滤；成功的
+   polyline 与非 polyline loop 都进入现有 `Snoop.Data.ObjectCollection`。
+2. 每个 loop 独立捕获 AutoCAD 宿主异常，以带 index 的
+   `Snoop.Data.Exception` 显示；一个失败项不会丢失其他 loop 或整个实体信息。
+3. `HatchLoop` 下钻按 `IsPolyline` 只读取匹配的 `Polyline` 或 `Curves` 集合，
+   避免主动触发另一种边界访问器的 `NotApplicable`。
+4. `HatchLoop` 在两个目标 SDK 中均为不实现 `IDisposable` 的托管值对象；窗口
+   仅在自身生命周期内保留结果，不处置数据库拥有的 Hatch 或事务对象。
+5. 实现基于仓库已有的禁用代码和 collector 修正，仅采用 Gile.Inspector 的
+   集合行为思路，没有复制其 `HatchLoopCollection` wrapper 或 UI 代码。
 
-该阶段的真实宿主行为风险高于 P2-A，因此即使只做编译验证，也必须在源码和
-PR 中明确标记 AutoCAD 2020/2026 的 loop 场景为 `Not run`。
+验证结果：
+
+| 目标 | 结果 |
+| --- | --- |
+| AutoCAD 2019 / .NET Framework 4.8 / Release x64 | Build passed |
+| AutoCAD 2025 / .NET 8 / Release x64 | Build passed |
+| 迁移边界与输出静态检查 | Passed |
+| polyline / curve loop 与逐项异常 CAD 宿主场景 | `Not run`，按本阶段边界不执行 |
 
 ### P2 之后才重新评估
 


### PR DESCRIPTION
### 相关的 Issue

Refs #124
Closes #132

### 原因

CadDiagnostics 的 Hatch collector 保留了一段因个别 `GetLoopAt()` 返回 `NotApplicable` 而整体禁用的旧代码，导致所有 loop 都无法下钻；已有 `HatchLoop` collector 也没有正确注册入口。

### 描述

- 按 `NumberOfLoops` 逐 index 调用 `GetLoopAt()`，成功项进入现有 `Snoop.Data.ObjectCollection`。
- 每个 AutoCAD 宿主异常单独显示为带 index 的 `Snoop.Data.Exception`，不影响后续 loop 或整个实体信息。
- 正确注册 `HatchLoop` collector；按 `IsPolyline` 仅读取匹配的 `Polyline` 或 `Curves` 边界集合，避免主动触发不匹配访问器的 `NotApplicable`。
- 注释明确 `HatchLoop` 是两个目标 SDK 中不实现 `IDisposable` 的托管值对象；不处置数据库拥有的 Hatch 或事务对象。
- 更新开源评估实施记录和文档索引。实现基于仓库已有禁用代码，仅采用 Gile.Inspector 的集合行为思路，没有复制其 wrapper 或 UI。
- 不引入 WPF、Brep、关联阵列、新命令、公共 API 或 `Fs.Fox.AutoCad.dll` 依赖。

### 验证

- AutoCAD 2019 / .NET Framework 4.8 / Release x64：Build passed。
- AutoCAD 2025 / .NET 8 / Release x64：Build passed。
- `Verify-CadDiagnostics.ps1 -Configuration Release`：passed。
- `git diff --check`、Markdown 相对链接和 GitHub GFM 渲染：passed。
- CAD 宿主 polyline/curve loop 与逐项异常场景：`Not run`（本阶段明确不执行宿主加载验证）。